### PR TITLE
🔤 40 Länder fehlten noch — bei sechs davon lag es an einem Kaufmanns-Und

### DIFF
--- a/app/Console/Commands/EnrichCountriesFromOsm.php
+++ b/app/Console/Commands/EnrichCountriesFromOsm.php
@@ -133,13 +133,17 @@ class EnrichCountriesFromOsm extends Command
      * Strassen, Flughaefen gleichen Namens — faellt hier raus, sonst wuerde aus "Georgia"
      * schnell der US-Bundesstaat statt des Landes.
      *
-     * Zwei Anlaeufe, weil die beiden Fehlerarten gegenlaeufig sind:
+     * Mehrere Anlaeufe, weil die Fehlerarten gegenlaeufig sind:
      *
      * 1. Mit Nominatims `featureType=country`. Gemessen am 2026-08-23: Mexico faellt
      *    damit von vier Treffern auf einen, Netherlands und Algeria von zwei auf einen.
      * 2. Findet der Filter nichts, noch einmal ohne ihn. Gebiete ohne eigene
-     *    Land-Relation — Antarktis, abhaengige Territorien — verschwinden sonst ganz,
-     *    und der erste Lauf hatte davon schon genug.
+     *    Land-Relation — Antarktis, abhaengige Territorien — verschwinden sonst ganz.
+     * 3. Beides noch einmal mit ausgeschriebenem Namen, falls unsere Schreibweise
+     *    kuerzt (siehe searchTerms()).
+     *
+     * Der erste Anlauf mit Treffern gewinnt; die Reihenfolge ist von praezise nach
+     * grosszuegig sortiert.
      *
      * @return Collection<int, array<string, mixed>>
      */
@@ -147,11 +151,43 @@ class EnrichCountriesFromOsm extends Command
     {
         $name = $country->english_name ?: $country->name;
 
-        $hits = $this->relationsFor($client, $name, $country->code, 'country');
+        foreach ($this->searchTerms($name) as $term) {
+            foreach (['country', null] as $featureType) {
+                $hits = $this->relationsFor($client, $term, $country->code, $featureType);
 
-        return $hits->isNotEmpty()
-            ? $hits
-            : $this->relationsFor($client, $name, $country->code, null);
+                if ($hits->isNotEmpty()) {
+                    return $hits;
+                }
+            }
+        }
+
+        return collect();
+    }
+
+    /**
+     * Die Schreibweisen, unter denen ein Land in OpenStreetMap zu finden sein kann.
+     *
+     * Unsere Laenderliste kuerzt, OpenStreetMap schreibt aus. Gemessen am 2026-08-23:
+     *
+     *   "Antigua & Barbuda"   0 Treffer   "Antigua and Barbuda"   1 (R536900)
+     *   "Trinidad & Tobago"   0 Treffer   "Trinidad and Tobago"   1 (R555717)
+     *   "St. Kitts & Nevis"   0 Treffer   "Saint Kitts and Nevis" 1 (R536899)
+     *
+     * Die Variante wird nur versucht, wenn sie sich vom Original unterscheidet — sonst
+     * kostet jeder Lauf eine zweite Anfrage pro Land fuer nichts, und bei 15 Sekunden
+     * Abstand ist das eine halbe Stunde.
+     *
+     * @return array<int, string>
+     */
+    private function searchTerms(string $name): array
+    {
+        $expanded = str_replace(
+            [' & ', 'St. ', 'Ste. '],
+            [' and ', 'Saint ', 'Sainte '],
+            $name,
+        );
+
+        return $expanded === $name ? [$name] : [$name, $expanded];
     }
 
     /**

--- a/tests/Feature/EnrichCountriesFromOsmTest.php
+++ b/tests/Feature/EnrichCountriesFromOsmTest.php
@@ -188,3 +188,51 @@ it('asks Nominatim for countries first and only then without the filter', functi
     Http::assertSent(fn ($request): bool => ($request->data()['featureType'] ?? null) === 'country');
     Http::assertSent(fn ($request): bool => ! isset($request->data()['featureType']));
 });
+
+it('retries with the spelled-out name when ours abbreviates', function () {
+    // Gemessen: "Antigua & Barbuda" findet nichts, "Antigua and Barbuda" findet R536900.
+    Http::fakeSequence()
+        ->push([])                                          // "Antigua & Barbuda" + featureType
+        ->push([])                                          // "Antigua & Barbuda" ohne Filter
+        ->push([osmCountryRow(['osm_id' => 536900])]);      // "Antigua and Barbuda" + featureType
+
+    $country = Country::factory()->create(['code' => 'ag', 'name' => 'Antigua & Barbuda', 'english_name' => 'Antigua & Barbuda']);
+
+    $this->artisan('countries:enrich-from-osm', ['--code' => ['ag'], '--interval-ms' => 0])
+        ->assertSuccessful();
+
+    expect($country->fresh()->osm_id)->toBe(536900);
+
+    Http::assertSent(fn ($request): bool => ($request->data()['q'] ?? '') === 'Antigua and Barbuda');
+});
+
+it('does not waste a request when the name has nothing to expand', function () {
+    // Bei 15 Sekunden Abstand kostet eine ueberfluessige Anfrage pro Land eine halbe
+    // Stunde — die Variante laeuft nur, wenn sie sich vom Original unterscheidet.
+    Http::fake(['*' => Http::response([])]);
+
+    Country::factory()->create(['code' => 'de', 'name' => 'Germany', 'english_name' => 'Germany']);
+
+    $this->artisan('countries:enrich-from-osm', ['--code' => ['de'], '--interval-ms' => 0])
+        ->assertSuccessful();
+
+    // Genau zwei: mit und ohne featureType. Keine dritte fuer eine Variante,
+    // die identisch waere.
+    Http::assertSentCount(2);
+});
+
+it('expands Saint as well as the ampersand', function () {
+    Http::fakeSequence()
+        ->push([])
+        ->push([])
+        ->push([osmCountryRow(['osm_id' => 536899])]);
+
+    $country = Country::factory()->create(['code' => 'kn', 'name' => 'St. Kitts & Nevis', 'english_name' => 'St. Kitts & Nevis']);
+
+    $this->artisan('countries:enrich-from-osm', ['--code' => ['kn'], '--interval-ms' => 0])
+        ->assertSuccessful();
+
+    expect($country->fresh()->osm_id)->toBe(536899);
+
+    Http::assertSent(fn ($request): bool => ($request->data()['q'] ?? '') === 'Saint Kitts and Nevis');
+});


### PR DESCRIPTION
Der dritte Lauf (nach #23) brachte **209 von 249**. Die Tiebreaker-Änderung hat gewirkt: von den zuvor 12 mehrdeutigen Ländern bleibt **keines** übrig, 14 kamen dazu.

## Die verbliebenen 40 zerfallen in zwei Gruppen

**Gruppe 1 — kein Objekt in OSM.** Abhängige Gebiete ohne eigene Land-Relation: Puerto Rico, Hongkong, Macao, Réunion, Guam, Martinique, Guadeloupe, Aruba, Curaçao, Antarktis … Dort hilft keine Suche, dort fehlt schlicht das Objekt.

**Gruppe 2 — unsere Schreibweise.** Unsere Länderliste kürzt, OpenStreetMap schreibt aus. Gemessen gegen die echte API:

| Suchbegriff | Treffer |
|---|---|
| `Antigua & Barbuda` | **0** |
| `Antigua and Barbuda` | **1** — R536900 |
| `Trinidad & Tobago` | **0** |
| `Trinidad and Tobago` | **1** — R555717 |
| `St. Kitts & Nevis` | **0** |
| `Saint Kitts and Nevis` | **1** — R536899 |

## Der Fix

Die Suchkette bekommt einen dritten Anlauf mit ausgeschriebenem Namen (`" & "` → `" and "`, `"St. "` → `"Saint "`, `"Ste. "` → `"Sainte "`). Aus der Restliste betrifft das außerdem St. Vincent & Grenadines, São Tomé & Príncipe, Turks & Caicos Islands, Heard & McDonald Islands, South Georgia & South Sandwich Islands, St. Barthélemy, St. Martin, St. Pierre & Miquelon, Svalbard & Jan Mayen und Wallis & Futuna.

**Die Variante läuft nur, wenn sie sich vom Original unterscheidet.** Bei 15 Sekunden Abstand kostet eine überflüssige Anfrage pro Land eine halbe Stunde — ein Test hält fest, dass `Germany` weiterhin genau **zwei** Anfragen auslöst.

## Warum nicht der ISO-Code-Weg über das angebotene Datenset

Der hier kostet nichts, braucht keine fremden Daten und ist in einer Zeile Normalisierung erledigt. Das Overpass-Datenset aus #12 bleibt die Option für Gruppe 1 — dort, wo die Namenssuche prinzipiell nicht helfen kann.

## Nachweis

Drei neue Tests: Ampersand-Variante, Saint-Variante, und **keine** dritte Anfrage bei Namen ohne Kürzung. Zusammen mit den OSM-Suiten **44 passed**, Pint sauber.

Additiv: nur die Suchreihenfolge im Befehl. Keine Migration, keine API-Änderung, `NominatimClient` unberührt.
