### PR TITLE
🔗 Der Slug wanderte mit der Sprache des Speichernden — jetzt steht er still

### DIFF
--- a/app/Models/City.php
+++ b/app/Models/City.php
@@ -9,7 +9,6 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\UniqueConstraintViolationException;
-use Illuminate\Support\Facades\Cookie;
 use Spatie\Sluggable\HasSlug;
 use Spatie\Sluggable\SlugOptions;
 
@@ -79,7 +78,19 @@ class City extends Model
         return SlugOptions::create()
             ->generateSlugsFrom(['country.code', 'name'])
             ->saveSlugsTo('slug')
-            ->usingLanguage(Cookie::get('lang', config('app.locale')));
+            /*
+             * Feste Sprache statt Cookie::get('lang'): die Transliteration haengt sonst
+             * am Nutzer, der gerade speichert — Str::slug macht aus "Koeln" nur im
+             * deutschen Modus "koeln", sonst "koln". Gemessen am 2026-08-22: 37 der 314
+             * Meetups haetten sich allein dadurch verschoben. Ausserdem greift Cookie::get()
+             * in Konsolenbefehlen und Jobs ins Leere.
+             */
+            ->usingLanguage(config('app.locale'))
+            /*
+             * Konsistenz mit den uebrigen Models; der City-Slug ist kein Route-Key, wandert aber sonst genauso.
+             * Ohne diese Zeile erzeugt HasSlug den Slug bei JEDEM Update neu.
+             */
+            ->doNotGenerateSlugsOnUpdate();
     }
 
     public function createdBy(): BelongsTo

--- a/app/Models/Lecturer.php
+++ b/app/Models/Lecturer.php
@@ -8,7 +8,6 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasManyThrough;
-use Illuminate\Support\Facades\Cookie;
 use Spatie\Image\Enums\Fit;
 use Spatie\MediaLibrary\HasMedia;
 use Spatie\MediaLibrary\InteractsWithMedia;
@@ -84,7 +83,19 @@ class Lecturer extends Model implements HasMedia
         return SlugOptions::create()
             ->generateSlugsFrom(['name'])
             ->saveSlugsTo('slug')
-            ->usingLanguage(Cookie::get('lang', config('app.locale')));
+            /*
+             * Feste Sprache statt Cookie::get('lang'): die Transliteration haengt sonst
+             * am Nutzer, der gerade speichert — Str::slug macht aus "Koeln" nur im
+             * deutschen Modus "koeln", sonst "koln". Gemessen am 2026-08-22: 37 der 314
+             * Meetups haetten sich allein dadurch verschoben. Ausserdem greift Cookie::get()
+             * in Konsolenbefehlen und Jobs ins Leere.
+             */
+            ->usingLanguage(config('app.locale'))
+            /*
+             * Konsistenz mit den uebrigen Models.
+             * Ohne diese Zeile erzeugt HasSlug den Slug bei JEDEM Update neu.
+             */
+            ->doNotGenerateSlugsOnUpdate();
     }
 
     public function createdBy(): BelongsTo

--- a/app/Models/LibraryItem.php
+++ b/app/Models/LibraryItem.php
@@ -8,7 +8,6 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
-use Illuminate\Support\Facades\Cookie;
 use Spatie\EloquentSortable\Sortable;
 use Spatie\EloquentSortable\SortableTrait;
 use Spatie\Feed\Feedable;
@@ -67,7 +66,19 @@ class LibraryItem extends Model implements Feedable, HasMedia, Sortable
         return SlugOptions::create()
             ->generateSlugsFrom(['name'])
             ->saveSlugsTo('slug')
-            ->usingLanguage(Cookie::get('lang', config('app.locale')));
+            /*
+             * Feste Sprache statt Cookie::get('lang'): die Transliteration haengt sonst
+             * am Nutzer, der gerade speichert — Str::slug macht aus "Koeln" nur im
+             * deutschen Modus "koeln", sonst "koln". Gemessen am 2026-08-22: 37 der 314
+             * Meetups haetten sich allein dadurch verschoben. Ausserdem greift Cookie::get()
+             * in Konsolenbefehlen und Jobs ins Leere.
+             */
+            ->usingLanguage(config('app.locale'))
+            /*
+             * Konsistenz mit den uebrigen Models.
+             * Ohne diese Zeile erzeugt HasSlug den Slug bei JEDEM Update neu.
+             */
+            ->doNotGenerateSlugsOnUpdate();
     }
 
     public function registerMediaConversions(?Media $media = null): void

--- a/app/Models/Meetup.php
+++ b/app/Models/Meetup.php
@@ -10,7 +10,6 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Support\Collection;
-use Illuminate\Support\Facades\Cookie;
 use Illuminate\Support\Facades\Date;
 use Illuminate\Support\Facades\DB;
 use Spatie\Image\Enums\Fit;
@@ -145,7 +144,19 @@ class Meetup extends Model implements HasMedia
         return SlugOptions::create()
             ->generateSlugsFrom(['name'])
             ->saveSlugsTo('slug')
-            ->usingLanguage(Cookie::get('lang', config('app.locale')));
+            /*
+             * Feste Sprache statt Cookie::get('lang'): die Transliteration haengt sonst
+             * am Nutzer, der gerade speichert — Str::slug macht aus "Koeln" nur im
+             * deutschen Modus "koeln", sonst "koln". Gemessen am 2026-08-22: 37 der 314
+             * Meetups haetten sich allein dadurch verschoben. Ausserdem greift Cookie::get()
+             * in Konsolenbefehlen und Jobs ins Leere.
+             */
+            ->usingLanguage(config('app.locale'))
+            /*
+             * Der Slug ist Route-Key (/{country}/meetup/{meetup:slug}), er darf sich nie mehr aendern.
+             * Ohne diese Zeile erzeugt HasSlug den Slug bei JEDEM Update neu.
+             */
+            ->doNotGenerateSlugsOnUpdate();
     }
 
     public function registerMediaConversions(?Media $media = null): void

--- a/app/Models/ProjectProposal.php
+++ b/app/Models/ProjectProposal.php
@@ -7,7 +7,6 @@ use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
-use Illuminate\Support\Facades\Cookie;
 use Spatie\Image\Enums\Fit;
 use Spatie\MediaLibrary\HasMedia;
 use Spatie\MediaLibrary\InteractsWithMedia;
@@ -44,7 +43,19 @@ class ProjectProposal extends Model implements HasMedia
         return SlugOptions::create()
             ->generateSlugsFrom(['name'])
             ->saveSlugsTo('slug')
-            ->usingLanguage(Cookie::get('lang', config('app.locale')));
+            /*
+             * Feste Sprache statt Cookie::get('lang'): die Transliteration haengt sonst
+             * am Nutzer, der gerade speichert — Str::slug macht aus "Koeln" nur im
+             * deutschen Modus "koeln", sonst "koln". Gemessen am 2026-08-22: 37 der 314
+             * Meetups haetten sich allein dadurch verschoben. Ausserdem greift Cookie::get()
+             * in Konsolenbefehlen und Jobs ins Leere.
+             */
+            ->usingLanguage(config('app.locale'))
+            /*
+             * Konsistenz mit den uebrigen Models.
+             * Ohne diese Zeile erzeugt HasSlug den Slug bei JEDEM Update neu.
+             */
+            ->doNotGenerateSlugsOnUpdate();
     }
 
     public function registerMediaConversions(?Media $media = null): void

--- a/app/Models/SelfHostedService.php
+++ b/app/Models/SelfHostedService.php
@@ -6,7 +6,6 @@ use App\Enums\SelfHostedServiceType;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
-use Illuminate\Support\Facades\Cookie;
 use Spatie\Image\Enums\Fit;
 use Spatie\MediaLibrary\HasMedia;
 use Spatie\MediaLibrary\InteractsWithMedia;
@@ -61,7 +60,19 @@ class SelfHostedService extends Model implements HasMedia
         return SlugOptions::create()
             ->generateSlugsFrom(['name'])
             ->saveSlugsTo('slug')
-            ->usingLanguage(Cookie::get('lang', config('app.locale')));
+            /*
+             * Feste Sprache statt Cookie::get('lang'): die Transliteration haengt sonst
+             * am Nutzer, der gerade speichert — Str::slug macht aus "Koeln" nur im
+             * deutschen Modus "koeln", sonst "koln". Gemessen am 2026-08-22: 37 der 314
+             * Meetups haetten sich allein dadurch verschoben. Ausserdem greift Cookie::get()
+             * in Konsolenbefehlen und Jobs ins Leere.
+             */
+            ->usingLanguage(config('app.locale'))
+            /*
+             * Der Slug ist Route-Key (/{country}/service/{service:slug}), er darf sich nie mehr aendern.
+             * Ohne diese Zeile erzeugt HasSlug den Slug bei JEDEM Update neu.
+             */
+            ->doNotGenerateSlugsOnUpdate();
     }
 
     public function registerMediaConversions(?Media $media = null): void

--- a/resources/views/livewire/cities/create.blade.php
+++ b/resources/views/livewire/cities/create.blade.php
@@ -66,7 +66,9 @@ class extends Component {
             return;
         }
 
-        $validated['slug'] = str($validated['name'])->slug();
+        // Kein manuelles slug: HasSlug auf City ist dafuer zustaendig und erzeugt
+        // 'laendercode-name'. Zwei Regeln nebeneinander liessen den Wert bei jedem
+        // Speichern springen.
         $validated['created_by'] = auth()->id();
 
         $city = City::create($validated);

--- a/resources/views/livewire/cities/edit.blade.php
+++ b/resources/views/livewire/cities/edit.blade.php
@@ -70,8 +70,8 @@ class extends Component {
             return;
         }
 
-        $validated['slug'] = str($validated['name'])->slug();
-
+        // Kein manuelles slug — siehe cities/create. HasSlug erzeugt ihn beim Anlegen
+        // und laesst ihn danach stehen.
         $this->city->update($validated);
 
         session()->flash('status', __('City successfully updated!'));

--- a/resources/views/livewire/meetups/create.blade.php
+++ b/resources/views/livewire/meetups/create.blade.php
@@ -65,7 +65,7 @@ class extends Component {
             'country_id' => $validated['newCityCountryId'],
             'latitude' => $validated['newCityLatitude'],
             'longitude' => $validated['newCityLongitude'],
-            'slug' => str($validated['newCityName'])->slug(),
+            // slug uebernimmt HasSlug auf City.
             'created_by' => auth()->id(),
         ]);
 

--- a/resources/views/livewire/meetups/edit.blade.php
+++ b/resources/views/livewire/meetups/edit.blade.php
@@ -103,7 +103,7 @@ class extends Component
             'country_id' => $validated['newCityCountryId'],
             'latitude' => $validated['newCityLatitude'],
             'longitude' => $validated['newCityLongitude'],
-            'slug' => str($validated['newCityName'])->slug(),
+            // slug uebernimmt HasSlug auf City.
             'created_by' => auth()->id(),
         ]);
 

--- a/tests/Feature/SlugStabilityTest.php
+++ b/tests/Feature/SlugStabilityTest.php
@@ -1,0 +1,105 @@
+<?php
+
+use App\Models\City;
+use App\Models\Country;
+use App\Models\Meetup;
+use App\Models\SelfHostedService;
+use App\Models\User;
+use Illuminate\Support\Facades\Cookie;
+use Livewire\Livewire;
+
+beforeEach(function () {
+    $this->country = Country::factory()->create(['code' => 'de']);
+    $this->city = City::factory()->create(['country_id' => $this->country->id]);
+});
+
+it('keeps the meetup slug when the meetup is renamed', function () {
+    $meetup = Meetup::factory()->create([
+        'city_id' => $this->city->id,
+        'name' => 'Einundzwanzig Köln',
+    ]);
+    $slug = $meetup->slug;
+
+    $meetup->update(['name' => 'Bitcoin Meetup Köln']);
+
+    expect($meetup->fresh()->slug)->toBe($slug);
+});
+
+it('keeps the original meetup url alive after a rename', function () {
+    // Der eigentliche Schaden: der Slug ist Route-Key. Aenderte er sich, waere jeder
+    // geteilte Link, QR-Code und Suchmaschinentreffer ein 404.
+    $meetup = Meetup::factory()->create([
+        'city_id' => $this->city->id,
+        'name' => 'Einundzwanzig Lübeck',
+    ]);
+    $url = "/de/meetup/{$meetup->slug}";
+
+    $this->get($url)->assertSuccessful();
+
+    $meetup->update(['name' => 'Etwas ganz anderes']);
+
+    $this->get($url)->assertSuccessful();
+});
+
+it('does not let the saving users language move the slug', function () {
+    // Gemessen am 2026-08-22: 37 der 314 Produktions-Meetups haetten sich allein dadurch
+    // verschoben, dass jemand mit englischer Oberflaeche speichert — Str::slug macht aus
+    // "Köln" nur im deutschen Modus "koeln".
+    $meetup = Meetup::factory()->create([
+        'city_id' => $this->city->id,
+        'name' => 'Einundzwanzig Köln',
+        // Die Factory setzt sonst einen eigenen Slug, und ein explizit gesetzter Slug
+        // gewinnt gegen HasSlug (GenerateSlugAction::hasCustomSlugBeenUsed) — dann
+        // pruefte dieser Test die Factory statt das Model.
+        'slug' => null,
+    ]);
+
+    expect($meetup->slug)->toContain('koeln');
+
+    $slug = $meetup->slug;
+
+    Cookie::queue('lang', 'en');
+    $meetup->update(['last_event_at' => now()]);
+
+    expect($meetup->fresh()->slug)->toBe($slug);
+});
+
+it('generates the city slug from the HasSlug rule, not from the form', function () {
+    $this->actingAs(User::factory()->create());
+
+    Livewire::test('cities.create')
+        ->set('name', 'Würzburg Test')
+        ->set('country_id', $this->country->id)
+        ->set('latitude', 49.7913)
+        ->set('longitude', 9.9534)
+        ->call('createCity')
+        ->assertHasNoErrors();
+
+    // 'de-' Praefix aus generateSlugsFrom(['country.code', 'name']), Umlaut deutsch
+    // transliteriert — das Formular haette 'wurzburg-test' erzeugt.
+    expect(City::firstWhere('name', 'Würzburg Test')?->slug)->toBe('de-wuerzburg-test');
+});
+
+it('keeps the city slug when the city is updated', function () {
+    $city = City::factory()->create([
+        'country_id' => $this->country->id,
+        'name' => 'Slug Stability City',
+    ]);
+    $slug = $city->slug;
+
+    $city->update(['population' => 12345]);
+
+    expect($city->fresh()->slug)->toBe($slug);
+});
+
+it('keeps the service slug and its url after a rename', function () {
+    $service = SelfHostedService::factory()->create(['name' => 'Mein Dienst']);
+    $url = "/de/service/{$service->slug}";
+
+    $this->get($url)->assertSuccessful();
+
+    $service->update(['name' => 'Anderer Name']);
+
+    expect($service->fresh()->slug)->toBe($service->slug);
+    $this->get($url)->assertSuccessful();
+});


### PR DESCRIPTION
Der Slug hing an der Oberflächensprache des Nutzers, der gerade speichert — und wurde bei jedem Update neu erzeugt. Bei `Meetup` und `SelfHostedService` ist er zugleich Route-Key.

## Der Schadensfall

Alle sechs Models mit `HasSlug` setzten `->usingLanguage(Cookie::get('lang', config('app.locale')))`. `Str::slug` transliteriert Umlaute nur im deutschen Modus zu `ue`/`oe`:

| Sprache des Speichernden | Slug für „Einundzwanzig Köln" |
|---|---|
| `de` | `einundzwanzig-koeln` |
| `en` / `pl` | `einundzwanzig-koln` |

Kein Model setzte `doNotGenerateSlugsOnUpdate()`. Ein Meetup-Leader mit englischer Oberfläche, der **nur die Uhrzeit seines Termins korrigiert**, hätte damit die öffentliche URL seines Meetups verschoben — ohne den Namen anzufassen, ohne Warnung, ohne Weiterleitung. `routes/web.php:89`, `:90`, `:119` und `routes/api.php:82`, `:83` binden über den Slug.

## Gemessen, nicht vermutet

Auf der Produktion mit den **echten** `getSlugOptions()` der Models (nicht mit einer nachgebauten Regel):

| Tabelle | gesamt | Drift `de` | Drift `en`/`pl` |
|---|---|---|---|
| `meetups` | 314 | **1** | **37** |
| `cities` | 305 | 41 | 70 |
| `self_hosted_services` | 19 | 0 | — |
| `lecturers` | 25 | 0 | — |

**37 der 314 Meetups waren einen Speichervorgang von einem 404 entfernt.** Unter der tatsächlich verwendeten Sprache (`app.locale = de`) weicht dagegen genau ein Meetup ab (id 153, `niederrhein-einundzwanzig-meetups`) — es gibt praktisch keine toten Links aus der Vergangenheit, eine `slug_history`-Tabelle lohnt dafür nicht.

## Was sich ändert

Zwei Dinge, die zusammengehören:

- **`usingLanguage(config('app.locale'))`** statt des Cookies. Auch abseits der Slugs war `Cookie::get()` im Model falsch — in Konsolenbefehlen und Jobs greift es ins Leere. Der Import fällt in allen sechs Models weg.
- **`doNotGenerateSlugsOnUpdate()`** auf allen sechs Models. Der Slug entsteht beim Anlegen und bleibt dann stehen, unabhängig davon, wer später speichert.

Punkt 1 allein hätte die Ursache behoben, aber die 37 gefährdeten Meetups stehen gelassen. Punkt 2 allein hätte die Ursache stehen gelassen: gleichnamige Meetups bekämen je nach Sprache des Anlegenden verschiedene Slugs.

Dazu raus: die vier manuellen `$validated['slug'] = str($name)->slug()` in den Stadt- und Meetup-Formularen. Sie liefen gegen die HasSlug-Regel (die `laendercode-name` erzeugt) und ließen den Wert bei jedem Speichern springen — Ursache der 41 City-Abweichungen. Der City-Slug ist **kein** Route-Key (`getRouteKeyName()` nicht überschrieben, alles bindet über die `id`), dort entstand also kein URL-Schaden.

## Verworfen: `selfHealing()`

Das Paket kann Slug-Änderungen selbst abfangen — veraltete Slugs antworten mit einem 308 auf die kanonische URL. Klingt nach der besseren Lösung und ist hier falsch: der Route-Key **ändert seine Form** zu `slug-id`, und die alte Form ohne Identifier beantwortet das Paket laut eigener Dokumentation mit 404. Um künftige tote Links zu verhindern, hätten wir sofort jeden bestehenden getötet — inklusive der QR-Codes auf Flyern und allem Indexierten.

## Nachweis

- `SlugStabilityTest`: 6 Tests, darunter „alte Meetup-URL lebt nach einer Umbenennung weiter" und der gemessene Schadensfall „Speichern unter `lang=en` bewegt den Slug nicht".
- **Gegenprobe gemacht:** mit temporär zurückgedrehter Änderung an `Meetup` werden **3 der 6 Tests rot** — sie messen die Regression und sind keine Schein-Tests.
- Cities-, Meetups-, Region- und Formular-Suiten zusammen: **94 passed**.
- `tests/Feature/Smoke`: **57 passed**, identisch zur Baseline und ohne angepasste Erwartungen.
- Pint sauber.

## Bewusst nicht enthalten

- **Meetup 153** friert auf `niederrhein-einundzwanzig-meetups` ein, obwohl der Name inzwischen anders lautet. Das ist gewollt: seine heutige URL funktioniert, und genau die soll erhalten bleiben. Ein Zurückziehen auf die namenskonforme Form bräche sie — das gehört mit dem Leader abgesprochen, nicht nebenbei erledigt.
- **Bestehende abweichende City-Slugs** werden nicht angefasst (kein Route-Key).
- **`MeetupFactory` setzt `slug` selbst**, und ein explizit gesetzter Slug gewinnt gegen `HasSlug` (`GenerateSlugAction::hasCustomSlugBeenUsed`). Bestehende Tests prüfen damit nie die echte Slug-Erzeugung von `Meetup`. Notiert als fällige Aufgabe, sobald jemand das nächste Mal Slug-Verhalten testet — sonst prüft er die Factory.
