### PR TITLE
🔒 nanoid auf 3.3.18 — GHSA-2v37-7h3g-55p8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1522,9 +1522,9 @@
             "license": "MIT"
         },
         "node_modules/nanoid": {
-            "version": "3.3.17",
-            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-            "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+            "version": "3.3.18",
+            "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+            "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
             "funding": [
                 {
                     "type": "github",


### PR DESCRIPTION
Schließt den offenen Dependabot-Alert `GHSA-2v37-7h3g-55p8` (`nanoid < 3.3.18`, als „high" eingestuft).

## Einordnung

Die Einstufung ist die des Advisories, nicht die des Risikos hier:

- `nanoid` kommt **transitiv**: `vite` → `postcss` → `nanoid`. Es steht weder in `dependencies` noch in `devDependencies`.
- Im eigenen Code wird es nirgends aufgerufen (`resources/js`, Views: keine Treffer).
- Der Bug betrifft **custom generators, die mit `size 0` aufgerufen werden**. postcss nutzt nanoid für Source-Map-IDs und tut das nie.
- Die Kette läuft zur **Build-Zeit**, nicht im Browser der Nutzer.

Das ändert nichts daran, dass der Fix drei Zeilen im Lockfile kostet — also weg damit, statt den Alert dauerhaft offen zu lassen.

## Nachweis

- `npm audit`: **0 vulnerabilities**.
- `npm run build` läuft unverändert durch (6 Module, 604 ms).
- Diff: ausschließlich `package-lock.json`, +3/−3.

Nebenbefund: `vite` war lokal auf 8.2.0 installiert, obwohl `package.json` `^8.2.1` verlangt. Das `npm update` hat die Installation mitkorrigiert; im Lockfile stand die richtige Version bereits.
