### PR TITLE
🌐 Sprachwahl überlebt den Login — und das 419-Log findet seinen eigenen Fall

### DIFF
--- a/app/Listeners/ApplyChosenLanguageAfterLogin.php
+++ b/app/Listeners/ApplyChosenLanguageAfterLogin.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Listeners;
+
+use Illuminate\Auth\Events\Login;
+use LangCountry;
+
+/**
+ * Bewahrt die Sprachwahl, die ein Gast VOR dem Anmelden getroffen hat.
+ *
+ * `stefro/laravel-lang-country` haengt einen eigenen Listener an dasselbe Login-Event
+ * (`LaravelLangCountryServiceProvider::boot()`), der die Session bedingungslos auf
+ * `users.lang_country` zurueckstellt. Wer sich abmeldet, auf Tschechisch stellt und
+ * sich wieder anmeldet, landete dadurch wieder in der Sprache, die irgendwann einmal
+ * am Konto gespeichert wurde — meist die, die `LangCountrySession` beim allerersten
+ * Besuch aus `HTTP_ACCEPT_LANGUAGE` geraten und ungefragt persistiert hatte.
+ *
+ * Dieser Listener laeuft danach (der App-Provider bootet nach den Paket-Providern) und
+ * dreht die Reihenfolge um: eine ausdrueckliche Wahl schlaegt den gespeicherten Wert
+ * und wird zugleich am Konto festgeschrieben, damit sie den naechsten Login ueberlebt.
+ *
+ * Nur eine ausdrueckliche Wahl zaehlt — `lang_country_chosen` setzt allein der
+ * Sprachwaehler. Eine von der Middleware geratene Sprache greift hier nicht ein.
+ */
+class ApplyChosenLanguageAfterLogin
+{
+    public function handle(Login $event): void
+    {
+        $chosen = session('lang_country_chosen');
+
+        if (! is_string($chosen) || ! in_array($chosen, config('lang-country.allowed', []), true)) {
+            return;
+        }
+
+        LangCountry::setAllSessions($chosen);
+
+        $user = $event->user;
+
+        if (array_key_exists('lang_country', $user->getAttributes()) && $user->lang_country !== $chosen) {
+            $user->lang_country = $chosen;
+            $user->save();
+        }
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -2,7 +2,9 @@
 
 namespace App\Providers;
 
+use App\Listeners\ApplyChosenLanguageAfterLogin;
 use App\Support\Carbon;
+use Illuminate\Auth\Events\Login;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Database\Eloquent\Model;
@@ -38,6 +40,13 @@ class AppServiceProvider extends ServiceProvider
     public function boot(): void
     {
         $this->configureRateLimiting();
+
+        /*
+         * Muss nach dem Listener von stefro/laravel-lang-country haengen, der dieselbe
+         * Session auf users.lang_country zurueckstellt — Paket-Provider booten vor dem
+         * App-Provider, die Reihenfolge stimmt also. Begruendung in der Listener-Klasse.
+         */
+        Event::listen(Login::class, ApplyChosenLanguageAfterLogin::class);
 
         Gate::define('viewApiDocs', fn (?Authenticatable $user = null): bool => true);
 

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -172,21 +172,35 @@ return Application::configure(basePath: dirname(__DIR__))
              * Produktionslog zu diesem Zeitpunkt keine einzige Zeile. Ohne Spur laesst
              * sich nicht einmal entscheiden, WELCHE der beiden Ursachen es war.
              *
-             * Deshalb: fuer angemeldete Nutzer wird beides protokolliert. Wer
-             * eingeloggt ist, ist kein Scanner — und genau dessen Faelle wollen wir
-             * sehen. Fuer anonyme Requests bleibt es still, sonst kehrt die Bot-Flut
-             * zurueck, wegen der die Unterdrueckung ueberhaupt eingebaut wurde.
+             * Die Bedingung war zuerst `auth()->check()` — und die schloss genau den
+             * Fall aus, den sie finden sollte. Ist die Ursache eine verlorene Session,
+             * ist der Request per Definition NICHT angemeldet: kein Session-Cookie,
+             * das der Server aufloesen kann, also auch kein Nutzer. Am 2026-08-23
+             * meldete iBobik um 12:20 UTC einen Fehlversuch; das Logging war seit
+             * 12:03 live und schrieb trotzdem keine Zeile.
+             *
+             * Das Kriterium ist deshalb jetzt: **hat der Browser ein Session-Cookie
+             * mitgeschickt?** Wer eins mitbringt, war irgendwann auf der Seite — das
+             * ist ein echter Besucher, ob seine Session serverseitig noch gilt oder
+             * nicht. Bots, die `/livewire/update` mit mutierten Snapshots beharken,
+             * schicken keins; die Flut, wegen der die Unterdrueckung eingebaut wurde,
+             * bleibt draussen.
              */
             if ($isSilencedFourNineteen($e)) {
                 $request = request();
 
-                if (! auth()->hasUser() || ! auth()->check()) {
+                $hasSessionCookie = $request->cookies->has(config('session.cookie'));
+
+                if (! $hasSessionCookie && ! auth()->hasUser()) {
                     return false;
                 }
 
-                Log::warning('419 fuer angemeldeten Nutzer', [
+                Log::warning('419 mit Session-Cookie', [
                     'exception' => $e::class,
-                    'user_id' => auth()->id(),
+                    // null heisst: Cookie da, Session serverseitig weg — genau der
+                    // Verdachtsfall aus Issue #18.
+                    'user_id' => auth()->hasUser() ? auth()->id() : null,
+                    'session_started' => $request->hasSession() && $request->session()->isStarted(),
                     'path' => $request->path(),
                     // Bei Livewire steht die eigentliche Komponente im Snapshot, nicht
                     // im Pfad — ohne sie weiss man nur "irgendwo im Portal".

--- a/resources/views/livewire/language/selector.blade.php
+++ b/resources/views/livewire/language/selector.blade.php
@@ -38,8 +38,30 @@ new class extends Component {
         return $options;
     }
 
-    public function updateLanguage() {
-        return redirect()->route('lang_country.switch', ['lang_country' => $this->langCountry]);
+    /**
+     * Lifecycle-Hook statt wire:change.
+     *
+     * Vorher hingen `wire:model.live` und `wire:change="updateLanguage"` am selben
+     * Element. Livewire 4 faehrt Property-Updates parallel, also gingen zwei Requests
+     * raus: einer, der `langCountry` setzt, und einer, der `updateLanguage()` ruft —
+     * letzterer mit dem Snapshot VOR der Aenderung. Traf er zuerst ein, leitete er auf
+     * die zuvor gewaehlte Sprache um, und die Auswahl sah aus, als spraenge sie zurueck.
+     * Zwei gleichzeitige Updates derselben Komponente sind ausserdem der Weg, auf dem
+     * ein Snapshot veraltet und Livewire mit 419 abbricht.
+     *
+     * Der Hook laeuft im selben Request, in dem die Property gesetzt wird — eine
+     * Anfrage, kein Rennen, und der Wert ist garantiert der neue.
+     */
+    public function updatedLangCountry(): void
+    {
+        /*
+         * Die bewusste Wahl getrennt festhalten: `lang_country` allein sagt nicht, ob
+         * sie jemand getroffen oder eine Middleware aus Accept-Language geraten hat.
+         * ApplyChosenLanguageAfterLogin braucht diesen Unterschied.
+         */
+        session(['lang_country_chosen' => $this->langCountry]);
+
+        $this->redirectRoute('lang_country.switch', ['lang_country' => $this->langCountry]);
     }
 };
 
@@ -49,7 +71,6 @@ new class extends Component {
     <flux:select
         variant="listbox" searchable
         wire:model.live="langCountry"
-        wire:change="updateLanguage"
         :placeholder="__('Sprache wählen')"
     >
         @foreach($this->languages as $option)

--- a/tests/Feature/FourNineteenIsLoggedTest.php
+++ b/tests/Feature/FourNineteenIsLoggedTest.php
@@ -2,6 +2,7 @@
 
 use App\Models\User;
 use Illuminate\Contracts\Debug\ExceptionHandler;
+use Illuminate\Http\Request;
 use Illuminate\Session\TokenMismatchException;
 use Illuminate\Support\Facades\Log;
 use Livewire\Mechanisms\HandleComponents\CorruptComponentPayloadException;
@@ -23,7 +24,7 @@ it('logs a silenced 419 when the user is signed in', function (string $exception
     app(ExceptionHandler::class)->report(new $exceptionClass('kaputt'));
 
     Log::shouldHaveReceived('warning')
-        ->withArgs(fn (string $message, array $context): bool => $message === '419 fuer angemeldeten Nutzer'
+        ->withArgs(fn (string $message, array $context): bool => $message === '419 mit Session-Cookie'
             && $context['exception'] === $exceptionClass)
         ->once();
 })->with([
@@ -31,9 +32,9 @@ it('logs a silenced 419 when the user is signed in', function (string $exception
     'livewire snapshot' => CorruptComponentPayloadException::class,
 ]);
 
-it('stays silent for anonymous requests so the bot noise does not return', function (string $exceptionClass) {
+it('stays silent for requests without a session cookie so the bot noise does not return', function (string $exceptionClass) {
     // Die Unterdrueckung wurde wegen Scannern eingebaut, die /livewire/update mit
-    // manipulierten Snapshots durchprobieren. Die bleiben still.
+    // manipulierten Snapshots durchprobieren. Die schicken kein Session-Cookie.
     Log::spy();
 
     app(ExceptionHandler::class)->report(new $exceptionClass('kaputt'));
@@ -43,3 +44,24 @@ it('stays silent for anonymous requests so the bot noise does not return', funct
     'csrf' => TokenMismatchException::class,
     'livewire snapshot' => CorruptComponentPayloadException::class,
 ]);
+
+it('logs a 419 from a browser whose session is gone but whose cookie is not', function () {
+    /*
+     * Der Fall, den die alte Bedingung `auth()->check()` ausschloss — und zugleich der
+     * wahrscheinlichste aus Issue #18. Ist die Session serverseitig weg, ist der
+     * Request nicht angemeldet; geloggt wurde deshalb nie etwas. Das Cookie ist der
+     * Beleg, dass da ein echter Browser sass und kein Scanner.
+     */
+    Log::spy();
+
+    $request = Request::create('/livewire/update', 'POST');
+    $request->cookies->set(config('session.cookie'), 'eine-abgelaufene-id');
+    app()->instance('request', $request);
+
+    app(ExceptionHandler::class)->report(new TokenMismatchException('kaputt'));
+
+    Log::shouldHaveReceived('warning')
+        ->withArgs(fn (string $message, array $context): bool => $message === '419 mit Session-Cookie'
+            && $context['user_id'] === null)
+        ->once();
+});

--- a/tests/Feature/LanguageChoiceTest.php
+++ b/tests/Feature/LanguageChoiceTest.php
@@ -1,0 +1,69 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Auth\Events\Login;
+use Livewire\Livewire;
+
+it('keeps the language a guest picked before logging in', function () {
+    /*
+     * Der gemeldete Ablauf: abmelden, Sprache umstellen, anmelden — und die Sprache
+     * springt auf die zurueck, die am Konto gespeichert ist. Der Listener des
+     * lang-country-Pakets stellt sie beim Login bedingungslos zurueck.
+     */
+    $user = User::factory()->create(['lang_country' => 'en-US']);
+
+    session(['lang_country_chosen' => 'cs-CZ']);
+
+    $this->actingAs($user);
+    event(new Login('web', $user, false));
+
+    expect(session('lang_country'))->toBe('cs-CZ')
+        ->and(session('locale'))->toBe('cs')
+        // Damit die Wahl auch den naechsten Login ueberlebt.
+        ->and($user->fresh()->lang_country)->toBe('cs-CZ');
+});
+
+it('leaves the stored language alone when the guest picked nothing', function () {
+    $user = User::factory()->create(['lang_country' => 'en-US']);
+
+    $this->actingAs($user);
+    event(new Login('web', $user, false));
+
+    expect($user->fresh()->lang_country)->toBe('en-US');
+});
+
+it('ignores a language that is not in the allowed list', function () {
+    // Der Wert stammt aus der Session und darf nie ungeprueft in die Datenbank.
+    $user = User::factory()->create(['lang_country' => 'en-US']);
+
+    session(['lang_country_chosen' => 'xx-XX']);
+
+    $this->actingAs($user);
+    event(new Login('web', $user, false));
+
+    expect($user->fresh()->lang_country)->toBe('en-US');
+});
+
+it('switches the language in a single request instead of racing two', function () {
+    /*
+     * Vorher standen wire:model.live und wire:change nebeneinander. Livewire 4 faehrt
+     * Property-Updates parallel, also lief updateLanguage() mit dem Snapshot VOR der
+     * Aenderung und leitete auf die alte Sprache um. Der Lifecycle-Hook sieht den
+     * neuen Wert, weil er im selben Request laeuft.
+     */
+    Livewire::test('language.selector')
+        ->set('langCountry', 'cs-CZ')
+        ->assertRedirect(route('lang_country.switch', ['lang_country' => 'cs-CZ']));
+
+    expect(session('lang_country_chosen'))->toBe('cs-CZ');
+});
+
+it('no longer carries a wire:change handler on the language select', function () {
+    /*
+     * Regressionsanker: die zweite Anfrage war die Ursache, nicht ein Symptom.
+     * Geprueft wird das gerenderte HTML, nicht die Quelldatei — deren PHP-Doc nennt
+     * `wire:change` absichtlich, um zu erklaeren, warum es weg ist.
+     */
+    Livewire::test('language.selector')
+        ->assertDontSee('wire:change', false);
+});


### PR DESCRIPTION
Zwei Befunde aus #18, beide mit derselben Wurzel: etwas läuft zweimal, und der zweite Lauf gewinnt.

## Der Sprachwähler feuerte zwei Requests

`language/selector` trug `wire:model.live="langCountry"` **und** `wire:change="updateLanguage"` am selben Element. Livewire 4 fährt Property-Updates parallel — es gingen zwei Requests raus: einer, der `langCountry` setzt, und einer, der `updateLanguage()` ruft, letzterer mit dem Snapshot **vor** der Änderung. Traf er zuerst ein, leitete er auf die zuvor gewählte Sprache um, und die Auswahl sah aus, als spränge sie zurück.

Zwei gleichzeitige Updates derselben Komponente sind zugleich der Weg, auf dem ein Snapshot veraltet und Livewire mit 419 abbricht. Ob das den gemeldeten 419 erklärt, ist damit **nicht bewiesen** — die Mechanik passt, der Beleg fehlt.

Der Lifecycle-Hook `updatedLangCountry()` läuft im selben Request, in dem die Property gesetzt wird.

## Der Login stellte die Sprache bedingungslos zurück

`stefro/laravel-lang-country` hängt einen Listener an `Login`, der die Session auf `users.lang_country` zurücksetzt. Wer sich abmeldet, umstellt und wieder anmeldet, landete in der Sprache, die irgendwann am Konto gespeichert wurde — meist die, die `LangCountrySession` beim ersten Besuch aus `HTTP_ACCEPT_LANGUAGE` geraten und ungefragt persistiert hat.

`ApplyChosenLanguageAfterLogin` läuft danach und dreht die Reihenfolge um. Nur eine ausdrückliche Wahl zählt, und der Wert wird gegen `lang-country.allowed` geprüft, bevor er in die Datenbank geht.

## Das 419-Log schloss seinen eigenen Fall aus

Die Bedingung war `auth()->check()`. Ist die Ursache eine verlorene Session, ist der Request per Definition **nicht** angemeldet — der Filter konnte nie greifen. Produktion lief seit 2026-08-23 12:03 UTC auf dem Release mit dem Logging, die Meldung kam 12:20 UTC, und im Fenster 12:00–12:30 UTC standen sieben Zeilen, keine davon ein 419.

Kriterium ist jetzt: **hat der Browser ein Session-Cookie mitgeschickt?** Bots, die `/livewire/update` mit mutierten Snapshots beharken, schicken keins. Der Eintrag führt zusätzlich `session_started`, damit „Cookie da, Session weg" als solcher lesbar ist.

## Tests

962 grün (3849 Assertions). Sechs neue Fälle: bewahrte Wahl, unangetasteter Kontowert, abgewiesener Fremdwert, Ein-Request-Wechsel, `wire:change` nicht mehr im Markup, 419 mit abgelaufenem Cookie.

## Nicht enthalten

Für Konten, deren `lang_country` aus Accept-Language geraten wurde, wirkt der alte Wert weiter, bis jemand einmal bewusst wählt.

Refs #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)