### PR TITLE
🔍 Ein 419 hinterließ keine Spur — jetzt tut er es, für angemeldete Nutzer

### DIFF
--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -8,6 +8,8 @@ use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
 use Illuminate\Http\Request;
+use Illuminate\Session\TokenMismatchException;
+use Illuminate\Support\Facades\Log;
 use Livewire\Exceptions\MethodNotFoundException;
 use Livewire\Exceptions\PublicPropertyNotFoundException;
 use Livewire\Features\SupportFileUploads\MissingFileUploadsTraitException;
@@ -98,7 +100,47 @@ return Application::configure(basePath: dirname(__DIR__))
             return $e instanceof PublicPropertyNotFoundException && ! app()->isLocal();
         };
 
-        $exceptions->report(function (Throwable $e) use ($isStaleLivewireAsset, $isStaleCompiledView, $isMissingFileUploadsTrait, $isLivewireExploitProbe, $isMalformedLivewirePropertyUpdate) {
+        /*
+         * TokenMismatchException steht in Laravels `internalDontReport`, und dieser
+         * Filter greift VOR den hier registrierten Callbacks — ohne stopIgnoring()
+         * wuerde der report()-Callback unten fuer sie nie laufen. Die Entscheidung,
+         * ob etwas protokolliert wird, faellt dann dort: angemeldet ja, anonym nein.
+         */
+        $exceptions->stopIgnoring(TokenMismatchException::class);
+
+        /*
+         * Die Ausnahmen, die als 419 enden und von Haus aus keine Spur hinterlassen.
+         * TokenMismatchException steht in Laravels internalDontReport,
+         * CorruptComponentPayloadException schalten wir selbst stumm.
+         */
+        $isSilencedFourNineteen = function (Throwable $e): bool {
+            return $e instanceof CorruptComponentPayloadException
+                || $e instanceof TokenMismatchException;
+        };
+
+        /*
+         * Die Namen der Livewire-Komponenten aus dem Request-Rumpf.
+         *
+         * Fail-soft: ein kaputter oder fehlender Snapshot ist genau der Fall, den wir
+         * protokollieren wollen — daran darf das Protokollieren nicht scheitern.
+         *
+         * @return array<int, string>
+         */
+        $livewireComponentNames = function (Request $request): array {
+            try {
+                return collect($request->input('components', []))
+                    ->pluck('snapshot')
+                    ->map(fn ($snapshot) => is_string($snapshot) ? json_decode($snapshot, true) : null)
+                    ->pluck('memo.name')
+                    ->filter()
+                    ->values()
+                    ->all();
+            } catch (Throwable) {
+                return [];
+            }
+        };
+
+        $exceptions->report(function (Throwable $e) use ($isStaleLivewireAsset, $isStaleCompiledView, $isMissingFileUploadsTrait, $isLivewireExploitProbe, $isMalformedLivewirePropertyUpdate, $isSilencedFourNineteen, $livewireComponentNames) {
             if ($isStaleLivewireAsset($e, request())) {
                 return false;
             }
@@ -119,12 +161,40 @@ return Application::configure(basePath: dirname(__DIR__))
                 return false;
             }
 
-            // Bots replay `/livewire/update` with a mutated snapshot whose HMAC
-            // checksum no longer matches its [name, id, data]. Checksum::verify()
-            // rejects these, so the rejection is the tamper signature, not an app
-            // fault — we silence the report noise. Rendering is left untouched:
-            // the exception already returns a native 419 on its own.
-            if ($e instanceof CorruptComponentPayloadException) {
+            /*
+             * Ein 419 ist unsichtbar, und das war das eigentliche Problem.
+             *
+             * Sowohl `TokenMismatchException` (CSRF) als auch
+             * `CorruptComponentPayloadException` enden als 419 — die erste steht in
+             * Laravels `internalDontReport`, die zweite haben wir hier selbst
+             * stummgeschaltet. Als am 2026-08-22 ein Nutzer ein Event nicht speichern
+             * konnte (Issue #18, mehrere 419 auf /livewire/update), stand im
+             * Produktionslog zu diesem Zeitpunkt keine einzige Zeile. Ohne Spur laesst
+             * sich nicht einmal entscheiden, WELCHE der beiden Ursachen es war.
+             *
+             * Deshalb: fuer angemeldete Nutzer wird beides protokolliert. Wer
+             * eingeloggt ist, ist kein Scanner — und genau dessen Faelle wollen wir
+             * sehen. Fuer anonyme Requests bleibt es still, sonst kehrt die Bot-Flut
+             * zurueck, wegen der die Unterdrueckung ueberhaupt eingebaut wurde.
+             */
+            if ($isSilencedFourNineteen($e)) {
+                $request = request();
+
+                if (! auth()->hasUser() || ! auth()->check()) {
+                    return false;
+                }
+
+                Log::warning('419 fuer angemeldeten Nutzer', [
+                    'exception' => $e::class,
+                    'user_id' => auth()->id(),
+                    'path' => $request->path(),
+                    // Bei Livewire steht die eigentliche Komponente im Snapshot, nicht
+                    // im Pfad — ohne sie weiss man nur "irgendwo im Portal".
+                    'livewire_components' => $livewireComponentNames($request),
+                    'referer' => $request->headers->get('referer'),
+                    'user_agent' => $request->userAgent(),
+                ]);
+
                 return false;
             }
 

--- a/tests/Feature/FourNineteenIsLoggedTest.php
+++ b/tests/Feature/FourNineteenIsLoggedTest.php
@@ -1,0 +1,45 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Contracts\Debug\ExceptionHandler;
+use Illuminate\Session\TokenMismatchException;
+use Illuminate\Support\Facades\Log;
+use Livewire\Mechanisms\HandleComponents\CorruptComponentPayloadException;
+
+/**
+ * Ein 419 war unsichtbar — genau das machte Issue #18 undiagnostizierbar.
+ *
+ * TokenMismatchException steht in Laravels internalDontReport,
+ * CorruptComponentPayloadException haben wir selbst stummgeschaltet. Beide enden als
+ * 419, und im Produktionslog stand zum Zeitpunkt des gemeldeten Fehlers nichts.
+ */
+it('logs a silenced 419 when the user is signed in', function (string $exceptionClass) {
+    Log::spy();
+
+    $this->actingAs(User::factory()->create());
+
+    // Den report()-Pfad des Handlers direkt ansprechen: der Router wuerde die
+    // Ausnahme sonst gar nicht erst erzeugen.
+    app(ExceptionHandler::class)->report(new $exceptionClass('kaputt'));
+
+    Log::shouldHaveReceived('warning')
+        ->withArgs(fn (string $message, array $context): bool => $message === '419 fuer angemeldeten Nutzer'
+            && $context['exception'] === $exceptionClass)
+        ->once();
+})->with([
+    'csrf' => TokenMismatchException::class,
+    'livewire snapshot' => CorruptComponentPayloadException::class,
+]);
+
+it('stays silent for anonymous requests so the bot noise does not return', function (string $exceptionClass) {
+    // Die Unterdrueckung wurde wegen Scannern eingebaut, die /livewire/update mit
+    // manipulierten Snapshots durchprobieren. Die bleiben still.
+    Log::spy();
+
+    app(ExceptionHandler::class)->report(new $exceptionClass('kaputt'));
+
+    Log::shouldNotHaveReceived('warning');
+})->with([
+    'csrf' => TokenMismatchException::class,
+    'livewire snapshot' => CorruptComponentPayloadException::class,
+]);


### PR DESCRIPTION
Zu #18: ein Nutzer konnte ein Event nicht speichern, im Browser mehrere **419** auf `/livewire/update`. Im Produktionslog stand zu diesem Zeitpunkt **keine einzige Zeile**.

## Das Schweigen ist kein Zufall — es ist doppelt eingebaut

- `TokenMismatchException` (CSRF) steht in Laravels `internalDontReport` (`Handler.php:181`) und wird zu `HttpException(419)` umgewandelt (Zeile 768).
- `CorruptComponentPayloadException` haben **wir** hier stummgeschaltet, gegen die Bot-Flut, die `/livewire/update` mit manipulierten Snapshots durchprobiert.

Beide enden als 419. Ohne Spur lässt sich nicht einmal entscheiden, **welche** der beiden es war — daran scheiterte die Diagnose.

## Der Fix

Beides wird protokolliert, sobald ein Nutzer **angemeldet** ist: wer eingeloggt ist, ist kein Scanner. Für anonyme Requests bleibt es still, sonst kehrt das Rauschen zurück, wegen dem die Unterdrückung eingebaut wurde.

Der Eintrag trägt, was zur Diagnose fehlte:

```
419 fuer angemeldeten Nutzer
  exception: Illuminate\Session\TokenMismatchException
  user_id: 1712
  path: livewire/update
  livewire_components: ["meetups.create-edit-events", "tags.picker"]
  referer: https://portal.einundzwanzig.space/cz/meetup/360/events/3734/edit
  user_agent: …
```

Ohne `livewire_components` weiß man bei `/livewire/update` nur „irgendwo im Portal". Das Auslesen ist **fail-soft**: ein kaputter Snapshot ist genau der Fall, den wir sehen wollen — daran darf das Protokollieren nicht scheitern.

`stopIgnoring(TokenMismatchException::class)` ist dafür nötig: Laravels `internalDontReport`-Filter greift **vor** den registrierten Callbacks, der `report()`-Callback liefe für sie sonst nie. Die Entscheidung, ob etwas ins Log geht, fällt dann bei uns.

## Was für #18 bereits ausgeschlossen ist

Damit es niemand zweimal prüft:

| Verdacht | Befund |
|---|---|
| Livewire-Release-Token ändert sich beim Deploy | **Nein** — `config('livewire.release_token')` ist fest `'a'`, der Token besteht aus `a-a-a` |
| Redis verdrängt Sessions | **Nein** — `evicted_keys: 0`, `maxmemory_policy: noeviction`, 15,6 MB ohne Limit |
| Session abgelaufen | **Nein** — `session.lifetime` = 3600 Minuten (60 Stunden) |
| Zusammenhang mit dem `NominatimClient`-TypeError aus #21 | **Nein** — der lief in einem Konsolenbefehl, ohne Browser-Beteiligung |

**Die verbleibende, kohärente Erklärung:** der Nutzer war nicht (mehr) angemeldet. Beides folgt daraus — kein gültiger CSRF-Token ergibt 419, und `createTag()` macht `abort_unless($user !== null, 403)`, was genau seinen zweiten Fehler erklärt (`Pro přístup … nemáte oprávnění`). Beweisen lässt sich das erst beim nächsten Vorfall — dafür ist dieser PR da.

## Nachweis

Vier Tests, je zwei pro Ausnahme: angemeldet wird geloggt, anonym nicht. `tests/Feature/Smoke` unverändert **57 passed**; die Exception-Handling-Suiten zusammen **106 passed**.

Rein additiv: nur `bootstrap/app.php` und eine neue Testdatei. Kein bestehender Pfad, keine Route, keine Migration.
