### PR TITLE
🌍 countries:enrich-from-osm — Länder holen sich ihre OSM-Referenz

### DIFF
--- a/app/Console/Commands/EnrichCountriesFromOsm.php
+++ b/app/Console/Commands/EnrichCountriesFromOsm.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\Country;
+use App\Services\Osm\NominatimClient;
+use Illuminate\Console\Command;
+use Illuminate\Support\Collection;
+
+/**
+ * Reichert Laender um ihre OpenStreetMap-Referenz an (Issue #12).
+ *
+ * Der Lauf ist langsam, und das ist Absicht: Nominatims Usage-Policy beschraenkt
+ * Skripte, die regelmaessig oder laenger als einen Tag laufen, auf 4 Anfragen pro
+ * Minute. `NominatimClient::forBulk()` haelt diese 15 Sekunden ein. 249 Laender
+ * dauern damit rund eine Stunde.
+ *
+ * Daraus folgt der Rest des Entwurfs: nach jedem Land wird sofort gespeichert, damit
+ * ein Abbruch nichts kostet und ein zweiter Aufruf dort weitermacht, wo der erste
+ * aufhoerte. Es gibt bewusst kein --force: bestehende Werte zu ueberschreiben ist eine
+ * andere Entscheidung als leere zu fuellen, und niemand hat bisher ueber veraltete
+ * OSM-Daten geklagt.
+ */
+class EnrichCountriesFromOsm extends Command
+{
+    protected $signature = 'countries:enrich-from-osm
+        {--limit=0 : Hoechstens so viele Laender bearbeiten (0 = alle)}
+        {--code=* : Nur diese Laendercodes, z. B. --code=de --code=us}
+        {--dry-run : Nur zeigen, was passieren wuerde}
+        {--interval-ms= : Abstand zwischen zwei Nominatim-Anfragen in Millisekunden. NUR fuer Tests herabsetzen — die Policy verlangt 15000 fuer Massenlaeufe.}';
+
+    protected $description = 'Ergaenzt fehlende OpenStreetMap-Referenzen auf Laendern (nur leere Felder)';
+
+    public function handle(): int
+    {
+        /*
+         * Bewusst selbst gebaut statt per Dependency Injection: die Container-Bindung
+         * liefert die normale Instanz mit 1,1 Sekunden Abstand, und die waere fuer einen
+         * Lauf ueber 249 Laender ein Policy-Verstoss. forBulk() haelt die 15 Sekunden ein,
+         * die Nominatim fuer regelmaessige oder lang laufende Skripte verlangt.
+         */
+        $intervalMs = $this->option('interval-ms');
+        $client = $intervalMs === null
+            ? NominatimClient::forBulk()
+            : new NominatimClient(minIntervalMs: (int) $intervalMs);
+
+        $dryRun = (bool) $this->option('dry-run');
+        $codes = array_map(mb_strtolower(...), (array) $this->option('code'));
+        $limit = (int) $this->option('limit');
+
+        $countries = Country::query()
+            ->withoutOsmReference()
+            ->when($codes !== [], fn ($query) => $query->whereIn(Country::raw('LOWER(code)'), $codes))
+            ->orderBy('name')
+            ->when($limit > 0, fn ($query) => $query->limit($limit))
+            ->get();
+
+        if ($countries->isEmpty()) {
+            $this->info('Nichts zu tun — alle betroffenen Laender haben bereits eine OSM-Referenz.');
+
+            return self::SUCCESS;
+        }
+
+        $this->line(sprintf(
+            '%d Laender, rund %d Minuten bei 15 Sekunden Abstand.%s',
+            $countries->count(),
+            (int) ceil($countries->count() * 15 / 60),
+            $dryRun ? ' (Probelauf, es wird nichts geschrieben.)' : '',
+        ));
+
+        $filled = 0;
+        $ambiguous = 0;
+        $missing = 0;
+
+        foreach ($countries as $country) {
+            $hits = $this->boundaryRelations($client, $country);
+
+            if ($hits->isEmpty()) {
+                $missing++;
+                $this->warn("  {$country->code} {$country->name}: kein Treffer");
+
+                continue;
+            }
+
+            if ($hits->count() > 1) {
+                /*
+                 * Lieber nichts als das Falsche: Territorien wie "U.S. Outlying Islands"
+                 * liefern mehrere Grenzrelationen, und die falsche zu waehlen faellt
+                 * niemandem auf, bis jemand der Karte nicht mehr traut.
+                 */
+                $ambiguous++;
+                $this->warn("  {$country->code} {$country->name}: {$hits->count()} Grenzrelationen — uebersprungen");
+
+                continue;
+            }
+
+            $hit = $hits->first();
+            $changes = $this->emptyFieldsFrom($country, $hit);
+
+            if ($changes === []) {
+                continue;
+            }
+
+            $this->line("  {$country->code} {$country->name}: ".implode(', ', array_keys($changes)));
+
+            if (! $dryRun) {
+                // Sofort speichern, nicht am Ende: ein Abbruch nach vierzig Minuten
+                // darf nicht vierzig Minuten Arbeit kosten.
+                $country->forceFill($changes)->save();
+            }
+
+            $filled++;
+        }
+
+        $this->info(sprintf(
+            'Fertig: %d ergaenzt, %d mehrdeutig, %d ohne Treffer (von %d).',
+            $filled, $ambiguous, $missing, $countries->count(),
+        ));
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * Die Grenzrelationen, die zu diesem Land gehoeren koennten.
+     *
+     * Ein Land ist in OSM eine Relation mit `boundary`-Kategorie. Alles andere — Staedte,
+     * Strassen, Flughaefen gleichen Namens — faellt hier raus, sonst wuerde aus "Georgia"
+     * schnell der US-Bundesstaat statt des Landes.
+     *
+     * @return Collection<int, array<string, mixed>>
+     */
+    private function boundaryRelations(NominatimClient $client, Country $country): Collection
+    {
+        return $client
+            ->search($country->english_name ?: $country->name, $country->code, limit: 10)
+            ->filter(fn (array $hit): bool => ($hit['osm_type'] ?? null) === 'relation'
+                && ($hit['category'] ?? null) === 'boundary')
+            ->values();
+    }
+
+    /**
+     * Nur die Felder, die heute leer sind — mit dem Wert, den OSM dafuer kennt.
+     *
+     * @param  array<string, mixed>  $hit
+     * @return array<string, mixed>
+     */
+    private function emptyFieldsFrom(Country $country, array $hit): array
+    {
+        $candidates = [
+            'osm_type' => $hit['osm_type'] ?? null,
+            'osm_id' => $hit['osm_id'] ?? null,
+            'osm_name' => $hit['osm_name'] ?? null,
+            'osm_address' => $hit['osm_address'] ?? null,
+            'osm_lat' => $hit['osm_lat'] ?? null,
+            'osm_lon' => $hit['osm_lon'] ?? null,
+            'wikidata' => $hit['wikidata'] ?? null,
+            'wikipedia' => $hit['wikipedia'] ?? null,
+            // Die Koordinatenspalten des Landes sind aelter als die osm_*-Spalten und bei
+            // 235 von 249 Laendern leer; der Mittelpunkt der Grenzrelation ist ein
+            // brauchbarer Wert dafuer.
+            'latitude' => $hit['osm_lat'] ?? null,
+            'longitude' => $hit['osm_lon'] ?? null,
+        ];
+
+        return collect($candidates)
+            ->filter(fn ($value, string $field): bool => $value !== null && $country->{$field} === null)
+            ->all();
+    }
+}

--- a/tests/Feature/EnrichCountriesFromOsmTest.php
+++ b/tests/Feature/EnrichCountriesFromOsmTest.php
@@ -1,0 +1,138 @@
+<?php
+
+use App\Models\Country;
+use App\Services\Osm\NominatimClient;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\Http;
+
+beforeEach(function () {
+    NominatimClient::resetThrottle();
+    Cache::flush();
+});
+
+function osmCountryRow(array $overrides = []): array
+{
+    return array_merge([
+        'osm_type' => 'relation',
+        'osm_id' => 51477,
+        'name' => 'Deutschland',
+        'display_name' => 'Deutschland',
+        'lat' => '51.1638175',
+        'lon' => '10.4478313',
+        'category' => 'boundary',
+        'extratags' => ['wikidata' => 'Q183', 'wikipedia' => 'de:Deutschland'],
+    ], $overrides);
+}
+
+it('fills the empty fields of a country from its boundary relation', function () {
+    Http::fake(['*' => Http::response([osmCountryRow()])]);
+
+    // latitude/longitude ausdruecklich leeren: die Factory setzt sie, und der Befehl
+    // fuellt bewusst nur Leeres — sonst pruefte dieser Test die Factory.
+    $country = Country::factory()->create([
+        'code' => 'de', 'name' => 'Germany', 'english_name' => 'Germany',
+        'latitude' => null, 'longitude' => null,
+    ]);
+
+    $this->artisan('countries:enrich-from-osm', ['--code' => ['de'], '--interval-ms' => 0])
+        ->assertSuccessful();
+
+    $country->refresh();
+
+    expect($country->osm_type)->toBe('relation')
+        ->and($country->osm_id)->toBe(51477)
+        ->and($country->wikidata)->toBe('Q183')
+        ->and($country->wikipedia)->toBe('de:Deutschland')
+        ->and($country->osm_url)->toBe('https://www.openstreetmap.org/relation/51477')
+        ->and((float) $country->latitude)->toBe(51.1638175);
+});
+
+it('never overwrites a value that is already there', function () {
+    // Ohne diese Regel waere jeder Lauf ein Risiko fuer von Hand gepflegte Korrekturen.
+    Http::fake(['*' => Http::response([osmCountryRow()])]);
+
+    $country = Country::factory()->create([
+        'code' => 'de',
+        'name' => 'Germany',
+        'latitude' => 1.234,
+        'wikidata' => 'Q-von-Hand',
+    ]);
+
+    $this->artisan('countries:enrich-from-osm', ['--code' => ['de'], '--interval-ms' => 0])
+        ->assertSuccessful();
+
+    $country->refresh();
+
+    expect((float) $country->latitude)->toBe(1.234)
+        ->and($country->wikidata)->toBe('Q-von-Hand')
+        // Was leer war, wurde trotzdem gefuellt.
+        ->and($country->osm_id)->toBe(51477);
+});
+
+it('writes nothing when several boundary relations match', function () {
+    // Lieber nichts als das Falsche — eine falsch gewaehlte Relation faellt niemandem
+    // auf, bis jemand der Karte nicht mehr traut.
+    Http::fake(['*' => Http::response([
+        osmCountryRow(),
+        osmCountryRow(['osm_id' => 99999, 'name' => 'Deutschland (anders)']),
+    ])]);
+
+    $country = Country::factory()->create(['code' => 'de', 'name' => 'Germany']);
+
+    $this->artisan('countries:enrich-from-osm', ['--code' => ['de'], '--interval-ms' => 0])
+        ->expectsOutputToContain('2 Grenzrelationen')
+        ->assertSuccessful();
+
+    expect($country->fresh()->osm_id)->toBeNull();
+});
+
+it('ignores hits that are not boundary relations', function () {
+    // "Georgia" trifft sonst den US-Bundesstaat oder eine gleichnamige Strasse.
+    Http::fake(['*' => Http::response([
+        osmCountryRow(['category' => 'place', 'osm_type' => 'node']),
+        osmCountryRow(['category' => 'highway', 'osm_type' => 'way']),
+    ])]);
+
+    $country = Country::factory()->create(['code' => 'ge', 'name' => 'Georgia']);
+
+    $this->artisan('countries:enrich-from-osm', ['--code' => ['ge'], '--interval-ms' => 0])
+        ->expectsOutputToContain('kein Treffer')
+        ->assertSuccessful();
+
+    expect($country->fresh()->osm_id)->toBeNull();
+});
+
+it('skips countries that already have a reference', function () {
+    Http::fake(['*' => Http::response([osmCountryRow()])]);
+
+    Country::factory()->create(['code' => 'de', 'name' => 'Germany', 'osm_type' => 'relation', 'osm_id' => 51477]);
+
+    $this->artisan('countries:enrich-from-osm', ['--code' => ['de'], '--interval-ms' => 0])
+        ->expectsOutputToContain('Nichts zu tun')
+        ->assertSuccessful();
+
+    Http::assertNothingSent();
+});
+
+it('changes nothing on a dry run', function () {
+    Http::fake(['*' => Http::response([osmCountryRow()])]);
+
+    $country = Country::factory()->create(['code' => 'de', 'name' => 'Germany']);
+
+    $this->artisan('countries:enrich-from-osm', ['--code' => ['de'], '--dry-run' => true, '--interval-ms' => 0])
+        ->assertSuccessful();
+
+    expect($country->fresh()->osm_id)->toBeNull();
+});
+
+it('honours the limit so a first run can stay small', function () {
+    Http::fake(['*' => Http::response([osmCountryRow()])]);
+
+    Country::factory()->create(['code' => 'de', 'name' => 'Aaa']);
+    Country::factory()->create(['code' => 'at', 'name' => 'Bbb']);
+
+    $this->artisan('countries:enrich-from-osm', ['--limit' => 1, '--interval-ms' => 0])
+        ->assertSuccessful();
+
+    expect(Country::whereNotNull('osm_id')->count())->toBe(1);
+});


### PR DESCRIPTION
Schließt Issue #12, Kommentar 2. Von 249 Ländern haben heute **14** Koordinaten; der Befehl füllt OSM-Referenz, Wikidata, Wikipedia und Koordinaten aus der Grenzrelation nach.

## Warum der Lauf eine Stunde dauert

Nominatims Usage-Policy beschränkt Skripte, die regelmäßig oder länger als einen Tag laufen, auf **4 Anfragen pro Minute**. `NominatimClient::forBulk()` hält diese 15 Sekunden ein — 249 Länder brauchen damit rund 62 Minuten.

Der Client wird deshalb bewusst **nicht** injiziert: die Container-Bindung liefert die normale Instanz mit 1,1 Sekunden Abstand, und die wäre für diesen Lauf ein Policy-Verstoß. `--interval-ms` existiert nur, damit die Tests nicht eine Viertelstunde schlafen.

## Was daraus folgt

| Entwurfsentscheidung | Grund |
|---|---|
| Nach jedem Land sofort speichern | Ein Abbruch nach vierzig Minuten darf nicht vierzig Minuten Arbeit kosten; der nächste Aufruf macht über `scopeWithoutOsmReference()` dort weiter |
| Nur leere Felder füllen | Eine von Hand eingetragene Korrektur zu überschreiben wäre die unangenehmste Art, hilfsbereit zu sein |
| Kein `--force` | Bestehende Werte zu überschreiben ist eine andere Entscheidung als leere zu füllen — und niemand hat bisher über veraltete OSM-Daten geklagt |
| Bei mehreren Grenzrelationen nichts schreiben | Territorien wie „U.S. Outlying Islands" liefern mehrere; die falsche zu wählen fällt niemandem auf, bis jemand der Karte nicht mehr traut |
| Nur `relation` + `boundary` zählt als Treffer | Sonst wird aus „Georgia" der US-Bundesstaat oder eine gleichnamige Straße |

`--dry-run` zeigt, was passieren würde. `--limit` hält einen ersten Lauf klein. `--code=de --code=us` beschränkt auf einzelne Länder.

## Nachweis

Sieben Tests, darunter:

- ein bereits gesetzter Wert bleibt unangetastet, während daneben Leeres gefüllt wird,
- ein mehrdeutiger Treffer schreibt **gar nichts**,
- Nicht-Grenzrelationen werden ignoriert,
- ein Land mit vorhandener Referenz löst keinen einzigen HTTP-Aufruf aus (`Http::assertNothingSent()`),
- `--dry-run` verändert nichts.

Rein additiv: eine neue Datei unter `app/Console/Commands/`, sonst nichts. Keine Migration, keine Route, kein bestehender Pfad im Diff.

## Nach dem Merge

```bash
php artisan countries:enrich-from-osm --dry-run --limit=5   # Stichprobe
php artisan countries:enrich-from-osm                        # der volle Lauf, ~62 Minuten
```
