### PR TITLE
🎯 54 Länder blieben ohne OSM-Referenz — die meisten davon unnötig

### DIFF
--- a/app/Console/Commands/EnrichCountriesFromOsm.php
+++ b/app/Console/Commands/EnrichCountriesFromOsm.php
@@ -31,6 +31,13 @@ class EnrichCountriesFromOsm extends Command
 
     protected $description = 'Ergaenzt fehlende OpenStreetMap-Referenzen auf Laendern (nur leere Felder)';
 
+    /**
+     * Wie deutlich der beste Treffer den zweitbesten schlagen muss, damit die Wahl
+     * ohne Menschen faellt. 1,05 trennt echte Sieger (gemessen: 1,14 bis 1,26) von
+     * Gleichstaenden (exakt 1,0), ohne knappe Faelle durchzuwinken.
+     */
+    private const CLEAR_WINNER_FACTOR = 1.05;
+
     public function handle(): int
     {
         /*
@@ -82,19 +89,18 @@ class EnrichCountriesFromOsm extends Command
                 continue;
             }
 
-            if ($hits->count() > 1) {
+            $hit = $hits->count() === 1 ? $hits->first() : $this->clearWinner($hits);
+
+            if ($hit === null) {
                 /*
-                 * Lieber nichts als das Falsche: Territorien wie "U.S. Outlying Islands"
-                 * liefern mehrere Grenzrelationen, und die falsche zu waehlen faellt
+                 * Lieber nichts als das Falsche: die falsche Relation zu waehlen faellt
                  * niemandem auf, bis jemand der Karte nicht mehr traut.
                  */
                 $ambiguous++;
-                $this->warn("  {$country->code} {$country->name}: {$hits->count()} Grenzrelationen — uebersprungen");
+                $this->warn("  {$country->code} {$country->name}: {$hits->count()} Grenzrelationen, kein klarer Vorsprung — uebersprungen");
 
                 continue;
             }
-
-            $hit = $hits->first();
             $changes = $this->emptyFieldsFrom($country, $hit);
 
             if ($changes === []) {
@@ -127,15 +133,64 @@ class EnrichCountriesFromOsm extends Command
      * Strassen, Flughaefen gleichen Namens — faellt hier raus, sonst wuerde aus "Georgia"
      * schnell der US-Bundesstaat statt des Landes.
      *
+     * Zwei Anlaeufe, weil die beiden Fehlerarten gegenlaeufig sind:
+     *
+     * 1. Mit Nominatims `featureType=country`. Gemessen am 2026-08-23: Mexico faellt
+     *    damit von vier Treffern auf einen, Netherlands und Algeria von zwei auf einen.
+     * 2. Findet der Filter nichts, noch einmal ohne ihn. Gebiete ohne eigene
+     *    Land-Relation — Antarktis, abhaengige Territorien — verschwinden sonst ganz,
+     *    und der erste Lauf hatte davon schon genug.
+     *
      * @return Collection<int, array<string, mixed>>
      */
     private function boundaryRelations(NominatimClient $client, Country $country): Collection
     {
+        $name = $country->english_name ?: $country->name;
+
+        $hits = $this->relationsFor($client, $name, $country->code, 'country');
+
+        return $hits->isNotEmpty()
+            ? $hits
+            : $this->relationsFor($client, $name, $country->code, null);
+    }
+
+    /**
+     * @return Collection<int, array<string, mixed>>
+     */
+    private function relationsFor(NominatimClient $client, string $name, string $code, ?string $featureType): Collection
+    {
         return $client
-            ->search($country->english_name ?: $country->name, $country->code, limit: 10)
+            ->search($name, $code, limit: 10, featureType: $featureType)
             ->filter(fn (array $hit): bool => ($hit['osm_type'] ?? null) === 'relation'
                 && ($hit['category'] ?? null) === 'boundary')
             ->values();
+    }
+
+    /**
+     * Der eindeutig wichtigste Treffer, oder null bei zu knappem Vorsprung.
+     *
+     * Nominatims `importance` rangiert das Land ueber alles, was zufaellig so heisst.
+     * Wo der Vorsprung deutlich ist, ist die Wahl sicher: Zypern kommt auf 0,7777
+     * gegen 0,6152 fuer die britische Militaerbasis Akrotiri and Dhekelia.
+     *
+     * Wo er es nicht ist, wird nicht geraten. Die Niederlande lieferten zwei Relationen
+     * mit exakt 0,8864 — das europaeische Nederland und das Koenigreich —, und welche
+     * davon gemeint ist, kann ein Zahlenvergleich nicht entscheiden.
+     *
+     * @param  Collection<int, array<string, mixed>>  $hits
+     * @return array<string, mixed>|null
+     */
+    private function clearWinner(Collection $hits): ?array
+    {
+        $ranked = $hits->sortByDesc(fn (array $hit): float => (float) ($hit['importance'] ?? 0))->values();
+        $best = (float) ($ranked[0]['importance'] ?? 0);
+        $second = (float) ($ranked[1]['importance'] ?? 0);
+
+        if ($best <= 0.0 || $second <= 0.0) {
+            return null;
+        }
+
+        return $best >= $second * self::CLEAR_WINNER_FACTOR ? $ranked[0] : null;
     }
 
     /**

--- a/app/Services/Osm/NominatimClient.php
+++ b/app/Services/Osm/NominatimClient.php
@@ -48,9 +48,10 @@ class NominatimClient
     /**
      * Search for a place. Returns an empty collection on any failure.
      *
+     * @param  string|null  $featureType  Nominatims featureType: country, state, city, settlement
      * @return Collection<int, array<string, mixed>>
      */
-    public function search(string $query, ?string $countryCode = null, int $limit = 5): Collection
+    public function search(string $query, ?string $countryCode = null, int $limit = 5, ?string $featureType = null): Collection
     {
         $query = trim($query);
 
@@ -67,6 +68,17 @@ class NominatimClient
             'extratags' => 1,
             'limit' => $limit,
             'countrycodes' => $countryCode ? mb_strtolower($countryCode) : null,
+            /*
+             * Nominatims eigener Grobfilter (country, state, city, settlement). Er
+             * raeumt Mehrdeutigkeiten weg, die ein Nachfiltern auf category=boundary
+             * stehen laesst: "Mexico" liefert ohne ihn vier Grenzrelationen — das Land,
+             * zweimal Mexiko-Stadt und den Bundesstaat.
+             *
+             * Nicht bedingungslos einsetzen: Gebiete ohne eigene Land-Relation
+             * (Antarktis, abhaengige Territorien) verschwinden damit ganz. Der Aufrufer
+             * entscheidet, ob er den Filter will und ob er ohne ihn nachfasst.
+             */
+            'featureType' => $featureType,
         ], fn ($value): bool => $value !== null);
 
         $cacheKey = 'osm:search:'.md5(json_encode($params));

--- a/tests/Feature/EnrichCountriesFromOsmTest.php
+++ b/tests/Feature/EnrichCountriesFromOsmTest.php
@@ -136,3 +136,55 @@ it('honours the limit so a first run can stay small', function () {
 
     expect(Country::whereNotNull('osm_id')->count())->toBe(1);
 });
+
+it('picks the clear winner when importance leaves no doubt', function () {
+    // Gemessen an Zypern: das Land 0,7777 gegen 0,6152 fuer die Militaerbasis
+    // Akrotiri and Dhekelia. Faktor 1,26 — kein Zweifel.
+    Http::fake(['*' => Http::response([
+        osmCountryRow(['osm_id' => 3263728, 'name' => 'Akrotiri and Dhekelia', 'importance' => 0.6152]),
+        osmCountryRow(['osm_id' => 307787, 'name' => 'Kypros', 'importance' => 0.7777]),
+    ])]);
+
+    $country = Country::factory()->create(['code' => 'cy', 'name' => 'Cyprus']);
+
+    $this->artisan('countries:enrich-from-osm', ['--code' => ['cy'], '--interval-ms' => 0])
+        ->assertSuccessful();
+
+    // Der wichtigere Treffer gewinnt, nicht der erste in der Liste.
+    expect($country->fresh()->osm_id)->toBe(307787);
+});
+
+it('still writes nothing when two relations are equally important', function () {
+    // Die Niederlande liefern zwei Relationen mit exakt 0,8864 — das europaeische
+    // Nederland und das Koenigreich. Welche gemeint ist, entscheidet keine Zahl.
+    Http::fake(['*' => Http::response([
+        osmCountryRow(['osm_id' => 47796, 'importance' => 0.8864]),
+        osmCountryRow(['osm_id' => 2323309, 'importance' => 0.8864]),
+    ])]);
+
+    $country = Country::factory()->create(['code' => 'nl', 'name' => 'Netherlands']);
+
+    $this->artisan('countries:enrich-from-osm', ['--code' => ['nl'], '--interval-ms' => 0])
+        ->expectsOutputToContain('kein klarer Vorsprung')
+        ->assertSuccessful();
+
+    expect($country->fresh()->osm_id)->toBeNull();
+});
+
+it('asks Nominatim for countries first and only then without the filter', function () {
+    // Der Filter raeumt Mehrdeutigkeiten weg; ohne den Nachschlag verschwaenden
+    // Gebiete ohne eigene Land-Relation aber ganz.
+    Http::fakeSequence()
+        ->push([])                            // featureType=country: nichts
+        ->push([osmCountryRow()]);            // ohne Filter: Treffer
+
+    $country = Country::factory()->create(['code' => 'de', 'name' => 'Germany']);
+
+    $this->artisan('countries:enrich-from-osm', ['--code' => ['de'], '--interval-ms' => 0])
+        ->assertSuccessful();
+
+    expect($country->fresh()->osm_id)->toBe(51477);
+
+    Http::assertSent(fn ($request): bool => ($request->data()['featureType'] ?? null) === 'country');
+    Http::assertSent(fn ($request): bool => ! isset($request->data()['featureType']));
+});


### PR DESCRIPTION
Der erste Lauf aus #20 ergänzte **195 von 249** Ländern. Von den 54 übrigen waren 12 nicht „nicht auffindbar", sondern **mehrdeutig** — mehrere Grenzrelationen, und der Befehl schreibt dann bewusst nichts.

## Gemessen, nicht geraten

Gegen die echte API, mit den tatsächlichen `importance`-Werten:

| Land | Treffer | Werte |
|---|---|---|
| Mexico | 4 | **0.8937** México · 0.7820 Ciudad de México (2×) · 0.6502 Estado de México |
| Cyprus | 3 | 0.7777 Κύπρος · **0.7777** Κύπρος-Kıbrıs · 0.6152 Akrotiri and Dhekelia |
| Netherlands | 2 | 0.8864 · 0.8864 |
| Algeria | 2 | 0.5414 · **0.8031** ← der Zweite ist der richtige |
| Luxembourg | 2 | **0.7879** Lëtzebuerg · 0.6754 |

Algeria zeigt, warum „nimm den ersten Treffer" nie eine Regel war.

## Zwei Änderungen, die zusammen greifen

**1. Nominatims `featureType=country`.** Gemessen fällt Mexico damit von vier Treffern auf einen, Netherlands und Algeria von zwei auf einen.

Der Filter läuft aber **nicht bedingungslos**: Antarktis und abhängige Territorien haben keine eigene Land-Relation und verschwänden ganz (nachgemessen: `featureType=country` liefert für `aq` und `pr` null Treffer). Findet er nichts, wird ohne ihn nachgefasst — die Trefferquote kann dadurch nur steigen.

**2. `importance` als Stichentscheid, aber nur bei deutlichem Vorsprung.** Zypern behält auch mit Filter zwei Treffer; 0.7777 gegen 0.6152 ist Faktor 1,26 und damit eindeutig.

Die Niederlande liefern zweimal **exakt** 0.8864 — das europäische Nederland und das Königreich. Welche gemeint ist, entscheidet keine Zahl, also wird dort weiterhin nichts geschrieben. Der Schwellwert 1,05 trennt echte Sieger (gemessen 1,14 bis 1,26) von Gleichständen (exakt 1,0).

## Nachweis

Drei neue Tests: klarer Sieger wird genommen (und zwar der wichtigere, nicht der erste), Gleichstand schreibt weiterhin nichts, und die zweistufige Suche fragt nachweislich erst **mit** und dann **ohne** Filter.

Zusammen mit den OSM-Suiten: **54 passed**. Pint sauber.

`search()` bekommt dafür einen optionalen `featureType`-Parameter — additiv, Standard `null`, also für jeden bestehenden Aufrufer unverändert. Der Cache-Key enthält die Parameter, alte Einträge kollidieren nicht.

## Nach dem Merge

```bash
php artisan countries:enrich-from-osm   # nur die 54 offenen, ~14 Minuten
```

Die 195 bereits angereicherten überspringt `scopeWithoutOsmReference()`.
