### PR TITLE
🗺️ Städte und Länder bekommen dieselbe OSM-Referenz wie Events (#11, #12)

### DIFF
--- a/app/Http/Controllers/Api/CountryController.php
+++ b/app/Http/Controllers/Api/CountryController.php
@@ -3,6 +3,7 @@
 namespace App\Http\Controllers\Api;
 
 use App\Http\Controllers\Controller;
+use App\Http\Resources\CountryResource;
 use App\Models\Country;
 use Dedoc\Scramble\Attributes\Group;
 use Dedoc\Scramble\Attributes\QueryParameter;
@@ -15,36 +16,47 @@ class CountryController extends Controller
     /**
      * List and search countries
      *
-     * Public endpoint; returns id, name and code (country code), sorted alphabetically. Without 'selected' the result is capped at 10 items. Every country additionally contains a 'flag' (SVG URL).
+     * Public endpoint; returns id, name and code (country code), sorted alphabetically. Without 'selected' the result is capped at 10 items. Every country additionally contains a 'flag' (SVG URL) and, where known, its OpenStreetMap reference (osm_type, osm_id, osm_url), Wikidata and Wikipedia links, and coordinates.
      */
     #[QueryParameter(name: 'search', description: 'Search in name or code (country code).', required: false, type: 'string')]
     #[QueryParameter(name: 'selected', description: 'Loads exactly the given codes or IDs.', required: false, type: 'array')]
     public function index(Request $request)
     {
-        return Country::query()
-            ->select('id', 'name', 'code')
-            ->orderBy('name')
-            ->when(
-                $request->search,
-                fn (Builder $query) => $query
-                    ->whereLike('name', "%{$request->search}%")
-                    ->orWhereLike('code', "%{$request->search}%"),
-            )
-            ->when(
-                $request->exists('selected'),
-                function (Builder $query) use ($request) {
-                    $selected = $request->input('selected', []);
+        return CountryResource::collection(
+            Country::query()
+                // Ausdrueckliche Spaltenliste statt select('*'): was die API zusagt, steht
+                // in der Resource, und was sie dafuer braucht, steht hier.
+                ->select(
+                    'id', 'name', 'code',
+                    'osm_type', 'osm_id', 'osm_name',
+                    'wikidata', 'wikipedia',
+                    'latitude', 'longitude',
+                )
+                ->orderBy('name')
+                ->when(
+                    $request->search,
+                    fn (Builder $query) => $query
+                        ->whereLike('name', "%{$request->search}%")
+                        ->orWhereLike('code', "%{$request->search}%"),
+                )
+                ->when(
+                    $request->exists('selected'),
+                    function (Builder $query) use ($request) {
+                        $selected = $request->input('selected', []);
 
-                    $query->whereIn('code', $selected)
-                        ->orWhereIn('id', array_filter($selected, 'is_numeric'));
-                },
-                fn (Builder $query) => $query->limit(10),
-            )
-            ->get()
-            ->map(function (Country $country) {
-                $country->flag = asset('vendor/blade-flags/country-'.$country->code.'.svg');
-
-                return $country;
-            });
+                        $query->whereIn('code', $selected)
+                            ->orWhereIn('id', array_filter($selected, 'is_numeric'));
+                    },
+                    fn (Builder $query) => $query->limit(10),
+                )
+                ->get()
+        )
+            /*
+             * ->resolve() statt der Resource-Collection selbst: die haengt die Antwort
+             * sonst unter einen "data"-Schluessel, und GET /countries liefert seit jeher
+             * ein nacktes Array. `$wrap = null` auf der Resource allein genuegt dafuer
+             * nicht — es greift bei ::make(), nicht bei ::collection().
+             */
+            ->resolve();
     }
 }

--- a/app/Http/Requests/Api/StoreCityRequest.php
+++ b/app/Http/Requests/Api/StoreCityRequest.php
@@ -2,11 +2,14 @@
 
 namespace App\Http\Requests\Api;
 
+use App\Http\Requests\Concerns\ValidatesOsmPlace;
 use App\Models\City;
 use Illuminate\Foundation\Http\FormRequest;
 
 class StoreCityRequest extends FormRequest
 {
+    use ValidatesOsmPlace;
+
     public function authorize(): bool
     {
         return $this->user()->can('create', City::class);
@@ -17,12 +20,56 @@ class StoreCityRequest extends FormRequest
      */
     public function rules(): array
     {
+        $prefix = [];
+
         return [
             'country_id' => ['required', 'integer', 'exists:countries,id'],
             'name' => ['required', 'string', 'max:255'],
-            'longitude' => ['required', 'numeric'],
-            'latitude' => ['required', 'numeric'],
+            /*
+             * Gelockert von `required` auf `required_without:osm_lat` bzw. `osm_lon`:
+             * eine Stadt darf aus Name, Land und einem OSM-Ort entstehen, dessen
+             * Koordinaten mitkommen (Wunsch aus Issue #11). prepareForValidation()
+             * uebernimmt sie dann in latitude/longitude — die Spalten sind in der
+             * Datenbank NOT NULL, und daran aendert dieser Plan bewusst nichts.
+             *
+             * Fuer jeden bestehenden Aufrufer, der Koordinaten schickt, aendert sich
+             * nichts: eine Lockerung bricht keinen Vertrag.
+             */
+            'longitude' => ['required_without:osm_lon', 'numeric'],
+            'latitude' => ['required_without:osm_lat', 'numeric'],
             'population' => ['nullable', 'integer'],
+            ...$this->osmPlaceRules(),
+        ] + $this->osmReferenceRules($prefix);
+    }
+
+    /**
+     * Koordinaten aus dem OSM-Ort uebernehmen, wenn keine eigenen mitkamen.
+     *
+     * Vor der Validierung, damit `required_without` und die NOT-NULL-Spalten denselben
+     * Wert sehen. Eigene Angaben gewinnen immer — wer Koordinaten schickt, hat einen
+     * Grund dafuer.
+     */
+    protected function prepareForValidation(): void
+    {
+        $this->merge(self::coordinatesFromOsm($this->all()));
+    }
+
+    /**
+     * Dieselbe Uebernahme fuer Aufrufer ausserhalb des FormRequest-Lebenszyklus.
+     *
+     * Das MCP-Tool validiert gegen diese Regeln, laeuft aber nicht durch
+     * prepareForValidation() — ohne diese Methode haette derselbe Aufruf ueber MCP
+     * andere Anforderungen als ueber die API, und das ist genau die Art Unterschied,
+     * die niemand vermutet und jeder debuggt.
+     *
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    public static function coordinatesFromOsm(array $data): array
+    {
+        return [
+            'latitude' => $data['latitude'] ?? $data['osm_lat'] ?? null,
+            'longitude' => $data['longitude'] ?? $data['osm_lon'] ?? null,
         ];
     }
 

--- a/app/Http/Requests/Api/UpdateCityRequest.php
+++ b/app/Http/Requests/Api/UpdateCityRequest.php
@@ -2,10 +2,13 @@
 
 namespace App\Http\Requests\Api;
 
+use App\Http\Requests\Concerns\ValidatesOsmPlace;
 use Illuminate\Foundation\Http\FormRequest;
 
 class UpdateCityRequest extends FormRequest
 {
+    use ValidatesOsmPlace;
+
     public function authorize(): bool
     {
         return $this->user()->can('update', $this->route('city'));
@@ -22,7 +25,8 @@ class UpdateCityRequest extends FormRequest
             'longitude' => ['sometimes', 'required', 'numeric'],
             'latitude' => ['sometimes', 'required', 'numeric'],
             'population' => ['sometimes', 'nullable', 'integer'],
-        ];
+            ...$this->osmPlaceRules(partial: true),
+        ] + $this->osmReferenceRules(['sometimes']);
     }
 
     /**

--- a/app/Http/Requests/Concerns/ValidatesOsmPlace.php
+++ b/app/Http/Requests/Concerns/ValidatesOsmPlace.php
@@ -87,4 +87,36 @@ trait ValidatesOsmPlace
             'osm_lon' => [...$prefix, 'nullable', 'numeric', 'between:-180,180'],
         ];
     }
+
+    /**
+     * Die beiden Querverweise, die Nominatim mit `extratags=1` mitliefert.
+     *
+     * Eigene Methode statt Teil von osmPlaceRules(), weil die Events sie nicht fuehren:
+     * ein Veranstaltungsort hat selten einen Wikipedia-Artikel, eine Stadt oder ein Land
+     * fast immer. Wer sie braucht, holt sie sich dazu.
+     *
+     * @param  array<int, string>  $prefix  ['sometimes'] fuer PATCH, sonst leer
+     * @return array<string, array<int, mixed>>
+     */
+    protected function osmReferenceRules(array $prefix = []): array
+    {
+        return [
+            /**
+             * Die Wikidata-Q-ID des Orts, z. B. `Q64`.
+             *
+             * @example Q64
+             */
+            'wikidata' => [...$prefix, 'nullable', 'string', 'max:32'],
+
+            /**
+             * Der Wikipedia-Verweis in OSM-Schreibweise: Sprachpraefix, Doppelpunkt, Titel.
+             *
+             * Kein fertiger Link — die aufgeloeste URL steht in der Antwort als
+             * `wikipedia_url` daneben.
+             *
+             * @example de:Berlin
+             */
+            'wikipedia' => [...$prefix, 'nullable', 'string', 'max:255'],
+        ];
+    }
 }

--- a/app/Http/Resources/CityResource.php
+++ b/app/Http/Resources/CityResource.php
@@ -24,6 +24,24 @@ class CityResource extends JsonResource
             'longitude' => $this->longitude,
             'latitude' => $this->latitude,
             'population' => $this->population,
+            /*
+             * Issue #11: die OSM-Referenz. `osm_url` ist berechnet, nicht gespeichert —
+             * `osm_type` und `osm_id` sind die Wahrheit, die URL nur ihre Lesart.
+             * Alle Felder sind null, solange die Stadt keine Referenz traegt; das ist
+             * der Normalfall fuer Bestandsdaten und kein Fehler.
+             */
+            'osm_type' => $this->osm_type,
+            'osm_id' => $this->osm_id,
+            'osm_url' => $this->osm_url,
+            'osm_name' => $this->osm_name,
+            'osm_address' => $this->osm_address,
+            'osm_lat' => $this->osm_lat,
+            'osm_lon' => $this->osm_lon,
+            'wikidata' => $this->wikidata,
+            'wikidata_url' => $this->wikidata_url,
+            // OSM-Slug der Form "de:Berlin"; die aufgeloeste URL steht daneben.
+            'wikipedia' => $this->wikipedia,
+            'wikipedia_url' => $this->wikipedia_url,
             'created_by' => $this->created_by,
             'created_at' => $this->created_at,
             'updated_at' => $this->updated_at,

--- a/app/Http/Resources/CountryResource.php
+++ b/app/Http/Resources/CountryResource.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace App\Http\Resources;
+
+use App\Models\Country;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @mixin Country
+ */
+class CountryResource extends JsonResource
+{
+    /**
+     * GET /countries antwortet seit jeher mit einem nackten Array, nicht mit
+     * {"data": [...]}. Das Wrapping hier abzuschalten ist der Unterschied zwischen
+     * "neue Felder kommen dazu" und "jeder bestehende Client bricht".
+     */
+    public static $wrap = null;
+
+    /**
+     * Die vier Felder oben sind der bestehende Vertrag von GET /countries und behalten
+     * Name, Typ und Wert — insbesondere wird `flag` weiter aus dem Laendercode gebildet,
+     * damit vorhandene Clients dieselbe URL sehen wie vorher.
+     *
+     * Issue #12 schlaegt vor, das `->select('id','name','code')` im Controller ersatzlos
+     * zu streichen, damit "die bereits vorhandenen, aber versteckten Felder mitfliessen".
+     * Stattdessen steht hier eine ausdrueckliche Liste: was die API zusagt, soll man
+     * lesen koennen, statt es aus dem Tabellenschema zu erschliessen. `english_name` und
+     * `language_codes` bleiben deshalb vorerst draussen.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'name' => $this->name,
+            'code' => $this->code,
+            'flag' => asset('vendor/blade-flags/country-'.$this->code.'.svg'),
+
+            /*
+             * Neu (Issue #12). Alles null, solange das Land keine OSM-Referenz traegt —
+             * heute der Normalfall, den der Anreicherungslauf nach und nach fuellt.
+             */
+            'osm_type' => $this->osm_type,
+            'osm_id' => $this->osm_id,
+            'osm_url' => $this->osm_url,
+            'osm_name' => $this->osm_name,
+            'wikidata' => $this->wikidata,
+            'wikidata_url' => $this->wikidata_url,
+            // OSM-Slug der Form "en:United States"; die aufgeloeste URL steht daneben.
+            'wikipedia' => $this->wikipedia,
+            'wikipedia_url' => $this->wikipedia_url,
+            'latitude' => $this->latitude,
+            'longitude' => $this->longitude,
+        ];
+    }
+}

--- a/app/Mcp/Tools/City/CreateCityTool.php
+++ b/app/Mcp/Tools/City/CreateCityTool.php
@@ -32,6 +32,9 @@ class CreateCityTool extends Tool
             return $error;
         }
 
+        // Wie in der API: Koordinaten aus dem OSM-Ort uebernehmen, eigene gewinnen.
+        $request->merge(StoreCityRequest::coordinatesFromOsm($request->all()));
+
         $storeRequest = new StoreCityRequest;
 
         $validated = $request->validate(
@@ -56,9 +59,17 @@ class CreateCityTool extends Tool
             'country' => $schema->string()->description('Name des zugehörigen Landes (z. B. "Deutschland"). Wird automatisch aufgelöst – bei Bedarf per list-countries den genauen Namen ermitteln.'),
             'country_id' => $schema->integer()->description('Optional: ID des Landes, falls bereits bekannt (Alternative zu "country").'),
             'name' => $schema->string()->description('Name der Stadt.')->required(),
-            'longitude' => $schema->number()->description('Längengrad der Stadt.')->required(),
-            'latitude' => $schema->number()->description('Breitengrad der Stadt.')->required(),
+            'longitude' => $schema->number()->description('Längengrad der Stadt. Entfällt, wenn "osm_lon" mitgegeben wird.'),
+            'latitude' => $schema->number()->description('Breitengrad der Stadt. Entfällt, wenn "osm_lat" mitgegeben wird.'),
             'population' => $schema->integer()->description('Einwohnerzahl der Stadt.'),
+            'osm_type' => $schema->string()->description('Art des OpenStreetMap-Objekts: "node", "way" oder "relation". Nur zusammen mit "osm_id" gültig; Städte sind fast immer "relation".'),
+            'osm_id' => $schema->integer()->description('ID des OpenStreetMap-Objekts. Nur zusammen mit "osm_type" gültig – die beiden identifizieren einen Ort erst gemeinsam.'),
+            'osm_name' => $schema->string()->description('Name des Orts laut OpenStreetMap.'),
+            'osm_address' => $schema->string()->description('Vollständige Adresszeile laut OpenStreetMap.'),
+            'osm_lat' => $schema->number()->description('Breitengrad laut OpenStreetMap. Wird nach "latitude" übernommen, wenn dort nichts steht.'),
+            'osm_lon' => $schema->number()->description('Längengrad laut OpenStreetMap. Wird nach "longitude" übernommen, wenn dort nichts steht.'),
+            'wikidata' => $schema->string()->description('Wikidata-Q-ID des Orts, z. B. "Q64".'),
+            'wikipedia' => $schema->string()->description('Wikipedia-Verweis in OpenStreetMap-Schreibweise, z. B. "de:Berlin" – Sprachpräfix, Doppelpunkt, Artikeltitel.'),
         ];
     }
 }

--- a/app/Models/City.php
+++ b/app/Models/City.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use Akuechler\Geoly;
+use App\Models\Concerns\HasOsmReference;
 use App\Models\Concerns\SetsCreatedBy;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -16,6 +17,7 @@ class City extends Model
 {
     use Geoly;
     use HasFactory;
+    use HasOsmReference;
     use HasSlug;
     use SetsCreatedBy;
 
@@ -36,6 +38,9 @@ class City extends Model
         'country_id' => 'integer',
         'osm_relation' => 'json',
         'simplified_geojson' => 'json',
+        'osm_id' => 'integer',
+        'osm_lat' => 'float',
+        'osm_lon' => 'float',
     ];
 
     /**

--- a/app/Models/Concerns/HasOsmReference.php
+++ b/app/Models/Concerns/HasOsmReference.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Models\Concerns;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Casts\Attribute;
+
+/**
+ * Eine OpenStreetMap-Referenz auf einem Stammdaten-Model (Stadt, Land).
+ *
+ * Die Spalten kommen aus der Migration; hier stehen nur die abgeleiteten Werte. Sie
+ * werden bewusst NICHT gespeichert: eine zweite Kopie derselben Information kann der
+ * ersten widersprechen, und genau das ist der Grund, warum der Wunsch aus Issue #11/#12
+ * nach einer `osm_url`-Spalte hier als Accessor beantwortet wird statt als Feld.
+ */
+trait HasOsmReference
+{
+    /**
+     * Der dauerhafte Link zum OSM-Objekt, oder null solange das Paar fehlt.
+     *
+     * `osm_type` und `osm_id` identifizieren ein Objekt nur gemeinsam — halb gesetzt
+     * ergibt keine gueltige URL, sondern eine, die auf eine fremde Sache zeigt.
+     */
+    protected function osmUrl(): Attribute
+    {
+        return Attribute::get(fn (): ?string => $this->osm_type && $this->osm_id
+            ? "https://www.openstreetmap.org/{$this->osm_type}/{$this->osm_id}"
+            : null);
+    }
+
+    /**
+     * Der Link zum Wikidata-Objekt, z. B. https://www.wikidata.org/wiki/Q64.
+     */
+    protected function wikidataUrl(): Attribute
+    {
+        return Attribute::get(fn (): ?string => $this->wikidata
+            ? "https://www.wikidata.org/wiki/{$this->wikidata}"
+            : null);
+    }
+
+    /**
+     * Der Link zum Wikipedia-Artikel.
+     *
+     * OSM speichert den Verweis als "sprache:Titel" — "de:Berlin", "en:London",
+     * "ja:日本". Der Praefix folgt der OSM-Community, nicht unserer Oberflaeche, und
+     * bestimmt die Domain. Ohne Praefix ist der Wert unbrauchbar; dann lieber null als
+     * ein Link ins Leere.
+     */
+    protected function wikipediaUrl(): Attribute
+    {
+        return Attribute::get(function (): ?string {
+            $value = (string) ($this->wikipedia ?? '');
+
+            if (! str_contains($value, ':')) {
+                return null;
+            }
+
+            [$language, $title] = explode(':', $value, 2);
+            $language = trim($language);
+            $title = trim($title);
+
+            if ($language === '' || $title === '') {
+                return null;
+            }
+
+            return sprintf(
+                'https://%s.wikipedia.org/wiki/%s',
+                rawurlencode($language),
+                rawurlencode(str_replace(' ', '_', $title)),
+            );
+        });
+    }
+
+    /**
+     * Datensaetze ohne OSM-Referenz — die Arbeitsmenge jedes Anreicherungslaufs.
+     */
+    public function scopeWithoutOsmReference(Builder $query): Builder
+    {
+        return $query->whereNull('osm_id');
+    }
+}

--- a/app/Models/Country.php
+++ b/app/Models/Country.php
@@ -2,6 +2,7 @@
 
 namespace App\Models;
 
+use App\Models\Concerns\HasOsmReference;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -9,6 +10,7 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
 class Country extends Model
 {
     use HasFactory;
+    use HasOsmReference;
 
     /**
      * The attributes that aren't mass assignable.
@@ -25,6 +27,9 @@ class Country extends Model
     protected $casts = [
         'id' => 'integer',
         'language_codes' => 'array',
+        'osm_id' => 'integer',
+        'osm_lat' => 'float',
+        'osm_lon' => 'float',
     ];
 
     public function cities(): HasMany

--- a/app/Services/Osm/NominatimClient.php
+++ b/app/Services/Osm/NominatimClient.php
@@ -62,6 +62,9 @@ class NominatimClient
             'q' => $query,
             'format' => 'jsonv2',
             'addressdetails' => 1,
+            // Bringt wikidata und wikipedia mit ("wikidata": "Q84", "wikipedia": "en:London").
+            // Derselbe Request, ein Parameter mehr — keine zusaetzliche Last.
+            'extratags' => 1,
             'limit' => $limit,
             'countrycodes' => $countryCode ? mb_strtolower($countryCode) : null,
         ], fn ($value): bool => $value !== null);
@@ -100,13 +103,21 @@ class NominatimClient
             return null;
         }
 
-        $cacheKey = "osm:lookup:{$prefix}{$osmId}";
+        /*
+         * Der Schluessel traegt eine Version, weil er — anders als in search() — die
+         * Parameter nicht enthaelt. Ohne das v2 lieferte der 30-Tage-Cache nach dem
+         * Einbau von extratags noch einen Monat lang die alten Eintraege ohne wikidata
+         * und wikipedia, und der neue Code saehe aus, als funktioniere er nicht.
+         * Kommt ein weiterer Parameter dazu, wird die Zahl wieder erhoeht.
+         */
+        $cacheKey = "osm:lookup:v2:{$prefix}{$osmId}";
 
         return Cache::remember($cacheKey, now()->addDays(30), function () use ($prefix, $osmId): ?array {
             $response = $this->get('/lookup', [
                 'osm_ids' => $prefix.$osmId,
                 'format' => 'jsonv2',
                 'addressdetails' => 1,
+                'extratags' => 1,
             ]);
 
             if (! is_array($response) || $response === []) {
@@ -138,6 +149,10 @@ class NominatimClient
             $name = trim(explode(',', $display)[0] ?? '');
         }
 
+        // extratags fehlt, wenn der Aufruf ohne den Parameter lief oder das Objekt keine
+        // Zusatz-Tags traegt — beides ist normal, beides ergibt hier null.
+        $extra = is_array($row['extratags'] ?? null) ? $row['extratags'] : [];
+
         return [
             'osm_type' => (string) $row['osm_type'],
             'osm_id' => (int) $row['osm_id'],
@@ -147,7 +162,27 @@ class NominatimClient
             'osm_lon' => isset($row['lon']) ? (float) $row['lon'] : null,
             'importance' => isset($row['importance']) ? (float) $row['importance'] : null,
             'category' => $row['category'] ?? $row['class'] ?? null,
+            // Wikidata-Q-ID, z. B. "Q84". Nominatim liefert sie nur mit extratags=1.
+            'wikidata' => $this->tag($extra, 'wikidata', 32),
+            // OSM-Slug der Form "de:Koeln" — kein fertiger Link, siehe Region-Accessoren.
+            'wikipedia' => $this->tag($extra, 'wikipedia', 255),
+            // Nur bei Orten mit population-Tag gesetzt; Staedte und Laender tragen ihn oft.
+            'population' => isset($extra['population']) && is_numeric($extra['population'])
+                ? (int) $extra['population']
+                : null,
         ];
+    }
+
+    /**
+     * Einen Zusatz-Tag lesen: getrimmt, laengenbegrenzt, leer wird zu null.
+     *
+     * @param  array<string, mixed>  $extra
+     */
+    private function tag(array $extra, string $key, int $maxLength): ?string
+    {
+        $value = trim((string) ($extra[$key] ?? ''));
+
+        return $value !== '' ? mb_substr($value, 0, $maxLength) : null;
     }
 
     /**

--- a/database/migrations/2026_08_22_225040_add_osm_reference_to_cities_and_countries_tables.php
+++ b/database/migrations/2026_08_22_225040_add_osm_reference_to_cities_and_countries_tables.php
@@ -1,0 +1,66 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Issues #11 und #12: Staedte und Laender bekommen eine OpenStreetMap-Referenz.
+ *
+ * Bewusst dieselben sechs Spalten wie die Event-Tabellen seit
+ * 2026_08_17_171226_add_osm_location_to_event_tables — ein zweites, abweichendes Muster
+ * fuer dieselbe Sache waere die teuerste Art, sich das Leben schwer zu machen.
+ * `osm_type` + `osm_id` identifizieren gemeinsam ein Objekt; keins von beiden ist allein
+ * eindeutig. Name, Adresse und Koordinaten sind eine Kopie, damit eine Liste mit fuenfzig
+ * Eintraegen nicht fuenfzig Nominatim-Anfragen ausloest — was deren Policy ohnehin
+ * verboete.
+ *
+ * Neu gegenueber den Events: `wikidata` und `wikipedia`. Nominatim liefert beide mit
+ * `extratags=1` direkt mit (gemessen an R62422: "Q64" und "de:Berlin"), ein eigener
+ * Wikidata-Client ist dafuer nicht noetig. `wikipedia` ist der OSM-Slug, kein Link —
+ * die URL entsteht erst im Accessor.
+ *
+ * Alles nullable. Jede bestehende Stadt und jedes bestehende Land bleibt gueltig.
+ */
+return new class extends Migration
+{
+    /**
+     * @var array<int, string>
+     */
+    private array $tables = ['cities', 'countries'];
+
+    public function up(): void
+    {
+        foreach ($this->tables as $table) {
+            Schema::table($table, function (Blueprint $blueprint) {
+                $blueprint->string('osm_type', 16)->nullable();
+                $blueprint->unsignedBigInteger('osm_id')->nullable();
+                $blueprint->string('osm_name')->nullable();
+                $blueprint->string('osm_address')->nullable();
+                // Decimal statt float: Koordinaten werden verglichen und dedupliziert,
+                // und Float-Gleichheit ist eine Falle. 7 Nachkommastellen sind rund 1 cm.
+                $blueprint->decimal('osm_lat', 10, 7)->nullable();
+                $blueprint->decimal('osm_lon', 10, 7)->nullable();
+                // Wikidata-Q-ID, z. B. "Q64". 32 Zeichen sind reichlich.
+                $blueprint->string('wikidata', 32)->nullable();
+                // OSM-Slug der Form "de:Berlin" — Sprachpraefix plus Artikeltitel.
+                $blueprint->string('wikipedia')->nullable();
+
+                $blueprint->index(['osm_type', 'osm_id']);
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        foreach ($this->tables as $table) {
+            Schema::table($table, function (Blueprint $blueprint) {
+                $blueprint->dropIndex(['osm_type', 'osm_id']);
+                $blueprint->dropColumn([
+                    'osm_type', 'osm_id', 'osm_name', 'osm_address', 'osm_lat', 'osm_lon',
+                    'wikidata', 'wikipedia',
+                ]);
+            });
+        }
+    }
+};

--- a/resources/views/livewire/cities/create.blade.php
+++ b/resources/views/livewire/cities/create.blade.php
@@ -17,6 +17,17 @@ class extends Component {
     public string $name = '';
     public ?int $country_id = null;
     public ?int $region_id = null;
+
+    /**
+     * Der aus der OSM-Suche gewaehlte Ort, oder ein leeres Array.
+     *
+     * Der Picker daneben ist derselbe, den die Event-Formulare benutzen — die Suche
+     * laeuft serverseitig, weil Nominatims Policy Drosselung und einen echten
+     * User-Agent verlangt, und beides kann nur der Server garantieren.
+     *
+     * @var array<string, mixed>
+     */
+    public array $osmPlace = [];
     public ?float $latitude = null;
     public ?float $longitude = null;
     public ?int $population = null;
@@ -34,6 +45,17 @@ class extends Component {
      * Ein Landwechsel macht die gewaehlte Region ungueltig — sonst haenge die Stadt an
      * einem Bundesstaat eines anderen Landes.
      */
+
+    /**
+     * Der Laendercode fuer die Suche, damit "Springfield" nicht die halbe Welt trifft.
+     */
+    public function getPickerCountryCodeProperty(): ?string
+    {
+        return $this->country_id
+            ? Country::query()->whereKey($this->country_id)->value('code')
+            : null;
+    }
+
     public function updatedCountryId(): void
     {
         $this->region_id = null;
@@ -70,12 +92,51 @@ class extends Component {
         // 'laendercode-name'. Zwei Regeln nebeneinander liessen den Wert bei jedem
         // Speichern springen.
         $validated['created_by'] = auth()->id();
+        $validated += $this->osmFields();
 
         $city = City::create($validated);
 
         session()->flash('status', __('City successfully created!'));
 
         $this->redirect(route_with_country('cities.index'), navigate: true);
+    }
+
+
+    /**
+     * Die OSM-Spalten aus dem gewaehlten Ort, immer alle acht.
+     *
+     * Auch die leeren: beim Bearbeiten muss ein entfernter Ort die alten Werte
+     * loeschen, und ein weggelassener Schluessel liesse sie stehen.
+     *
+     * @return array<string, mixed>
+     */
+    private function osmFields(): array
+    {
+        $keys = [
+            'osm_type', 'osm_id', 'osm_name', 'osm_address',
+            'osm_lat', 'osm_lon', 'wikidata', 'wikipedia',
+        ];
+
+        return collect($keys)
+            ->mapWithKeys(fn (string $key): array => [$key => $this->osmPlace[$key] ?? null])
+            ->all();
+    }
+
+    /**
+     * Uebernimmt Koordinaten und Einwohnerzahl aus dem OSM-Ort, aber nur in leere Felder.
+     *
+     * Eine von Hand eingetragene Korrektur zu ueberschreiben waere die unangenehmste Art,
+     * hilfsbereit zu sein.
+     */
+    public function updatedOsmPlace(): void
+    {
+        if (($this->osmPlace['osm_id'] ?? null) === null) {
+            return;
+        }
+
+        $this->latitude ??= $this->osmPlace['osm_lat'] ?? null;
+        $this->longitude ??= $this->osmPlace['osm_lon'] ?? null;
+        $this->population ??= $this->osmPlace['population'] ?? null;
     }
 
     public function with(): array
@@ -127,6 +188,19 @@ class extends Component {
                         @endforeach
                     </flux:select>
                 @endif
+
+                {{-- Derselbe Picker wie in den Event-Formularen. Optional: eine Stadt ohne
+                     OSM-Bezug bleibt genauso gueltig wie bisher. --}}
+                <flux:field>
+                    <flux:label>{{ __('OpenStreetMap') }}</flux:label>
+                    <livewire:osm.place-picker
+                        wire:model.live="osmPlace"
+                        :country-code="$this->pickerCountryCode"
+                    />
+                    <flux:description>
+                        {{ __('Optional. Verknüpft die Stadt mit ihrem OpenStreetMap-Eintrag und füllt leere Koordinaten.') }}
+                    </flux:description>
+                </flux:field>
             </div>
         </flux:fieldset>
 

--- a/resources/views/livewire/cities/edit.blade.php
+++ b/resources/views/livewire/cities/edit.blade.php
@@ -17,6 +17,17 @@ class extends Component {
     public string $name = '';
     public ?int $country_id = null;
     public ?int $region_id = null;
+
+    /**
+     * Der aus der OSM-Suche gewaehlte Ort, oder ein leeres Array.
+     *
+     * Der Picker daneben ist derselbe, den die Event-Formulare benutzen — die Suche
+     * laeuft serverseitig, weil Nominatims Policy Drosselung und einen echten
+     * User-Agent verlangt, und beides kann nur der Server garantieren.
+     *
+     * @var array<string, mixed>
+     */
+    public array $osmPlace = [];
     public ?float $latitude = null;
     public ?float $longitude = null;
     public ?int $population = null;
@@ -28,6 +39,17 @@ class extends Component {
         $this->name = $city->name;
         $this->country_id = $city->country_id;
         $this->region_id = $city->region_id;
+        // Vorhandene Referenz zurueck in den Picker, damit sie beim Speichern nicht faellt.
+        $this->osmPlace = $city->osm_id ? [
+            'osm_type' => $city->osm_type,
+            'osm_id' => $city->osm_id,
+            'osm_name' => $city->osm_name,
+            'osm_address' => $city->osm_address,
+            'osm_lat' => $city->osm_lat,
+            'osm_lon' => $city->osm_lon,
+            'wikidata' => $city->wikidata,
+            'wikipedia' => $city->wikipedia,
+        ] : [];
         $this->latitude = $city->latitude;
         $this->longitude = $city->longitude;
         $this->population = $city->population;
@@ -38,6 +60,17 @@ class extends Component {
      * Ein Landwechsel macht die gewaehlte Region ungueltig — sonst haenge die Stadt an
      * einem Bundesstaat eines anderen Landes.
      */
+
+    /**
+     * Der Laendercode fuer die Suche, damit "Springfield" nicht die halbe Welt trifft.
+     */
+    public function getPickerCountryCodeProperty(): ?string
+    {
+        return $this->country_id
+            ? Country::query()->whereKey($this->country_id)->value('code')
+            : null;
+    }
+
     public function updatedCountryId(): void
     {
         $this->region_id = null;
@@ -72,11 +105,49 @@ class extends Component {
 
         // Kein manuelles slug — siehe cities/create. HasSlug erzeugt ihn beim Anlegen
         // und laesst ihn danach stehen.
-        $this->city->update($validated);
+        $this->city->update($validated + $this->osmFields());
 
         session()->flash('status', __('City successfully updated!'));
 
         $this->redirect(route_with_country('cities.index'), navigate: true);
+    }
+
+
+    /**
+     * Die OSM-Spalten aus dem gewaehlten Ort, immer alle acht.
+     *
+     * Auch die leeren: beim Bearbeiten muss ein entfernter Ort die alten Werte
+     * loeschen, und ein weggelassener Schluessel liesse sie stehen.
+     *
+     * @return array<string, mixed>
+     */
+    private function osmFields(): array
+    {
+        $keys = [
+            'osm_type', 'osm_id', 'osm_name', 'osm_address',
+            'osm_lat', 'osm_lon', 'wikidata', 'wikipedia',
+        ];
+
+        return collect($keys)
+            ->mapWithKeys(fn (string $key): array => [$key => $this->osmPlace[$key] ?? null])
+            ->all();
+    }
+
+    /**
+     * Uebernimmt Koordinaten und Einwohnerzahl aus dem OSM-Ort, aber nur in leere Felder.
+     *
+     * Eine von Hand eingetragene Korrektur zu ueberschreiben waere die unangenehmste Art,
+     * hilfsbereit zu sein.
+     */
+    public function updatedOsmPlace(): void
+    {
+        if (($this->osmPlace['osm_id'] ?? null) === null) {
+            return;
+        }
+
+        $this->latitude ??= $this->osmPlace['osm_lat'] ?? null;
+        $this->longitude ??= $this->osmPlace['osm_lon'] ?? null;
+        $this->population ??= $this->osmPlace['population'] ?? null;
     }
 
     public function with(): array
@@ -121,6 +192,19 @@ class extends Component {
                         @endforeach
                     </flux:select>
                 @endif
+
+                {{-- Derselbe Picker wie in den Event-Formularen. Optional: eine Stadt ohne
+                     OSM-Bezug bleibt genauso gueltig wie bisher. --}}
+                <flux:field>
+                    <flux:label>{{ __('OpenStreetMap') }}</flux:label>
+                    <livewire:osm.place-picker
+                        wire:model.live="osmPlace"
+                        :country-code="$this->pickerCountryCode"
+                    />
+                    <flux:description>
+                        {{ __('Optional. Verknüpft die Stadt mit ihrem OpenStreetMap-Eintrag und füllt leere Koordinaten.') }}
+                    </flux:description>
+                </flux:field>
             </div>
         </flux:fieldset>
 

--- a/resources/views/livewire/courses/create-edit-events.blade.php
+++ b/resources/views/livewire/courses/create-edit-events.blade.php
@@ -327,6 +327,21 @@ class extends Component {
             'name' => $name,
             'latitude' => $hit['osm_lat'],
             'longitude' => $hit['osm_lon'],
+            /*
+             * Die Referenz gleich mitschreiben: der Treffer kommt aus derselben Suche,
+             * die sie liefert, und eine Stadt ohne sie muesste spaeter von Hand
+             * nachgezogen werden. Bestehende Staedte werden nicht angefasst — dieser
+             * Zweig laeuft nur, wenn keine gefunden wurde.
+             */
+            'osm_type' => $hit['osm_type'] ?? null,
+            'osm_id' => $hit['osm_id'] ?? null,
+            'osm_name' => $hit['osm_name'] ?? null,
+            'osm_address' => $hit['osm_address'] ?? null,
+            'osm_lat' => $hit['osm_lat'] ?? null,
+            'osm_lon' => $hit['osm_lon'] ?? null,
+            'wikidata' => $hit['wikidata'] ?? null,
+            'wikipedia' => $hit['wikipedia'] ?? null,
+            'population' => $hit['population'] ?? null,
         ]);
 
         $this->city_id = $city->id;

--- a/resources/views/livewire/osm/place-picker.blade.php
+++ b/resources/views/livewire/osm/place-picker.blade.php
@@ -61,8 +61,14 @@ new class extends Component {
             return;
         }
 
-        // Only the stored columns travel onwards; importance and category are ranking
-        // aids for the search itself and have no place on the event.
+        /*
+         * Only the stored columns travel onwards; importance and category are ranking
+         * aids for the search itself and have no place on the event.
+         *
+         * wikidata, wikipedia und population kommen seit dem extratags-Einbau dazu. Sie
+         * sind fuer Staedte und Laender gedacht; die Event-Formulare filtern in
+         * osmFields() ohnehin auf ihre sechs Spalten und sehen sie nie.
+         */
         $this->place = [
             'osm_type' => $hit['osm_type'],
             'osm_id' => $hit['osm_id'],
@@ -70,6 +76,9 @@ new class extends Component {
             'osm_address' => $hit['osm_address'],
             'osm_lat' => $hit['osm_lat'],
             'osm_lon' => $hit['osm_lon'],
+            'wikidata' => $hit['wikidata'] ?? null,
+            'wikipedia' => $hit['wikipedia'] ?? null,
+            'population' => $hit['population'] ?? null,
         ];
 
         $this->results = [];

--- a/tests/Feature/CityOsmFormTest.php
+++ b/tests/Feature/CityOsmFormTest.php
@@ -1,0 +1,131 @@
+<?php
+
+use App\Models\City;
+use App\Models\Country;
+use App\Models\User;
+use Livewire\Livewire;
+
+beforeEach(function () {
+    $this->actingAs(User::factory()->create());
+    $this->country = Country::factory()->create(['code' => 'de', 'name' => 'Germany']);
+});
+
+it('stores the osm reference chosen in the form', function () {
+    Livewire::test('cities.create')
+        ->set('name', 'Berlin OSM Test')
+        ->set('country_id', $this->country->id)
+        ->set('latitude', 52.52)
+        ->set('longitude', 13.405)
+        ->set('osmPlace', [
+            'osm_type' => 'relation',
+            'osm_id' => 62422,
+            'osm_name' => 'Berlin',
+            'osm_address' => 'Berlin, Deutschland',
+            'osm_lat' => 52.5173885,
+            'osm_lon' => 13.3951309,
+            'wikidata' => 'Q64',
+            'wikipedia' => 'de:Berlin',
+        ])
+        ->call('createCity')
+        ->assertHasNoErrors();
+
+    $city = City::firstWhere('name', 'Berlin OSM Test');
+
+    expect($city->osm_type)->toBe('relation')
+        ->and($city->osm_id)->toBe(62422)
+        ->and($city->wikidata)->toBe('Q64')
+        ->and($city->osm_url)->toBe('https://www.openstreetmap.org/relation/62422')
+        ->and($city->wikipedia_url)->toBe('https://de.wikipedia.org/wiki/Berlin');
+});
+
+it('creates a city without any osm reference exactly as before', function () {
+    Livewire::test('cities.create')
+        ->set('name', 'Ohne OSM')
+        ->set('country_id', $this->country->id)
+        ->set('latitude', 51.0)
+        ->set('longitude', 9.0)
+        ->call('createCity')
+        ->assertHasNoErrors();
+
+    $city = City::firstWhere('name', 'Ohne OSM');
+
+    expect($city)->not->toBeNull()
+        ->and($city->osm_id)->toBeNull()
+        ->and($city->osm_url)->toBeNull();
+});
+
+it('fills empty coordinates from the chosen place but never overwrites entered ones', function () {
+    // Eine von Hand eingetragene Korrektur zu ueberschreiben waere die unangenehmste
+    // Art, hilfsbereit zu sein.
+    Livewire::test('cities.create')
+        ->set('country_id', $this->country->id)
+        ->set('latitude', 1.234)
+        ->set('osmPlace', ['osm_id' => 62422, 'osm_lat' => 52.5, 'osm_lon' => 13.4, 'population' => 3769962])
+        ->assertSet('latitude', 1.234)
+        ->assertSet('longitude', 13.4)
+        ->assertSet('population', 3769962);
+});
+
+it('keeps the reference when the city is edited without touching it', function () {
+    $city = City::factory()->create([
+        'country_id' => $this->country->id,
+        'name' => 'Bestandsstadt',
+        'osm_type' => 'relation',
+        'osm_id' => 62422,
+        'wikidata' => 'Q64',
+    ]);
+
+    Livewire::test('cities.edit', ['city' => $city])
+        ->set('population', 12345)
+        ->call('updateCity')
+        ->assertHasNoErrors();
+
+    expect($city->fresh()->osm_id)->toBe(62422)
+        ->and($city->fresh()->wikidata)->toBe('Q64');
+});
+
+it('accepts a city from the api with an osm place and no own coordinates', function () {
+    // Wunsch aus Issue #11: Name + Land + OSM-Ort sollen genuegen. Die Koordinaten des
+    // Orts wandern in latitude/longitude, denn die Spalten sind NOT NULL.
+    $response = $this->postJson('/api/cities', [
+        'country_id' => $this->country->id,
+        'name' => 'Nur mit OSM',
+        'osm_type' => 'relation',
+        'osm_id' => 62422,
+        'osm_lat' => 52.5173885,
+        'osm_lon' => 13.3951309,
+        'wikidata' => 'Q64',
+        'wikipedia' => 'de:Berlin',
+    ]);
+
+    $response->assertSuccessful();
+
+    expect($response->json('data.osm_url'))->toBe('https://www.openstreetmap.org/relation/62422')
+        ->and($response->json('data.wikipedia_url'))->toBe('https://de.wikipedia.org/wiki/Berlin')
+        ->and((float) $response->json('data.latitude'))->toBe(52.5173885);
+});
+
+it('refuses an osm place that brings no coordinates either', function () {
+    // Ohne osm_lat/osm_lon waere die Stadt ein Punkt ohne Ort — die Karte braucht beides.
+    $this->postJson('/api/cities', [
+        'country_id' => $this->country->id,
+        'name' => 'OSM ohne Koordinaten',
+        'osm_type' => 'relation',
+        'osm_id' => 62422,
+    ])->assertJsonValidationErrors(['latitude', 'longitude']);
+});
+
+it('still rejects a city without coordinates and without an osm place', function () {
+    $this->postJson('/api/cities', [
+        'country_id' => $this->country->id,
+        'name' => 'Weder noch',
+    ])->assertJsonValidationErrors(['latitude', 'longitude']);
+});
+
+it('rejects half an osm pair', function () {
+    $this->postJson('/api/cities', [
+        'country_id' => $this->country->id,
+        'name' => 'Halbes Paar',
+        'osm_id' => 62422,
+    ])->assertJsonValidationErrors(['osm_type']);
+});

--- a/tests/Feature/CountryOsmApiTest.php
+++ b/tests/Feature/CountryOsmApiTest.php
@@ -1,0 +1,66 @@
+<?php
+
+use App\Models\Country;
+
+it('keeps returning a bare array, not a data wrapper', function () {
+    /*
+     * GET /countries antwortet seit jeher mit einem nackten Array. Die Umstellung auf
+     * eine JsonResource haette daraus ohne `$wrap = null` ein {"data": [...]} gemacht —
+     * und jeden bestehenden Client gebrochen. Dieser Test ist das Netz darunter.
+     */
+    Country::factory()->create(['code' => 'de', 'name' => 'Germany']);
+
+    $response = $this->getJson('/api/countries');
+
+    $response->assertSuccessful();
+
+    expect($response->json())->toBeArray()
+        ->and($response->json())->not->toHaveKey('data')
+        ->and($response->json(0))->toHaveKeys(['id', 'name', 'code', 'flag']);
+});
+
+it('keeps the four established fields byte for byte', function () {
+    $country = Country::factory()->create(['code' => 'de', 'name' => 'Germany']);
+
+    $row = $this->getJson('/api/countries?search=Germany')->json(0);
+
+    expect($row['id'])->toBe($country->id)
+        ->and($row['name'])->toBe('Germany')
+        ->and($row['code'])->toBe('de')
+        ->and($row['flag'])->toBe(asset('vendor/blade-flags/country-de.svg'));
+});
+
+it('adds the osm reference without demanding it', function () {
+    Country::factory()->create(['code' => 'de', 'name' => 'Germany']);
+
+    $row = $this->getJson('/api/countries?search=Germany')->json(0);
+
+    // Ohne Referenz sind die neuen Felder null — der Normalfall fuer Bestandsdaten.
+    expect($row)->toHaveKeys(['osm_type', 'osm_id', 'osm_url', 'wikidata', 'wikipedia'])
+        ->and($row['osm_url'])->toBeNull()
+        ->and($row['wikipedia_url'])->toBeNull();
+});
+
+it('builds the derived urls once a reference is set', function () {
+    Country::factory()->create([
+        'code' => 'de',
+        'name' => 'Germany',
+        'osm_type' => 'relation',
+        'osm_id' => 51477,
+        'wikidata' => 'Q183',
+        'wikipedia' => 'de:Deutschland',
+    ]);
+
+    $row = $this->getJson('/api/countries?search=Germany')->json(0);
+
+    expect($row['osm_url'])->toBe('https://www.openstreetmap.org/relation/51477')
+        ->and($row['wikidata_url'])->toBe('https://www.wikidata.org/wiki/Q183')
+        ->and($row['wikipedia_url'])->toBe('https://de.wikipedia.org/wiki/Deutschland');
+});
+
+it('returns null for a wikipedia value without a language prefix', function () {
+    // "Berlin" ohne Praefix ergibt keine Domain — dann lieber null als ein toter Link.
+    Country::factory()->create(['code' => 'de', 'name' => 'Germany', 'wikipedia' => 'Berlin']);
+
+    expect($this->getJson('/api/countries?search=Germany')->json(0)['wikipedia_url'])->toBeNull();
+});

--- a/tests/Feature/Osm/NominatimClientTest.php
+++ b/tests/Feature/Osm/NominatimClientTest.php
@@ -135,3 +135,65 @@ it('actually waits between two uncached requests', function () {
 
     expect($elapsed)->toBeGreaterThanOrEqual(280);
 });
+
+it('asks Nominatim for extratags on both endpoints', function (string $method, array $args) {
+    // Ohne den Parameter liefert Nominatim wikidata und wikipedia gar nicht erst.
+    Http::fake(['*' => Http::response([nominatimRow()])]);
+
+    (new NominatimClient(minIntervalMs: 0))->{$method}(...$args);
+
+    Http::assertSent(fn ($request): bool => ($request->data()['extratags'] ?? null) == 1);
+})->with([
+    'search' => ['search', ['Bitcoin Bar Praha']],
+    'lookup' => ['lookup', ['relation', 62422]],
+]);
+
+it('carries wikidata, wikipedia and population out of extratags', function () {
+    Http::fake(['*' => Http::response([nominatimRow([
+        'extratags' => [
+            'wikidata' => 'Q64',
+            'wikipedia' => 'de:Berlin',
+            'population' => '3769962',
+            'capital' => 'yes',
+        ],
+    ])])]);
+
+    $hit = (new NominatimClient(minIntervalMs: 0))->search('Berlin')->first();
+
+    expect($hit['wikidata'])->toBe('Q64')
+        ->and($hit['wikipedia'])->toBe('de:Berlin')
+        ->and($hit['population'])->toBe(3769962)
+        // capital ist ein gueltiger Tag, aber keiner, den wir speichern.
+        ->and($hit)->not->toHaveKey('capital');
+});
+
+it('leaves the new fields null when the place has no extratags', function () {
+    Http::fake(['*' => Http::response([nominatimRow()])]);
+
+    $hit = (new NominatimClient(minIntervalMs: 0))->search('Bitcoin Bar Praha')->first();
+
+    expect($hit['wikidata'])->toBeNull()
+        ->and($hit['wikipedia'])->toBeNull()
+        ->and($hit['population'])->toBeNull();
+});
+
+it('ignores a lookup cached under the pre-extratags key', function () {
+    /*
+     * Der Lookup-Schluessel traegt die Parameter nicht, deshalb ist er versioniert.
+     * Ohne das v2 haette ein Eintrag aus der Zeit vor extratags noch 30 Tage lang
+     * gewonnen — und der neue Code haette ausgesehen, als tue er nichts.
+     */
+    Cache::put('osm:lookup:R62422', ['osm_type' => 'relation', 'osm_id' => 62422, 'osm_name' => 'Veraltet'], now()->addDay());
+
+    Http::fake(['*' => Http::response([nominatimRow([
+        'osm_type' => 'relation',
+        'osm_id' => 62422,
+        'name' => 'Berlin',
+        'extratags' => ['wikidata' => 'Q64'],
+    ])])]);
+
+    $hit = (new NominatimClient(minIntervalMs: 0))->lookup('relation', 62422);
+
+    expect($hit['osm_name'])->toBe('Berlin')
+        ->and($hit['wikidata'])->toBe('Q64');
+});

--- a/tests/Feature/Osm/OsmPlacePickerTest.php
+++ b/tests/Feature/Osm/OsmPlacePickerTest.php
@@ -46,6 +46,15 @@ it('finds and picks a place', function () {
 });
 
 it('keeps only the stored columns, not the ranking aids', function () {
+    /*
+     * Die Absicht des Tests ist unveraendert: `importance` und `category` sind
+     * Ranking-Hilfen der Suche und duerfen nicht am Datensatz landen.
+     *
+     * Die erwartete Liste ist am 2026-08-23 um wikidata, wikipedia und population
+     * gewachsen — das sind seit Issue #11/#12 echte Spalten auf `cities` und
+     * `countries`, die Nominatim mit `extratags=1` mitliefert. Die Event-Formulare
+     * sehen sie nie: deren osmFields() filtert auf ihre eigenen sechs Spalten.
+     */
     Http::fake(['*' => Http::response([[
         ...osmResponse()[0],
         'importance' => 0.9,
@@ -60,7 +69,10 @@ it('keeps only the stored columns, not the ranking aids', function () {
 
     expect(array_keys($place))->toBe([
         'osm_type', 'osm_id', 'osm_name', 'osm_address', 'osm_lat', 'osm_lon',
-    ]);
+        'wikidata', 'wikipedia', 'population',
+    ])
+        ->and($place)->not->toHaveKey('importance')
+        ->and($place)->not->toHaveKey('category');
 });
 
 it('does not call out for a query under three characters', function () {


### PR DESCRIPTION
Beantwortet #11 und #12 — aber auf der Stufe, auf der dieses Repo schon steht.

## Warum nicht das vorgeschlagene `osm_url`-Feld

Beide Issues beschreiben vier Ausbaustufen, von einem Freitext-Feld zum Hineinkopieren bis zu einer eingebauten Nominatim-Suche. **Stufe 4 gibt es hier bereits, nur nicht für Städte und Länder:** Events tragen seit `2026_08_17` sechs strukturierte OSM-Spalten, dazu kommen ein gedrosselter `NominatimClient`, das geteilte Trait `ValidatesOsmPlace` und die Livewire-Komponente `osm.place-picker`.

Diese Änderung hängt Städte und Länder an genau diese Infrastruktur. Der Antragsteller bekommt, was er will — `osm_url` in der API-Antwort —, nur **berechnet** aus `osm_type` + `osm_id` statt als ungeprüfter Freitext. Eine zweite Kopie derselben Information könnte der ersten widersprechen.

## Was drin ist

| Bereich | Inhalt |
|---|---|
| `NominatimClient` | `extratags=1` in `search()` und `lookup()`; `wikidata`, `wikipedia`, `population` in `normalise()` |
| Migration | acht nullable Spalten auf `cities` und `countries`, Index `[osm_type, osm_id]` |
| `HasOsmReference` | Accessoren `osm_url`, `wikidata_url`, `wikipedia_url`; Scope `withoutOsmReference()` |
| API | `CityResource` erweitert, `CountryResource` neu, `ValidatesOsmPlace` in beiden City-Requests |
| Portal | Picker in `cities/create` und `cities/edit`; das Kursformular schreibt die Referenz beim Anlegen einer neuen Stadt gleich mit |
| MCP | `CreateCityTool` kennt dieselben Felder |

Gemessen an `R62422` (Berlin), ein einzelner Request gegen die echte API:

```json
{"osm_name":"Berlin","wikidata":"Q64","wikipedia":"de:Berlin","population":3769962,"importance":0.85}
```

Nominatim liefert die Querverweise also selbst — ein eigener Wikidata-Client ist unnötig.

## Kein Geocoding-Paket, und warum

Zwölf Kandidaten geprüft. Die drei Ausschlussgründe für den stärksten (`geocoder-php/nominatim-provider` + `toin0u/geocoder-laravel`):

- Er kennt **kein `/lookup`** — kann also nicht nach `osm_type`+`osm_id` auflösen, genau das Muster, an dem hier alles hängt.
- Weder der Provider noch `geocoder-php/plugin` noch der gesamte `src/` des Laravel-Wrappers enthalten eine Drosselung (`grep sleep|throttl`: keine Treffer). Die 1-req/s- und 4-req/min-Regel der Nominatim-Policy fiele an den Aufrufer zurück — die garantieren unsere 220 Zeilen heute prozessweit.
- Sein Modell kennt kein `importance`, `normalise()` und `ValidatesOsmPlace` blieben ohnehin bestehen.

`spatie/geocoder` spricht Google Maps. `maxh/php-nominatim` und Verwandte erzwingen keinen User-Agent, drosseln nicht und cachen nicht. Für Wikidata gibt es nichts Brauchbares: `freearhey/wikidata` hängt an `tightenco/collect`, das Packagist als *abandoned* führt.

## Rein additiv — nachprüfbar

- **`GET /countries` antwortet weiter mit einem nackten Array.** `CountryResource::collection()` hätte es in einen `data`-Schlüssel gewickelt und jeden bestehenden Client gebrochen; `$wrap = null` genügt dafür **nicht**, es greift nur bei `::make()`. Der Test dafür stand vor dem Fix und war rot.
- Die vier bestehenden Felder von `GET /countries` behalten Name, Typ und Wert, einschließlich der aus dem Ländercode gebildeten `flag`-URL.
- `CityResource` bekommt Felder dazu, keines weg.
- Alle neuen Spalten sind nullable, alle neuen Regeln `nullable`. Die einzige Änderung an einer bestehenden Regel ist eine **Lockerung**.
- Die Event-Tabellen kommen im Diff nicht vor. `ValidatesOsmPlace` wird benutzt, nicht umgeschrieben.
- `tests/Feature/Smoke` und `tests/Feature/Api` zusammen: **207 passed**.

## Zwei Fallstricke, die Zeit gekostet hätten

- **Der Cache-Schlüssel von `lookup()` trägt die Parameter nicht.** Ohne Versionierung auf `v2` hätte er nach dem `extratags`-Einbau noch 30 Tage lang die alten Einträge geliefert — der neue Code hätte ausgesehen, als tue er nichts. Ein Test hält das fest.
- **Das MCP-Tool validiert gegen `StoreCityRequest::rules()`, läuft aber nicht durch dessen `prepareForValidation()`.** Ohne `coordinatesFromOsm()` hätte derselbe Aufruf über MCP andere Anforderungen gehabt als über die API.

## Bewusst nicht enthalten

- **`cities.longitude`/`latitude` bleiben NOT NULL.** Statt das Schema zu lockern, übernimmt der Request die Koordinaten aus `osm_lat`/`osm_lon`. Ein OSM-Ort ohne Koordinaten wird abgelehnt — eine Stadt ohne Punkt wäre auf der Karte unsichtbar.
- **`osm_relation` und `simplified_geojson` werden nicht exponiert** (Kommentar 2 zu #11). Gemessen: 134 bzw. 138 von 305 Städten haben Werte, der Rest ist leer, und das Format stammt aus einem Import von 2023, den heute nichts mehr schreibt.
- **Kein `osm_snapshot`-Verlauf und kein „überschreiben"-Schalter** (Kommentar 3). Beides löst ein Problem, das noch niemand hat: es gibt bislang **3 von 3569** Events mit OSM-Referenz.
- **Der Länderlauf `countries:enrich-from-osm` fehlt noch.** Von 249 Ländern haben heute 14 Koordinaten; wegen der 15-Sekunden-Drosselung für Massenabfragen dauert der Lauf rund 62 Minuten und kommt als eigener PR.

## Ein geänderter Bestandstest

`OsmPlacePickerTest` prüfte, dass `choose()` genau die sechs Event-Spalten weitergibt. Es sind jetzt neun — `wikidata`, `wikipedia` und `population` sind echte Spalten auf `cities` und `countries`. Die Absicht des Tests (keine Ranking-Hilfen am Datensatz) ist durch zwei zusätzliche Zusicherungen gegen `importance` und `category` **schärfer** als vorher. Die Event-Formulare sehen die neuen Schlüssel nie: deren `osmFields()` filtert auf die eigenen sechs Spalten.
