### PR TITLE
⬆️ Flux UI v2.16.0 → v2.17.0

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -3891,16 +3891,16 @@
         },
         {
             "name": "livewire/flux",
-            "version": "v2.16.0",
+            "version": "v2.17.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/livewire/flux.git",
-                "reference": "b7e993d567dd7ffdcba42dcc7cdcb2163183b7f8"
+                "reference": "a999138107f528ad91ccd40d9ae7282b7b329a22"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/livewire/flux/zipball/b7e993d567dd7ffdcba42dcc7cdcb2163183b7f8",
-                "reference": "b7e993d567dd7ffdcba42dcc7cdcb2163183b7f8",
+                "url": "https://api.github.com/repos/livewire/flux/zipball/a999138107f528ad91ccd40d9ae7282b7b329a22",
+                "reference": "a999138107f528ad91ccd40d9ae7282b7b329a22",
                 "shasum": ""
             },
             "require": {
@@ -3951,25 +3951,25 @@
             ],
             "support": {
                 "issues": "https://github.com/livewire/flux/issues",
-                "source": "https://github.com/livewire/flux/tree/v2.16.0"
+                "source": "https://github.com/livewire/flux/tree/v2.17.0"
             },
-            "time": "2026-08-09T17:23:35+00:00"
+            "time": "2026-08-18T14:16:09+00:00"
         },
         {
             "name": "livewire/flux-pro",
-            "version": "2.16.0",
+            "version": "2.17.0",
             "dist": {
                 "type": "zip",
-                "url": "https://composer.fluxui.dev/download/a2785ad0-57b4-455c-8f7d-4f2810c5080b/flux-pro-2.16.0.zip",
-                "reference": "60a4c24de8676775a18c672561796f105a80bf72",
-                "shasum": "dbfe0b2c330b271e828e828ee69bcf5a34639d3a"
+                "url": "https://composer.fluxui.dev/download/a2884f79-b24c-46df-8d92-f4e6778149e8/flux-pro-2.17.0.zip",
+                "reference": "3b6a4f5a2f2052fc6163934b04e025f7e5ee6ddb",
+                "shasum": "d3b8313dd37d613beb0af3fb4d870e8c5d7cf4f2"
             },
             "require": {
                 "illuminate/console": "^10.0|^11.0|^12.0|^13.0",
                 "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
                 "illuminate/view": "^10.0|^11.0|^12.0|^13.0",
                 "laravel/prompts": "^0.1.24|^0.2|^0.3",
-                "livewire/flux": "2.16.0|dev-main",
+                "livewire/flux": "2.17.0|dev-main",
                 "livewire/livewire": "^3.7.4|^4.0|dev-main",
                 "php": "^8.1",
                 "symfony/console": "^6.0|^7.0|^8.0"
@@ -4026,7 +4026,7 @@
                 "livewire",
                 "ui"
             ],
-            "time": "2026-08-10T16:07:15+00:00"
+            "time": "2026-08-18T14:28:46+00:00"
         },
         {
             "name": "livewire/livewire",


### PR DESCRIPTION
Hebt Livewire Flux von **v2.16.0 auf v2.17.0** — ein Minor, nur die beiden Flux-Pakete bewegen sich, der Lock-Diff enthält genau zwei Versionszeilen.

## Was sich ändert, ohne dass eine Zeile angefasst wird

24 Stubs geändert (15 free, 9 pro), 3 neu (`toggle`, `select/group` in free und pro), keiner entfernt. Davon rendert dieses Repo **8 Komponenten, zusammen 194 Tags**:

| Komponente | Tags | | Komponente | Tags |
|---|---:|---|---|---:|
| `button` | 133 | | `navbar.item` | 4 |
| `select` | 21 | | `menu.item` | 4 |
| `separator` | 20 | | `navbar` | 2 |
| `card` | 9 | | `accordion.content` | 1 |

`field` (120), `input` (104), `select.option` (29), `textarea` (13) und `modal` (8) sind **nicht** betroffen — deren Änderungen kamen bereits in 2.16.

Sichtbare Auswirkungen:

- **`button`** — asymmetrisches Icon-Padding jetzt auch bei `sm`/`xs`, `gap-1` bei `xs`; `disabled` von `opacity-75` auf `opacity-50`, dazu `disabled:shadow-none`
- **`navbar.item`** — Icon-only wechselt von `h-8` auf `h-10!`, das Icon von `size-6` auf `size-5`
- **`navbar`** — `gap-1` auf `gap-0.5`
- **`card`** — neuer Prop `variant="outline|soft"`, Rahmenfarbe wandert nach `[:where(&)]`
- **`select`** — Dark-Optionsfarben greifen jetzt auch innerhalb eines `<optgroup>`
- **`accordion.content`** — `hidden="until-found"` statt `x-show`/`x-cloak`; Ctrl+F findet damit eingeklappte Inhalte

## Zwei Punkte eigens geprüft

- **Die 6 publizierten Views** unter `resources/views/flux/` beschatten den Vendor vollständig — aber **keine** davon ist in 2.17 geändert (4 eigene Icons, `navlist/group`, `pillbox/selected`). Es geht also kein Fix verloren.
- **Der Separator-Riegel** aus dem Ernteplan (#2675 legt die Attribute in 2.17 auf die Wurzel, wodurch ein `class=` erstmals den Text trifft) **greift hier nicht**: 0 Separatoren mit `text=`. Die 12 mit `class=` nutzen den unveränderten Nicht-Text-Zweig.

## Nicht in diesem PR

`artisan langscanner` läuft als `post-update-cmd` mit und schrieb einen neuen Übersetzungsschlüssel in alle 9 `lang/*.json` — und entfernte dabei den abschließenden Zeilenumbruch. Gehört nicht zu einem Flux-Upgrade, daher zurückgesetzt. Der fehlende Schlüssel bleibt als eigene Aufgabe.

## Tore

| | Ergebnis |
|---|---|
| `composer test` | **880 passed** (3615 Assertions), exit 0 — zeilenweise deckungsgleich mit dem Lauf davor |
| `composer test:lint` | exit 0 |
| `composer lint` | exit 0, keine Änderung am Baum |
