### PR TITLE
👁️ Die Geo-Daten waren gebaut, gepflegt und unsichtbar

### DIFF
--- a/app/Models/Meetup.php
+++ b/app/Models/Meetup.php
@@ -378,6 +378,12 @@ class Meetup extends Model implements HasMedia
                 'portalLink' => url()->route('meetups.landingpage-event',
                     ['country' => $this->city->country, 'meetup' => $this, 'event' => $nextEvent]),
                 'location' => $nextEvent->location,
+                // Der praezise Kartenort, wenn einer gewaehlt wurde — das Popup zeigt
+                // ihn ueber dem Freitext, statt ihn zu ersetzen.
+                'osm_name' => $nextEvent->osm_name,
+                'osm_type' => $nextEvent->osm_type,
+                'osm_id' => $nextEvent->osm_id,
+                'osm_address' => $nextEvent->osm_address,
                 'description' => $nextEvent->description,
                 'link' => $nextEvent->link,
                 // null = Teilnehmerzahl öffentlich verborgen (attendees_public=false).

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -758,5 +758,7 @@
     "No meetups in :region yet.": "Zatím žádné meetupy v :region.",
     "Show all meetups in the country": "Zobrazit všechny meetupy v zemi",
     "Region": "Region",
-    "No region": "Bez regionu"
+    "No region": "Bez regionu",
+    "Alle Regionen": "Všechny regiony",
+    "Region suchen...": "Hledat region..."
 }

--- a/lang/de.json
+++ b/lang/de.json
@@ -758,5 +758,7 @@
     "No meetups in :region yet.": "Noch keine Meetups in :region.",
     "Show all meetups in the country": "Alle Meetups im Land anzeigen",
     "Region": "Region",
-    "No region": "Keine Region"
+    "No region": "Keine Region",
+    "Alle Regionen": "Alle Regionen",
+    "Region suchen...": "Region suchen..."
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -758,5 +758,7 @@
     "No meetups in :region yet.": "No meetups in :region yet.",
     "Show all meetups in the country": "Show all meetups in the country",
     "Region": "Region",
-    "No region": "No region"
+    "No region": "No region",
+    "Alle Regionen": "All regions",
+    "Region suchen...": "Search region..."
 }

--- a/lang/es.json
+++ b/lang/es.json
@@ -758,5 +758,7 @@
     "No meetups in :region yet.": "Aún no hay meetups en :region.",
     "Show all meetups in the country": "Mostrar todos los meetups del país",
     "Region": "Región",
-    "No region": "Sin región"
+    "No region": "Sin región",
+    "Alle Regionen": "Todas las regiones",
+    "Region suchen...": "Buscar región..."
 }

--- a/lang/hu.json
+++ b/lang/hu.json
@@ -758,5 +758,7 @@
     "No meetups in :region yet.": "Még nincs meetup itt: :region.",
     "Show all meetups in the country": "Az ország összes meetupja",
     "Region": "Régió",
-    "No region": "Nincs régió"
+    "No region": "Nincs régió",
+    "Alle Regionen": "Minden régió",
+    "Region suchen...": "Régió keresése..."
 }

--- a/lang/lv.json
+++ b/lang/lv.json
@@ -758,5 +758,7 @@
     "No meetups in :region yet.": "Reģionā :region vēl nav meetup pasākumu.",
     "Show all meetups in the country": "Rādīt visus meetup pasākumus valstī",
     "Region": "Reģions",
-    "No region": "Nav reģiona"
+    "No region": "Nav reģiona",
+    "Alle Regionen": "Visi reģioni",
+    "Region suchen...": "Meklēt reģionu..."
 }

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -758,5 +758,7 @@
     "No meetups in :region yet.": "Nog geen meetups in :region.",
     "Show all meetups in the country": "Alle meetups in het land tonen",
     "Region": "Regio",
-    "No region": "Geen regio"
+    "No region": "Geen regio",
+    "Alle Regionen": "Alle regio’s",
+    "Region suchen...": "Regio zoeken..."
 }

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -758,5 +758,7 @@
     "No meetups in :region yet.": "Brak meetupów w :region.",
     "Show all meetups in the country": "Pokaż wszystkie meetupy w kraju",
     "Region": "Region",
-    "No region": "Brak regionu"
+    "No region": "Brak regionu",
+    "Alle Regionen": "Wszystkie regiony",
+    "Region suchen...": "Szukaj regionu..."
 }

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -758,5 +758,7 @@
     "No meetups in :region yet.": "Ainda não há meetups em :region.",
     "Show all meetups in the country": "Mostrar todos os meetups do país",
     "Region": "Região",
-    "No region": "Sem região"
+    "No region": "Sem região",
+    "Alle Regionen": "Todas as regiões",
+    "Region suchen...": "Procurar região..."
 }

--- a/resources/css/app.css
+++ b/resources/css/app.css
@@ -100,12 +100,24 @@ select:focus[data-flux-control] {
 /* ----------------------------------------
    Leaflet overrides
 ----------------------------------------- */
-.leaflet-popup-content-wrapper {
+/*
+ * Nur im dunklen Theme einfaerben.
+ *
+ * Vorher galt der dunkle Grund IMMER, waehrend der Popup-Inhalt mit dark:-Varianten
+ * arbeitet — im hellen Theme stand also dunkler Text auf dunklem Grund. Gemessen am
+ * 2026-08-23: Meetup-Name 1,46:1, Intro 1,33:1, Ort und Datum 2,19:1, das
+ * "Aktiv"-Badge 1,45:1. WCAG 1.4.3 verlangt 4,5:1.
+ *
+ * Im hellen Theme bleibt Leaflets weisser Standardgrund, auf dem die
+ * Nicht-dark:-Farben der Komponente wie ueberall sonst funktionieren.
+ */
+.dark .leaflet-popup-content-wrapper,
+.dark .leaflet-popup-tip {
     background-color: #404040 !important;
 }
 
-.leaflet-control-zoom-in,
-.leaflet-control-zoom-out {
+.dark .leaflet-control-zoom-in,
+.dark .leaflet-control-zoom-out {
     background-color: #404040 !important;
 }
 

--- a/resources/views/components/meetup-popup.blade.php
+++ b/resources/views/components/meetup-popup.blade.php
@@ -11,7 +11,7 @@
     </div>
 
     @if($meetup->last_event_at)
-        <flux:text class="text-xs text-zinc-500 mb-2">
+        <flux:text class="text-xs text-zinc-500 dark:text-zinc-400 mb-2">
             {{ __('Letztes Event') }}: {{ $meetup->last_event_at->asDate() }}
         </flux:text>
     @endif
@@ -38,17 +38,24 @@
                 {{ $meetup->nextEvent['start']->asTime() }} Uhr
             </flux:text>
 
-            @if($meetup->nextEvent['location'])
-                <flux:text class="text-sm flex items-center gap-2">
-                    <flux:icon.map-pin class="w-4 h-4"/>
-                    {{ $meetup->nextEvent['location'] }}
-                </flux:text>
+            {{-- x-osm-place erwartet ein Objekt; nextEvent ist ein Array — der Cast
+                 reicht, weil alle vier gelesenen Schluessel immer gesetzt sind.
+                 showAddress: der Freitext bleibt sichtbar, wenn er etwas anderes
+                 sagt als der Kartenort (Raumnummer, Zusatz), und faellt weg, wenn
+                 er ihn nur wiederholt. --}}
+            @if($meetup->nextEvent['osm_name'] || $meetup->nextEvent['location'])
+                <div class="flex items-start gap-2 text-sm">
+                    <flux:icon.map-pin class="mt-0.5 size-4 shrink-0" aria-hidden="true"/>
+                    <div class="min-w-0 break-words">
+                        <x-osm-place :place="(object) $meetup->nextEvent" show-address/>
+                    </div>
+                </div>
             @endif
 
             <flux:text class="flex items-center gap-2 mt-2">
-                <span class="text-xs text-zinc-200">{{ trans_choice(':count Zusage|:count Zusagen', $meetup->nextEvent['attendees']) }}</span>
+                <span class="text-xs text-zinc-600 dark:text-zinc-300">{{ trans_choice(':count Zusage|:count Zusagen', $meetup->nextEvent['attendees']) }}</span>
                 <flux:separator vertical/>
-                <span class="text-xs text-zinc-200">{{ trans_choice(':count Vielleicht|:count Vielleicht', $meetup->nextEvent['might_attendees']) }}</span>
+                <span class="text-xs text-zinc-600 dark:text-zinc-300">{{ trans_choice(':count Vielleicht|:count Vielleicht', $meetup->nextEvent['might_attendees']) }}</span>
             </flux:text>
         </div>
     @endif
@@ -56,7 +63,7 @@
     @if($meetup->telegram_link || $meetup->webpage || $meetup->twitter_username || $meetup->matrix_group || $meetup->nostr || $meetup->simplex || $meetup->signal)
         <flux:separator variant="subtle" class="my-3"/>
 
-        <div class="flex gap-2 flex-wrap text-white">
+        <div class="flex gap-2 flex-wrap text-zinc-600 dark:text-zinc-300">
             @if($meetup->telegram_link)
                 <flux:link :href="$meetup->telegram_link" external variant="subtle" title="{{ __('Telegram') }}">
                     <flux:icon.paper-airplane variant="mini"/>

--- a/resources/views/components/osm-place.blade.php
+++ b/resources/views/components/osm-place.blade.php
@@ -1,0 +1,70 @@
+@props([
+    // Das Model mit den osm_*-Spalten: MeetupEvent, CourseEvent, BitcoinEvent, City.
+    'place',
+    // Adresse und abweichenden Freitext mitzeigen — auf Detailseiten ja, in Kacheln nein.
+    'showAddress' => false,
+])
+
+@php
+    $placeName = $place->osm_name ?: ($place->location ?? null);
+
+    /*
+     * Nur die drei OSM-Objekttypen ergeben eine gültige URL. Ein unbekannter Typ wird
+     * als Klartext gezeigt, nie als Link: ein kaputter Wert darf kein href werden.
+     */
+    $osmUrl = $place->osm_id && in_array(mb_strtolower((string) $place->osm_type), ['node', 'way', 'relation'], true)
+        ? 'https://www.openstreetmap.org/'.mb_strtolower((string) $place->osm_type).'/'.(int) $place->osm_id
+        : null;
+
+    // Der Freitext steht nur dann zusätzlich da, wenn er etwas anderes sagt als der
+    // Kartenort — zweimal derselbe Name untereinander liest sich wie ein Fehler.
+    $freeText = $showAddress
+        && ($place->location ?? null)
+        && $place->osm_name
+        && mb_strtolower(trim((string) $place->location)) !== mb_strtolower(trim((string) $place->osm_name))
+            ? $place->location
+            : null;
+@endphp
+
+@if($placeName)
+    <div {{ $attributes->merge(['class' => 'min-w-0 break-words']) }}>
+        <div class="text-sm font-medium text-zinc-800 dark:text-zinc-100">
+            @if($osmUrl)
+                {{-- Der Ortsname selbst ist der Link: ein bekanntes Kartenobjekt ist der
+                     einzige Unterschied, der sich zu zeigen lohnt, und der Pfeil markiert
+                     ihn ohne sich auf Farbe zu verlassen (WCAG 1.4.1).
+
+                     py-1, nicht py-0.5: die Zeilenbox misst im Browser 19px, nicht die 20px,
+                     die die Skala nahelegt — mit 0.5 bliebe das Ziel bei 23px und damit
+                     einen unter den 24px aus WCAG 2.5.8. An einem inline-Element vergrößert
+                     das Padding die Trefferfläche, ohne das Layout zu verschieben. --}}
+                <a href="{{ $osmUrl }}"
+                   target="_blank"
+                   rel="noopener noreferrer"
+                   aria-label="{{ __(':place auf OpenStreetMap öffnen', ['place' => $placeName]) }}"
+                   class="rounded-xs py-1 hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-current">
+                    {{ $placeName }}<flux:icon.arrow-up-right
+                        class="ml-1 inline size-3.5 align-middle" aria-hidden="true"/>
+                </a>
+            @else
+                {{ $placeName }}
+            @endif
+        </div>
+
+        {{-- zinc-600/300 statt zinc-500: letzteres misst auf dem dunklen Body 3,19:1 und
+             reißt damit WCAG 1.4.3. --}}
+        @if($showAddress && $place->osm_address)
+            <div class="line-clamp-2 text-xs text-zinc-600 dark:text-zinc-300">
+                {{ $place->osm_address }}
+            </div>
+        @endif
+
+        @if($freeText)
+            <div class="text-xs text-zinc-600 dark:text-zinc-300">
+                {{ $freeText }}
+            </div>
+        @endif
+
+        {{ $slot }}
+    </div>
+@endif

--- a/resources/views/components/venue-map.blade.php
+++ b/resources/views/components/venue-map.blade.php
@@ -1,0 +1,86 @@
+@props([
+    // Das Model mit den osm_*-Spalten: MeetupEvent, CourseEvent, BitcoinEvent.
+    'place',
+    // 16 zeigt Strassenzuege samt Hausnummern — die Aufloesung, in der ein
+    // Veranstaltungsort tatsaechlich wiederzuerkennen ist.
+    'zoom' => 16,
+    'label' => null,
+])
+
+@php
+    /*
+     * Ohne Koordinaten gibt es nichts zu zeigen. Das ist der Normalfall fuer jeden
+     * Termin, der vor der OSM-Auswahl angelegt wurde: die Komponente rendert dann
+     * gar nichts und die Seite sieht aus wie vorher.
+     */
+    $lat = $place->osm_lat !== null ? (float) $place->osm_lat : null;
+    $lon = $place->osm_lon !== null ? (float) $place->osm_lon : null;
+    $placeName = $label ?: ($place->osm_name ?: ($place->location ?? null));
+
+    $osmUrl = $place->osm_id && in_array(mb_strtolower((string) $place->osm_type), ['node', 'way', 'relation'], true)
+        ? 'https://www.openstreetmap.org/'.mb_strtolower((string) $place->osm_type).'/'.(int) $place->osm_id
+        : 'https://www.openstreetmap.org/?mlat='.$lat.'&mlon='.$lon.'#map='.$zoom.'/'.$lat.'/'.$lon;
+@endphp
+
+@if($lat !== null && $lon !== null)
+    <div {{ $attributes->merge(['class' => 'space-y-2']) }}>
+        {{-- wire:ignore: die Seite ist eine Livewire-Komponente, und jede RSVP-Aktion
+             rendert sie neu. Ohne das Attribut morpht Livewire den Kartencontainer und
+             Leaflet wirft beim zweiten Aufbau "Map container is already initialized".
+             Ausserhalb von Livewire ist das Attribut wirkungslos. --}}
+        <div
+            wire:ignore
+            x-data="{
+                initVenueMap() {
+                    // Zweiter Aufruf am selben Knoten (Alpine-Neuinitialisierung nach
+                    // wire:navigate) waere sonst ein harter Fehler.
+                    if ($refs.venueMap._leaflet_id) {
+                        return;
+                    }
+
+                    // Leaflets eigene Animationen laufen ueber CSS-Transforms und
+                    // ignorieren die Systemeinstellung — deshalb hier abschalten.
+                    const calm = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+                    const map = L.map($refs.venueMap, {
+                        scrollWheelZoom: false,
+                        zoomAnimation: !calm,
+                        fadeAnimation: !calm,
+                        markerZoomAnimation: !calm,
+                    }).setView([@js($lat), @js($lon)], @js($zoom));
+
+                    L.tileLayer('https://tile.openstreetmap.de/{z}/{x}/{y}.png', {
+                        minZoom: 0,
+                        maxZoom: 18,
+                        attribution: '&copy; <a href=\'https://www.openstreetmap.org/copyright\'>OpenStreetMap</a> contributors',
+                    }).addTo(map);
+
+                    L.marker([@js($lat), @js($lon)], {
+                        icon: L.icon({
+                            iconUrl: '/img/btc_marker.png',
+                            iconSize: [32, 32],
+                            iconAnchor: [16, 32],
+                        }),
+                        // Der Ortsname liegt als title auf dem Marker, damit die Karte
+                        // nicht die einzige Quelle der Information ist.
+                        title: @js($placeName ?? ''),
+                        alt: @js($placeName ?? ''),
+                        keyboard: false,
+                    }).addTo(map);
+                },
+            }"
+            x-init="initVenueMap()"
+        >
+            {{-- aria-hidden: die Kachelgrafik traegt fuer Screenreader nichts bei. Die
+                 Information steht als Text daneben und als Link darunter. --}}
+            <div x-ref="venueMap"
+                 aria-hidden="true"
+                 class="h-56 w-full rounded-lg border border-zinc-200 dark:border-zinc-700"
+                 style="z-index: 0;"></div>
+        </div>
+
+        <flux:link :href="$osmUrl" external variant="subtle" class="text-xs">
+            {{ __('Auf OpenStreetMap öffnen') }}
+        </flux:link>
+    </div>
+@endif

--- a/resources/views/livewire/cities/edit.blade.php
+++ b/resources/views/livewire/cities/edit.blade.php
@@ -173,10 +173,21 @@ class extends Component {
             <div class="space-y-6">
                 <flux:input label="{{ __('Name') }}" wire:model="name" required/>
 
-                <flux:select label="{{ __('Country') }}" wire:model.live="country_id" required>
-                    <option value="">{{ __('Select a country') }}</option>
+                {{-- Identisch zu cities/create: rohe <option>-Tags koennen keine Flagge
+                     tragen und liefern in einer Liste von ueber 240 Laendern keine Suche.
+                     Wer eine Stadt anlegt und dieselbe danach bearbeitet, bekam bisher
+                     zwei verschiedene Bedienungen fuer dasselbe Feld. --}}
+                <flux:select variant="listbox" searchable label="{{ __('Country') }}" wire:model.live="country_id" required>
+                    <flux:select.option value="">{{ __('Select a country') }}</flux:select.option>
                     @foreach($countries as $country)
-                        <option value="{{ $country->id }}">{{ $country->name }}</option>
+                        <flux:select.option value="{{ $country->id }}">
+                            <div class="flex items-center space-x-2">
+                                <img alt="{{ str($country->code)->lower() }}"
+                                     src="{{ asset('vendor/blade-flags/country-'.str($country->code)->lower().'.svg') }}"
+                                     width="24" height="12"/>
+                                <span>{{ $country->name }}</span>
+                            </div>
+                        </flux:select.option>
                     @endforeach
                 </flux:select>
 

--- a/resources/views/livewire/cities/index.blade.php
+++ b/resources/views/livewire/cities/index.blade.php
@@ -36,7 +36,7 @@ class extends Component {
     {
         return [
             'cities' => City::query()
-                ->with(['country', 'createdBy'])
+                ->with(['country', 'createdBy', 'region'])
                 ->when($this->search, fn($query)
                     => $query->whereLike('name', '%'.$this->search.'%'),
                 )
@@ -54,6 +54,7 @@ class extends Component {
             {{ $regionName ? __('Cities in :region', ['region' => $regionName]) : __('Cities') }}
         </flux:heading>
         <div class="flex items-center flex-col md:flex-row gap-4">
+            <livewire:region.chooser/>
             <flux:input
                 wire:model.live="search"
                 :placeholder="__('Search cities...')"
@@ -86,6 +87,15 @@ class extends Component {
                     <flux:table.cell>
                         @if($city->country)
                             {{ $city->country->name }}
+                            {{-- Inline statt eigener Spalte: eine Kolumne waere bei den
+                                 heutigen Daten fast nur Bindestriche, und das Auge liest
+                                 sie als Ausfall statt als Optionalitaet. Der Mittelpunkt
+                                 statt eines Kommas, weil "Deutschland, Bayern" wie eine
+                                 Adresszeile klingt und "Deutschland · Bayern" wie zwei
+                                 Facetten. --}}
+                            @if($city->region)
+                                <span class="text-zinc-600 dark:text-zinc-300"> · {{ $city->region->name }}</span>
+                            @endif
                         @endif
                     </flux:table.cell>
                     <flux:table.cell>

--- a/resources/views/livewire/courses/landingpage.blade.php
+++ b/resources/views/livewire/courses/landingpage.blade.php
@@ -149,55 +149,23 @@ class extends Component {
                             {{ $event->from->format('H:i') }} - {{ $event->to->format('H:i') }} Uhr
                         </flux:text>
 
-                        @php
-                            // The map place is the precise answer; the free text is the one
-                            // that always exists. Never both — they name the same spot.
-                            $placeName = $event->osm_name ?: $event->location;
+                        {{-- Die Whitelist fuer osm_type, das 24px-Ziel und der Pfeil stehen
+                             jetzt in x-osm-place, damit die naechste Korrektur nicht vier
+                             Kopien verfehlt.
 
-                            // osm_type is stored as whatever Nominatim returned and goes
-                            // straight into an href, so it is whitelisted rather than
-                            // trusted: anything else renders as plain text, not as a link.
-                            $osmUrl = $event->osm_id && in_array(mb_strtolower((string) $event->osm_type), ['node', 'way', 'relation'], true)
-                                ? 'https://www.openstreetmap.org/'.mb_strtolower((string) $event->osm_type).'/'.(int) $event->osm_id
-                                : null;
-                        @endphp
-
-                        @if($placeName || $event->city)
+                             Die Stadt steht bewusst NEBEN der Komponente, nicht in ihrem Slot:
+                             ein Termin ohne Kartenort und ohne Freitext hat trotzdem eine
+                             Stadt, und die soll er weiter zeigen. --}}
+                        @if($event->osm_name || $event->location || $event->city)
                             <div class="mt-2 flex items-start gap-1.5">
                                 <flux:icon.map-pin class="mt-0.5 size-4 shrink-0 text-zinc-600 dark:text-zinc-300"
                                                    aria-hidden="true"/>
+                                {{-- Der gemeinsame Wrapper haelt beide Zustaende auf derselben
+                                     Hoehe. Gemessen: ohne ihn schob das eigene Padding des
+                                     Ankers die Stadt um 4px nach unten, und zwei Karten
+                                     nebeneinander liefen ausgefranst. --}}
                                 <div class="min-w-0 break-words">
-                                    {{-- Both states share this wrapper so the city line below sits
-                                         at the same height either way. Measured: without it the
-                                         anchor's own padding pushed the city down by 4px, and two
-                                         cards side by side went ragged. --}}
-                                    @if($placeName)
-                                        <div class="text-sm font-medium text-zinc-800 dark:text-zinc-100">
-                                            @if($osmUrl)
-                                                {{-- The place name itself is the link: a known map
-                                                     object is the only difference worth showing, and
-                                                     the trailing arrow marks it without relying on
-                                                     colour alone (WCAG 1.4.1).
-
-                                                     py-1, not py-0.5: the line box measures 19px in
-                                                     the browser, not the 20px the scale suggests, so
-                                                     0.5 left the target at 23px — one under the 24px
-                                                     WCAG 2.5.8 asks for. On an inline element the
-                                                     padding grows the hit area without moving layout. --}}
-                                                <a href="{{ $osmUrl }}"
-                                                   target="_blank"
-                                                   rel="noopener noreferrer"
-                                                   aria-label="{{ __(':place auf OpenStreetMap öffnen', ['place' => $placeName]) }}"
-                                                   class="rounded-xs py-1 hover:underline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-current">
-                                                    {{ $placeName }}<flux:icon.arrow-up-right
-                                                        class="ml-1 inline size-3.5 align-middle" aria-hidden="true"/>
-                                                </a>
-                                            @else
-                                                {{ $placeName }}
-                                            @endif
-                                        </div>
-                                    @endif
-
+                                    <x-osm-place :place="$event"/>
                                     @if($event->city)
                                         <div class="text-sm text-zinc-600 dark:text-zinc-300">
                                             {{ $event->city->name }}

--- a/resources/views/livewire/meetups/index.blade.php
+++ b/resources/views/livewire/meetups/index.blade.php
@@ -37,7 +37,7 @@ class extends Component {
     public function with(): array
     {
         return [
-            'meetups' => Meetup::with(['city.country', 'createdBy'])
+            'meetups' => Meetup::with(['city.country', 'city.region', 'createdBy'])
                 ->withExists([
                     'meetupEvents as has_future_events' => fn($query) => $query->where('start', '>=', now()),
                 ])
@@ -70,6 +70,9 @@ class extends Component {
             {{ $regionName ? __('Meetups in :region', ['region' => $regionName]) : __('Meetups') }}
         </flux:heading>
         <div class="flex flex-col md:flex-row items-center gap-4">
+            {{-- Der Einstieg in die Regions-Ansicht. Zeigt sich nur, wenn das Land
+                 Regionen hat — sonst bleibt die Leiste wie bisher. --}}
+            <livewire:region.chooser/>
             <flux:button class="cursor-pointer" x-copy-to-clipboard="'{{ route('ics') }}'"
                          icon="calendar-date-range">{{ __('Kalender-Stream-URL kopieren') }}</flux:button>
             <flux:input
@@ -108,11 +111,19 @@ class extends Component {
                             @if($meetup->city)
                                 <a href="{{ route('meetups.landingpage', ['meetup' => $meetup, 'country' => $country]) }}">
                                     <span>{{ $meetup->name }}</span>
-                                    <div class="text-xs text-zinc-500 flex items-center space-x-2">
+                                    {{-- zinc-600/300 statt zinc-500: letzteres misst auf dem
+                                         dunklen Body 3,19:1 und reisst damit WCAG 1.4.3.
+                                         Der Fehler ist Bestand, sitzt aber genau da, wo
+                                         jetzt Text dazukommt. --}}
+                                    <div class="text-xs text-zinc-600 dark:text-zinc-300 flex items-center space-x-2">
                                         <div>{{ $meetup->city->name }}</div>
                                         @if($meetup->city->country)
                                             <flux:separator vertical/>
                                             <div>{{ $meetup->city->country->name }}</div>
+                                        @endif
+                                        @if($meetup->city->region)
+                                            <flux:separator vertical/>
+                                            <div>{{ $meetup->city->region->name }}</div>
                                         @endif
                                     </div>
                                 </a>

--- a/resources/views/livewire/meetups/landingpage-event.blade.php
+++ b/resources/views/livewire/meetups/landingpage-event.blade.php
@@ -381,6 +381,17 @@ class extends Component {
                                  icon="calendar-date-range">{{ __('Kalender-Stream-URL kopieren') }}</flux:button>
                 </div>
             </div>
+
+            {{-- hidden md:block: auf schmalen Geraeten steht die rechte Spalte unter dem
+                 kompletten Termin samt Teilnehmerlisten — dort waere die Karte weit weg
+                 von der Ortszeile, auf die sie sich bezieht, und laedt trotzdem ihre
+                 Kacheln. Die Ortsangabe selbst steht oben, auf jeder Breite. --}}
+            @if($event->osm_lat && $event->osm_lon)
+                <div class="hidden md:block">
+                    <flux:heading size="lg" class="mb-2">{{ __('Anfahrt') }}</flux:heading>
+                    <x-venue-map :place="$event"/>
+                </div>
+            @endif
         </div>
     </div>
 </div>

--- a/resources/views/livewire/meetups/landingpage-event.blade.php
+++ b/resources/views/livewire/meetups/landingpage-event.blade.php
@@ -209,12 +209,16 @@ class extends Component {
                     </div>
 
                     <!-- Location -->
-                    @if($event->location)
-                        <div class="flex items-center text-zinc-700 dark:text-zinc-300">
-                            <flux:icon.map-pin class="w-5 h-5 mr-3"/>
-                            <div>
+                    {{-- Die Bedingung waechst von `location` auf `osm_name || location`:
+                         ein Termin mit Kartenort, aber ohne getippten Freitext zeigt jetzt
+                         etwas statt nichts. Die alte Bedingung ist eine echte Teilmenge
+                         der neuen — kein bestehender Termin verliert seine Ortszeile. --}}
+                    @if($event->osm_name || $event->location)
+                        <div class="flex items-start text-zinc-700 dark:text-zinc-300">
+                            <flux:icon.map-pin class="mt-0.5 w-5 h-5 mr-3 shrink-0" aria-hidden="true"/>
+                            <div class="min-w-0">
                                 <div class="font-semibold">{{ __('Ort') }}</div>
-                                <div class="text-sm">{{ $event->location }}</div>
+                                <x-osm-place :place="$event" show-address/>
                             </div>
                         </div>
                     @endif

--- a/resources/views/livewire/meetups/landingpage.blade.php
+++ b/resources/views/livewire/meetups/landingpage.blade.php
@@ -256,11 +256,15 @@ class extends Component {
                             {{ $event->start->asTime() }} Uhr
                         </flux:text>
 
-                        @if($event->location)
-                            <flux:text class="mt-1 text-sm text-zinc-600 dark:text-zinc-400">
-                                <flux:icon.map-pin class="inline w-4 h-4"/>
-                                {{ $event->location }}
-                            </flux:text>
+                        {{-- Einzeilig: die Kachel beantwortet "welcher Termin", der Ortsname
+                             schaerft das. Die Adresse gehoert auf die Detailseite, nicht in
+                             fuenf Kacheln nebeneinander. --}}
+                        @if($event->osm_name || $event->location)
+                            <div class="mt-1 flex items-start gap-1.5">
+                                <flux:icon.map-pin class="mt-0.5 size-4 shrink-0 text-zinc-600 dark:text-zinc-300"
+                                                   aria-hidden="true"/>
+                                <x-osm-place :place="$event"/>
+                            </div>
                         @endif
 
                         @if($event->description)

--- a/resources/views/livewire/region/chooser.blade.php
+++ b/resources/views/livewire/region/chooser.blade.php
@@ -1,0 +1,109 @@
+<?php
+
+use App\Models\Region;
+use Livewire\Attributes\Locked;
+use Livewire\Component;
+
+/**
+ * Der Einstieg in die Regions-Ansichten.
+ *
+ * Die Routen `meetups.index-region`, `meetups.map-region` und `cities.index-region`
+ * existieren seit dem 2026-08-22 und funktionieren — aber nichts im Portal verwies auf
+ * sie. 67 gepflegte Regionen, drei Routen, null Einstiegspunkte: gebaut, erreichbar und
+ * unauffindbar. Diese Komponente ist die fehlende Tuer.
+ *
+ * Sie zeigt sich nur, wenn das Land ueberhaupt Regionen hat. Fuer die uebrigen 247
+ * Laender ist die Seite unveraendert — eine leere Auswahl waere die schlechtere Antwort
+ * als gar keine.
+ */
+new class extends Component {
+    #[Locked]
+    public string $country = 'de';
+
+    /** Der Code der aktuell gewaehlten Region, oder leer fuer "alle im Land". */
+    public string $region = '';
+
+    /**
+     * Der Routenname der TRAGENDEN Seite, festgehalten beim ersten Rendern.
+     *
+     * Nicht bei jedem Aufruf neu aus `request()->route()` lesen: bei einem
+     * Livewire-Update heisst die Route `livewire.update`, und die steht in keiner
+     * Zuordnung — der Waehler waere nach der ersten Interaktion verschwunden.
+     */
+    #[Locked]
+    public string $pageRoute = '';
+
+    /**
+     * Welche Route ohne und welche mit Regionssegment gilt — je nachdem, auf welcher
+     * Seite der Waehler steht.
+     *
+     * @var array<string, array{0: string, 1: string}>
+     */
+    private const ROUTES = [
+        'meetups.index' => ['meetups.index', 'meetups.index-region'],
+        'meetups.index-region' => ['meetups.index', 'meetups.index-region'],
+        'meetups.map' => ['meetups.map', 'meetups.map-region'],
+        'meetups.map-region' => ['meetups.map', 'meetups.map-region'],
+        'cities.index' => ['cities.index', 'cities.index-region'],
+        'cities.index-region' => ['cities.index', 'cities.index-region'],
+    ];
+
+    /**
+     * Land und Seitenroute kommen normalerweise aus der Route; beide sind trotzdem
+     * uebergebbar, damit die Komponente pruefbar bleibt, ohne dass ein Test eine
+     * gesperrte Property beschreiben muesste (was sie zu Recht nicht darf).
+     */
+    public function mount(?string $country = null, ?string $pageRoute = null, ?string $region = null): void
+    {
+        $this->country = $country ?? (string) request()->route('country', config('app.domain_country'));
+        $this->region = $region ?? (string) (request()->route('region') ?? '');
+        $this->pageRoute = $pageRoute ?? (string) (request()->route()?->getName() ?? '');
+    }
+
+    public function updatedRegion(string $value): void
+    {
+        [$plain, $withRegion] = self::ROUTES[$this->pageRoute] ?? [null, null];
+
+        if ($plain === null) {
+            return;
+        }
+
+        $this->redirectRoute(
+            $value === '' ? $plain : $withRegion,
+            $value === ''
+                ? ['country' => $this->country]
+                : ['country' => $this->country, 'region' => $value],
+            navigate: true,
+        );
+    }
+
+    public function with(): array
+    {
+        return [
+            'regions' => Region::query()
+                ->whereHas('country', fn ($query) => $query->whereRaw('LOWER(code) = ?', [mb_strtolower($this->country)]))
+                ->orderBy('name')
+                ->get(['id', 'code', 'name']),
+            'supported' => isset(self::ROUTES[$this->pageRoute]),
+        ];
+    }
+}; ?>
+
+<div>
+    @if($supported && $regions->isNotEmpty())
+        <flux:select variant="listbox" searchable wire:model.live="region"
+                     placeholder="{{ __('Alle Regionen') }}" class="min-w-48">
+            <x-slot name="search">
+                <flux:select.search class="px-4" placeholder="{{ __('Region suchen...') }}"/>
+            </x-slot>
+            <flux:select.option value="">{{ __('Alle Regionen') }}</flux:select.option>
+            {{-- `$item`, nicht `$region`: die Schleifenvariable wuerde sonst die
+                 gleichnamige Property ueberschreiben und die Vorauswahl zerstoeren. --}}
+            @foreach($regions as $item)
+                <flux:select.option :key="$item->id" value="{{ $item->code }}">
+                    {{ $item->name }}
+                </flux:select.option>
+            @endforeach
+        </flux:select>
+    @endif
+</div>

--- a/tests/Feature/GeoDataVisibilityTest.php
+++ b/tests/Feature/GeoDataVisibilityTest.php
@@ -1,0 +1,115 @@
+<?php
+
+use App\Models\City;
+use App\Models\Country;
+use App\Models\Meetup;
+use App\Models\MeetupEvent;
+use App\Models\Region;
+use Livewire\Livewire;
+
+beforeEach(function () {
+    $this->country = Country::factory()->create(['code' => 'de', 'name' => 'Germany']);
+    $this->region = Region::factory()->create([
+        'country_id' => $this->country->id, 'code' => 'by', 'name' => 'Bayern', 'slug' => 'bayern',
+    ]);
+    $this->city = City::factory()->create([
+        'country_id' => $this->country->id, 'region_id' => $this->region->id, 'name' => 'Regensburg Test',
+    ]);
+    $this->meetup = Meetup::factory()->create(['city_id' => $this->city->id, 'name' => 'Regensburg Meetup']);
+});
+
+it('shows the chosen map place on the event page, not just the typed text', function () {
+    // Der Anlass: wer im Formular sorgfaeltig einen Ort waehlt, sah davon bisher nichts.
+    $event = MeetupEvent::factory()->create([
+        'meetup_id' => $this->meetup->id,
+        'location' => 'Im Hinterhof',
+        'osm_type' => 'way',
+        'osm_id' => 12345,
+        'osm_name' => 'Bürgerhaus Regensburg',
+        'osm_address' => 'Bürgerhaus, Hauptstraße 1, 93047 Regensburg',
+        'start' => now()->addWeek(),
+    ]);
+
+    $this->get("/de/meetup/{$this->meetup->slug}/event/{$event->id}")
+        ->assertSuccessful()
+        ->assertSee('Bürgerhaus Regensburg')
+        ->assertSee('Hauptstraße 1', false)
+        // Der Freitext bleibt daneben stehen, er sagt etwas anderes.
+        ->assertSee('Im Hinterhof')
+        ->assertSee('https://www.openstreetmap.org/way/12345', false);
+});
+
+it('leaves an event without a map place exactly as it was', function () {
+    // 3566 von 3569 Terminen haben keine Referenz — das ist der Normalfall, nicht der
+    // Ausnahmefall, und er darf nicht wie ein Fehler aussehen.
+    $event = MeetupEvent::factory()->create([
+        'meetup_id' => $this->meetup->id,
+        'location' => 'Nur Freitext',
+        'osm_type' => null, 'osm_id' => null, 'osm_name' => null,
+        'start' => now()->addWeek(),
+    ]);
+
+    $this->get("/de/meetup/{$this->meetup->slug}/event/{$event->id}")
+        ->assertSuccessful()
+        ->assertSee('Nur Freitext')
+        ->assertDontSee('openstreetmap.org', false);
+});
+
+it('never turns an unknown osm type into a link', function () {
+    $event = MeetupEvent::factory()->create([
+        'meetup_id' => $this->meetup->id,
+        'osm_type' => 'javascript', 'osm_id' => 1, 'osm_name' => 'Kaputt',
+        'start' => now()->addWeek(),
+    ]);
+
+    $this->get("/de/meetup/{$this->meetup->slug}/event/{$event->id}")
+        ->assertSuccessful()
+        ->assertSee('Kaputt')
+        ->assertDontSee('openstreetmap.org/javascript', false);
+});
+
+it('shows the region next to the country in both lists', function () {
+    $this->get('/de/cities')->assertSuccessful()->assertSee('Bayern');
+    $this->get('/de/meetups')->assertSuccessful()->assertSee('Bayern');
+});
+
+it('embeds the region chooser on the pages that have a region route', function () {
+    $this->get('/de/meetups')->assertSuccessful()->assertSeeLivewire('region.chooser');
+    $this->get('/de/cities')->assertSuccessful()->assertSeeLivewire('region.chooser');
+});
+
+it('offers regions only where the country has them', function () {
+    /*
+     * Auf die Komponente selbst geprueft statt auf Text im Seiten-HTML: Flux rendert
+     * die Optionen einer listbox nicht als Klartext, und ob es das tut, ist Flux'
+     * Sache und kein Vertrag, den dieser Test halten sollte. Was hier zaehlt, ist
+     * die Entscheidung der Komponente.
+     */
+    Livewire::test('region.chooser', ['country' => 'de', 'pageRoute' => 'meetups.index'])
+        ->assertViewHas('supported', true)
+        ->assertViewHas('regions', fn ($regions) => $regions->pluck('name')->contains('Bayern'));
+
+    // Land ohne gepflegte Regionen: der Waehler bleibt leer und zeigt sich nicht.
+    Country::factory()->create(['code' => 'at', 'name' => 'Austria']);
+
+    Livewire::test('region.chooser', ['country' => 'at', 'pageRoute' => 'meetups.index'])
+        ->assertViewHas('regions', fn ($regions) => $regions->isEmpty());
+});
+
+it('does not offer itself on a page without a region route', function () {
+    // Auf einer Seite ohne Regions-Gegenstueck waere die Auswahl eine Sackgasse.
+    Livewire::test('region.chooser', ['country' => 'de', 'pageRoute' => 'meetups.landingpage'])
+        ->assertViewHas('supported', false);
+});
+
+it('keeps the city list working for cities without a region', function () {
+    City::factory()->create([
+        'country_id' => $this->country->id, 'region_id' => null, 'name' => 'Ohne Region Test',
+    ]);
+
+    $this->get('/de/cities')
+        ->assertSuccessful()
+        ->assertSee('Ohne Region Test')
+        // Kein Bindestrich, kein "keine Region" — die Zeile ist schlicht kuerzer.
+        ->assertDontSee('keine Region');
+});

--- a/tests/Feature/GeoDataVisibilityTest.php
+++ b/tests/Feature/GeoDataVisibilityTest.php
@@ -5,6 +5,7 @@ use App\Models\Country;
 use App\Models\Meetup;
 use App\Models\MeetupEvent;
 use App\Models\Region;
+use App\Models\User;
 use Livewire\Livewire;
 
 beforeEach(function () {
@@ -112,4 +113,71 @@ it('keeps the city list working for cities without a region', function () {
         ->assertSee('Ohne Region Test')
         // Kein Bindestrich, kein "keine Region" — die Zeile ist schlicht kuerzer.
         ->assertDontSee('keine Region');
+});
+
+it('draws the venue map only when the event carries coordinates', function () {
+    $withCoords = MeetupEvent::factory()->create([
+        'meetup_id' => $this->meetup->id,
+        'osm_type' => 'way', 'osm_id' => 12345, 'osm_name' => 'Bürgerhaus Regensburg',
+        'osm_lat' => 49.0134, 'osm_lon' => 12.1016,
+        'start' => now()->addWeek(),
+    ]);
+
+    $this->get("/de/meetup/{$this->meetup->slug}/event/{$withCoords->id}")
+        ->assertSuccessful()
+        ->assertSee('initVenueMap', false)
+        ->assertSee('Anfahrt');
+
+    // Ohne Koordinaten faellt die Karte samt Ueberschrift weg — die Seite sieht aus
+    // wie vor dieser Aenderung.
+    $withoutCoords = MeetupEvent::factory()->create([
+        'meetup_id' => $this->meetup->id,
+        'location' => 'Nur Freitext',
+        'osm_lat' => null, 'osm_lon' => null,
+        'start' => now()->addWeek(),
+    ]);
+
+    $this->get("/de/meetup/{$this->meetup->slug}/event/{$withoutCoords->id}")
+        ->assertSuccessful()
+        ->assertDontSee('initVenueMap', false)
+        ->assertDontSee('Anfahrt');
+});
+
+it('shows the chosen map place in the map popup', function () {
+    MeetupEvent::factory()->create([
+        'meetup_id' => $this->meetup->id,
+        'location' => 'Im Hinterhof',
+        'osm_type' => 'way', 'osm_id' => 12345, 'osm_name' => 'Bürgerhaus Regensburg',
+        'start' => now()->addWeek(),
+    ]);
+
+    $html = view('components.meetup-popup', [
+        'meetup' => $this->meetup->fresh(),
+        'url' => '/de/meetup/'.$this->meetup->slug,
+        'eventUrl' => null,
+    ])->render();
+
+    expect($html)
+        ->toContain('Bürgerhaus Regensburg')
+        ->toContain('https://www.openstreetmap.org/way/12345')
+        // Der Freitext sagt etwas anderes und bleibt daneben stehen.
+        ->toContain('Im Hinterhof')
+        /*
+         * text-zinc-200 stand vor dem festen dunklen Popup-Grund; seit der nur noch im
+         * dunklen Theme gilt, waere es auf Leaflets weisser Standardflaeche unlesbar.
+         */
+        ->not->toContain('text-zinc-200');
+});
+
+it('offers the same country picker when editing a city as when creating one', function () {
+    $this->actingAs(User::factory()->create());
+
+    // Die Flagge ist der sichtbare Beleg dafuer, dass beide Formulare dieselbe
+    // Flux-Listbox verwenden — rohe <option>-Tags koennen kein Bild tragen.
+    $flag = 'vendor/blade-flags/country-de.svg';
+
+    $this->get(route('cities.create', ['country' => 'de']))->assertSuccessful()->assertSee($flag, false);
+    $this->get(route('cities.edit', ['country' => 'de', 'city' => $this->city]))
+        ->assertSuccessful()
+        ->assertSee($flag, false);
 });


### PR DESCRIPTION
Vier Ebenen tragen inzwischen OSM-Referenzen — **249 von 249** Ländern, alle neuen Städte, 67 Regionen, jeder neu gepflegte Termin. Angezeigt wurde davon genau **eine** Stelle: der Ortsblock auf `courses/landingpage`.

Der `design-lead` hat die Bestandsaufnahme gemacht und dabei zwei Annahmen aus meinem Auftrag kassiert.

## Fund 1: Die Regions-Routen hatten keinen einzigen Link

`meetups.index-region`, `meetups.map-region` und `cities.index-region` sind registriert, getestet und erreichbar — aber `grep -rn "index-region\|map-region"` über `resources/` und `app/` findet **keinen `route()`-Aufruf**.

**67 Regionen, drei Routen, null Einstiegspunkte.** Nicht die fehlende Tabellenspalte war das Problem, sondern dass fertige Arbeit unauffindbar war.

## Fund 2: Die Länderdaten bleiben bewusst unsichtbar

Es gibt keine Country-Detailseite, und eine zu bauen, damit 249 vollständige Zeilen einen Leser haben, hieße die Seite **aus dem Datenbestand abzuleiten statt aus einer Frage**. Ein gutes Datenergebnis ohne Anzeigefolge ist ein Ergebnis, kein offener Posten.

## Gebaut

| # | Was |
|---|---|
| 1 | `region.chooser` über den Listen in `meetups/index` und `cities/index` — zeigt sich nur, wenn das Land Regionen hat |
| 2 | `x-osm-place` als Komponente; die `osm_type`-Whitelist steht jetzt einmal statt viermal |
| 3 | Event-Seite zeigt `osm_name`, Adresse und Link statt nur den getippten Freitext |
| 4 | Event-Kacheln der Meetup-Seite: Ortsname einzeilig, ohne Adresse |
| 6 | Region inline hinter dem Land, Mittelpunkt statt Komma |

**Keine eigene Regions-Spalte:** bei den heutigen Daten wäre sie fast nur Bindestriche, und das Auge liest das als Ausfall statt als Optionalität.

**Eine Korrektur ohne Geo-Bezug**, die aber genau dort sitzt, wo neuer Text hinzukam: `text-zinc-500` misst auf dem dunklen Body **3,19:1** und reißt WCAG 1.4.3.

## Drei Stolperstellen, die der erste Entwurf hatte

- **Die Stadt lag im Slot der neuen Komponente.** Ein Termin ohne Kartenort und ohne Freitext hätte damit seine Stadt verloren — die Komponente rendert bei leerem Ortsnamen gar nichts, Slot inklusive. Sie steht jetzt daneben.
- **Die Schleifenvariable hieß `$region`** wie die gleichnamige Property und hätte die Vorauswahl überschrieben.
- **`request()->route()` heißt bei einem Livewire-Update `livewire.update`.** Der Wähler wäre nach der ersten Interaktion verschwunden; die Seitenroute wird jetzt beim Mount festgehalten.

## Editierbarkeit — schärfer als meine These

`wikidata` und `wikipedia` gehören in **gar kein** Formular. `EnrichCountriesFromOsm` füllt nur leere Felder; ein handgetippter falscher Wert wird deshalb nie korrigiert — er **blockiert die Automatik dauerhaft und unsichtbar**. Die übrigen `osm_*`-Felder bleiben beim Picker, weil `osm_type` und `osm_id` nur gemeinsam ein Objekt identifizieren und zwei Rohfelder genau zum halben Zustand einladen.

## Nachweis

Acht neue Tests, darunter:

- **der Leerzustand als Normalfall** — 3566 von 3569 Terminen haben keine Referenz und müssen aussehen wie immer,
- ein unbekannter `osm_type` wird **nie** zu einem `href`,
- der Wähler bietet sich nicht auf Seiten ohne Regions-Gegenstück an (das wäre eine Sackgasse).

Mit Meetups-, Courses-, Cities- und Region-Suiten: **105 passed**. `tests/Feature/Smoke` unverändert **57 passed**. Pint sauber.

## Noch offen aus dem Konzept

- **Vorschaltung:** das Leaflet-Popup misst im hellen Theme **1,33:1 bis 2,19:1** — ein WCAG-Verstoß im Bestand. Muss vor Punkt 5 kommen.
- **Punkt 5:** `osm_name` ins Kartenpopup.
- **Punkt 7:** Venue-Karte in der rechten Spalte der Event-Seite — 580 px gemessener leerer Raum, aber Reichweite heute 3 von 3569.
- **Punkt 8:** Land-Select in `cities/edit` an `create` angleichen.
