### PR TITLE
🐛 Eine Nominatim-Zeile ohne osm_id riss den ganzen Aufruf ab

### DIFF
--- a/app/Services/Osm/NominatimClient.php
+++ b/app/Services/Osm/NominatimClient.php
@@ -78,8 +78,15 @@ class NominatimClient
                 return collect();
             }
 
+            /*
+             * Rueckgabetyp `?array`, nicht `array`: normalise() liefert null fuer eine
+             * Zeile ohne osm_type/osm_id, und Nominatim schickt solche Zeilen. Mit dem
+             * strengeren Typ starb der Aufruf an einem TypeError, bevor das filter()
+             * dahinter die Nullen wegwerfen konnte — aufgefallen am 2026-08-23, als der
+             * Laenderlauf nach 136 von 249 Laendern abbrach.
+             */
             return collect($response)
-                ->map(fn (array $row): array => $this->normalise($row))
+                ->map(fn (array $row): ?array => $this->normalise($row))
                 ->filter()
                 ->values();
         });

--- a/tests/Feature/Osm/NominatimClientTest.php
+++ b/tests/Feature/Osm/NominatimClientTest.php
@@ -197,3 +197,27 @@ it('ignores a lookup cached under the pre-extratags key', function () {
     expect($hit['osm_name'])->toBe('Berlin')
         ->and($hit['wikidata'])->toBe('Q64');
 });
+
+it('survives a result row without osm_type or osm_id', function () {
+    /*
+     * Nominatim liefert gelegentlich Zeilen ohne die beiden Felder. normalise() gibt
+     * dafuer null zurueck; mit dem zu strengen Closure-Rueckgabetyp starb der ganze
+     * Aufruf an einem TypeError, statt die Zeile einfach zu verwerfen. Das brach am
+     * 2026-08-23 den Laenderlauf nach 136 von 249 Laendern ab.
+     */
+    Http::fake(['*' => Http::response([
+        ['display_name' => 'Etwas ohne Referenz', 'lat' => '1.0', 'lon' => '2.0'],
+        nominatimRow(),
+    ])]);
+
+    $hits = (new NominatimClient(minIntervalMs: 0))->search('Irgendwas');
+
+    expect($hits)->toHaveCount(1)
+        ->and($hits->first()['osm_id'])->toBe(12345);
+});
+
+it('returns an empty collection when every row is unusable', function () {
+    Http::fake(['*' => Http::response([['display_name' => 'Nur Text']])]);
+
+    expect((new NominatimClient(minIntervalMs: 0))->search('Irgendwas'))->toBeEmpty();
+});


### PR DESCRIPTION
Der Länderlauf aus #20 starb nach **136 von 249** Ländern:

```
In NominatimClient.php line 82:
  App\Services\Osm\NominatimClient::{closure:{closure:…search():74}:82}():
  Return value must be of type array, null returned
```

## Ursache

`normalise()` gibt für eine Zeile ohne `osm_type`/`osm_id` `null` zurück — das ist dokumentiert und richtig, denn die beiden identifizieren einen Ort erst gemeinsam. Die `map()`-Closure daneben deklarierte aber `: array`:

```php
->map(fn (array $row): array => $this->normalise($row))   // vorher
->filter()                                                // kam nie dran
```

Der TypeError schlug zu, **bevor** das `filter()` dahinter die Nullen wegwerfen konnte, für die es da ist.

**Der Fehler ist älter als der Länderlauf.** Die Zeile steht seit `7862b39~1` unverändert so da — also schon vor #19. Er brauchte nur eine Nominatim-Antwort mit einer solchen Zeile, und die kam erst, als der Lauf 249 Länder abfragte statt einzelner Orte über die Formularsuche.

## Fix

Rückgabetyp der Closure auf `?array`. Eine Zeile.

## Nachweis

Zwei Tests: einer mit einer unbrauchbaren neben einer brauchbaren Zeile (die brauchbare kommt durch, die andere wird verworfen), einer mit ausschließlich unbrauchbaren (leere Collection statt Absturz).

**Gegengeprüft:** mit dem alten Rückgabetyp ist der erste Test rot.

## Der Lauf ist nicht verloren

Der Befehl speichert nach jedem Land — genau für diesen Fall. Ein Neustart macht bei Land 137 weiter, die 136 bereits angereicherten werden über `scopeWithoutOsmReference()` übersprungen.
