### PR TITLE
📡 Realtime-Änderungen: api_changes, /api/changes und Reverb (#29)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,7 +35,7 @@ SESSION_ENCRYPT=false
 SESSION_PATH=/
 SESSION_DOMAIN=null
 
-BROADCAST_CONNECTION=log
+BROADCAST_CONNECTION=reverb
 FILESYSTEM_DISK=local
 QUEUE_CONNECTION=database
 
@@ -72,3 +72,28 @@ VITE_APP_NAME="${APP_NAME}"
 # Volume). Niemals echte Schlüssel committen (storage/oauth-*.key ist .gitignored).
 PASSPORT_PRIVATE_KEY=
 PASSPORT_PUBLIC_KEY=
+
+# Laravel Reverb — der WebSocket-Server hinter /docs/websockets (Issue #29).
+# Das Portal SENDET nur; es abonniert seine eigenen Kanaele nicht. Deshalb bewusst
+# keine VITE_REVERB_*-Variablen: die gehoeren zu einem Echo-Client im Frontend, den es
+# hier nicht gibt.
+REVERB_APP_ID=
+REVERB_APP_KEY=
+REVERB_APP_SECRET=
+# Wohin der Daemon selbst bindet.
+REVERB_SERVER_HOST=127.0.0.1
+REVERB_SERVER_PORT=8080
+# Pfad-Praefix des Handshakes. NICHT der Default "app": die Site hat bereits eine
+# Route `GET app/auth` (Mobile-Login-Handoff), die ein nginx-Proxy auf /app/ verdecken
+# wuerde. Muss zu `reverb:start --path=` und zum nginx-location passen.
+REVERB_SERVER_PATH=reverb
+# Wohin die ANWENDUNG publiziert. In Produktion der lokale Daemon, nicht der
+# oeffentliche Hostname — sonst geht jeder Broadcast als TLS-Roundtrip durch nginx auf
+# denselben Server zurueck.
+REVERB_HOST=127.0.0.1
+REVERB_PORT=8080
+REVERB_SCHEME=http
+# Kommagetrennte Hostnamen, Wildcards erlaubt. Leer = "*". Siehe config/reverb.php:
+# eine konkrete Liste sperrt Clients OHNE Origin-Header aus — also gerade die
+# serverseitigen Konsumenten, fuer die das gebaut ist.
+REVERB_APP_ALLOWED_ORIGINS=

--- a/app/Attributes/SeoDataAttribute.php
+++ b/app/Attributes/SeoDataAttribute.php
@@ -288,6 +288,20 @@ class SeoDataAttribute
                 twitter_username: $domainTwitter,
                 site_name: $domainSiteName,
             ),
+            /*
+             * Bewusst NICHT durch __() gefuehrt: die Seite selbst ist englisch, weil
+             * sie neben /docs/api steht und denselben Vertrag mit denselben Feldnamen
+             * beschreibt. Ein deutscher Titel ueber einer englischen Seite waere ein
+             * Versprechen, das der Inhalt nicht haelt.
+             */
+            'docs_websockets' => new SEOData(
+                title: 'Realtime change feed - EINUNDZWANZIG API',
+                description: 'WebSocket channels and the /api/changes cursor feed: learn about created, updated and deleted meetups, dates, cities, courses and lecturers as they happen.',
+                author: $domainAuthor,
+                image: $domainImage,
+                twitter_username: $domainTwitter,
+                site_name: $domainSiteName,
+            ),
             // Add more as needed
             'default' => new SEOData(
                 title: __('Willkommen'),

--- a/app/Console/Commands/Database/PruneApiChanges.php
+++ b/app/Console/Commands/Database/PruneApiChanges.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Console\Commands\Database;
+
+use App\Models\ApiChange;
+use Illuminate\Console\Command;
+
+/**
+ * Haelt das Aenderungs-Log (Issue #29) auf seiner Aufbewahrungsfrist.
+ *
+ * Die Frist ist zugleich das Versprechen an den Konsumenten: laenger als sie kann
+ * niemand per /api/changes nachziehen. Wer laenger offline war, braucht einen
+ * vollstaendigen Abgleich — deshalb steht die Zahl in der Config und nicht hier fest
+ * verdrahtet.
+ */
+class PruneApiChanges extends Command
+{
+    /**
+     * @var string
+     */
+    protected $signature = 'api-changes:prune {--days= : Aufbewahrungsfrist in Tagen; Default aus einundzwanzig.change_log.prune_days}';
+
+    /**
+     * @var string
+     */
+    protected $description = 'Loescht Eintraege des API-Aenderungs-Logs, die aelter als die Aufbewahrungsfrist sind';
+
+    public function handle(): int
+    {
+        $days = (int) ($this->option('days') ?? config('einundzwanzig.change_log.prune_days', 30));
+
+        if ($days < 1) {
+            $this->error('Die Aufbewahrungsfrist muss mindestens einen Tag betragen.');
+
+            return Command::FAILURE;
+        }
+
+        $cutoff = now()->subDays($days);
+
+        $deleted = ApiChange::query()
+            ->where('occurred_at', '<', $cutoff)
+            ->delete();
+
+        $this->info("{$deleted} Aenderungen vor {$cutoff->toDateTimeString()} geloescht.");
+
+        return Command::SUCCESS;
+    }
+}

--- a/app/Events/ResourceChanged.php
+++ b/app/Events/ResourceChanged.php
@@ -41,16 +41,26 @@ class ResourceChanged implements ShouldBroadcast
     public function __construct(public readonly array $payload) {}
 
     /**
-     * Der Event-Name auf dem Kanal, etwa `.meetup-event.created`.
+     * Der Event-Name auf dem Draht, etwa `meetup-event.created`.
      *
-     * Der fuehrende Punkt ist Pflicht und kein Schoenheitsfehler: ohne ihn stellt Echo
-     * den Anwendungs-Namespace voran und der Konsument muesste auf
-     * `App\Events\ResourceChanged` hoeren — ein interner Klassenname als Aussenvertrag.
-     * Mit Punkt hoert er auf den Namen, der auch in der Doku steht.
+     * OHNE FUEHRENDEN PUNKT, und das ist der Punkt. Was diese Methode zurueckgibt,
+     * geht WOERTLICH ueber die Leitung: {@see BroadcastEvent::handle()}
+     * nimmt `enum_value($this->event->broadcastAs())` als Event-Namen, ohne irgendetwas
+     * daran zu aendern. Der fuehrende Punkt, den man aus Laravel-Beispielen kennt, ist
+     * CLIENT-Syntax: `Echo.channel(…).listen('.meetup-event.created')` sagt Echo „stell
+     * mir keinen App-Namespace voran"; Echo entfernt ihn und abonniert
+     * `meetup-event.created`. Er reist nie mit.
+     *
+     * Stuende der Punkt hier, hiesse das Ereignis auf dem Draht buchstaeblich
+     * `.meetup-event.created` — und ein Echo-Konsument mit der naheliegenden
+     * Schreibweise abonnierte `meetup-event.created` und hoerte fuer immer nichts.
+     * Ein oeffentlicher Pusher-Kanal hat keinen Rueckkanal: ein Abo auf einen Namen,
+     * den niemand sendet, ist erfolgreich und still. Genau die Fehlerklasse, vor der
+     * /docs/websockets warnt — sie darf nicht aus diesem Repo kommen.
      */
     public function broadcastAs(): string
     {
-        return sprintf('.%s.%s', $this->payload['resource'], $this->payload['action']);
+        return sprintf('%s.%s', $this->payload['resource'], $this->payload['action']);
     }
 
     /**

--- a/app/Events/ResourceChanged.php
+++ b/app/Events/ResourceChanged.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace App\Events;
+
+use App\Support\Broadcasting\ChangeRecorder;
+use Illuminate\Broadcasting\BroadcastEvent;
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+
+/**
+ * Eine Aenderung an einer oeffentlichen API-Ressource, unterwegs zu Reverb (Issue #29).
+ *
+ * DIESE KLASSE TRAEGT EIN ARRAY UND NIEMALS EIN MODEL. Das ist die eine Eigenschaft,
+ * die sie nie verlieren darf, und der Grund dafuer steht in Laravels eigenem Code:
+ * {@see BroadcastEvent} setzt `deleteWhenMissingModels = true`
+ * (Zeile 66). Traegt ein Event ein Eloquent-Model in die Queue, versucht
+ * `SerializesModels` es beim Ausfuehren nachzuladen — und findet es bei einem `deleted`
+ * nie wieder, weil kein Model dieses Projekts SoftDeletes nutzt. Der Job wird dann
+ * STILL verworfen: kein Fehler, kein `failed_jobs`-Eintrag, kein Log. Ein Konsument
+ * erfuehre von Loeschungen nie etwas, und niemand saehe, dass etwas fehlt.
+ *
+ * Derselbe Mechanismus faelschte bei `updated` das Payload: das nachgeladene Model
+ * traegt den Stand zur SENDEzeit, nicht den zur Aenderungszeit — bei mehreren
+ * parallelen Horizon-Prozessen also in beliebiger Reihenfolge.
+ *
+ * Deshalb: kein `SerializesModels`, keine Model-Property, keine Resource-Aufloesung im
+ * Job. Das Payload ist fertig, wenn es hier ankommt; {@see ChangeRecorder} hat es
+ * synchron im Request gebaut. `tests/Feature/Broadcasting/ResourceChangedTest.php`
+ * haelt das per Reflection fest.
+ */
+class ResourceChanged implements ShouldBroadcast
+{
+    use Dispatchable, InteractsWithSockets;
+
+    /**
+     * @param  array<string, mixed>  $payload  Der fertige Umschlag aus
+     *                                         {@see ChangeRecorder::broadcastPayload()} — schon auf 10 KB geprueft.
+     */
+    public function __construct(public readonly array $payload) {}
+
+    /**
+     * Der Event-Name auf dem Kanal, etwa `.meetup-event.created`.
+     *
+     * Der fuehrende Punkt ist Pflicht und kein Schoenheitsfehler: ohne ihn stellt Echo
+     * den Anwendungs-Namespace voran und der Konsument muesste auf
+     * `App\Events\ResourceChanged` hoeren — ein interner Klassenname als Aussenvertrag.
+     * Mit Punkt hoert er auf den Namen, der auch in der Doku steht.
+     */
+    public function broadcastAs(): string
+    {
+        return sprintf('.%s.%s', $this->payload['resource'], $this->payload['action']);
+    }
+
+    /**
+     * Genau zwei oeffentliche Kanaele — und `meetup-events` traegt nur Termine.
+     *
+     * `portal` ist der Firehose: ein Abo, ein Handler, alle sechs Ressourcen. Das ist
+     * der "clear caches instantly"-Fall aus Issue #29.
+     *
+     * `meetup-events` ist der einzige gegenstandsbezogene Kanal, weil Meetup-Termine
+     * das einzige sind, was im Issue woertlich benannt wurde. Ein Kanal, der so heisst
+     * und dann auch Kurse und Staedte truege, waere schlimmer als kein Kanal: sein
+     * Name sagt etwas zu, was er nicht haelt, der Konsument filtert entweder nach oder
+     * verarbeitet Fremdes — und merkt den Unterschied nie, weil ein oeffentlicher
+     * Pusher-Kanal keinen Rueckkanal hat. Die Zusammensetzung wird deshalb hier
+     * entschieden, an der Ressource im Payload, und nicht beim Dispatch: der Recorder
+     * kennt Kanaele nicht, und ein zweiter Ort mit derselben Regel waere ein Ort, an
+     * dem sie eines Tages abweicht.
+     *
+     * Weitere Kanalfamilien (Geo, Entity, RSVP) sind P7 und gehen erst raus, wenn ein
+     * Konsument sie mit Namen anfragt. Ein veroeffentlichter Kanal ist ein Vertrag,
+     * dessen Bruch beim Abonnenten lautlos ist.
+     *
+     * @return array<int, Channel>
+     */
+    public function broadcastOn(): array
+    {
+        $channels = [new Channel('portal')];
+
+        if ($this->payload['resource'] === 'meetup-event') {
+            $channels[] = new Channel('meetup-events');
+        }
+
+        return $channels;
+    }
+
+    /**
+     * Das Payload, unveraendert.
+     *
+     * Kein zweites Format: was hier rausgeht, ist byte-gleich zu dem, was
+     * {@see ChangeRecorder::broadcastPayload()} aus der `api_changes`-Zeile macht.
+     * Haette der Kanal eine eigene Gestalt, muesste ein Konsument nach einem
+     * Verbindungsabriss zwei Parser pflegen — und der Resync ueber `/api/changes` waere
+     * kein Resync, sondern eine Uebersetzung.
+     *
+     * @return array<string, mixed>
+     */
+    public function broadcastWith(): array
+    {
+        return $this->payload;
+    }
+}

--- a/app/Http/Controllers/Api/ChangeController.php
+++ b/app/Http/Controllers/Api/ChangeController.php
@@ -1,0 +1,223 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\IndexChangeRequest;
+use App\Http\Resources\ApiChangeResource;
+use App\Models\ApiChange;
+use Carbon\Carbon;
+use Carbon\CarbonInterface;
+use Dedoc\Scramble\Attributes\Group;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Facades\Log;
+
+#[Group(name: 'Realtime', weight: 6)]
+class ChangeController extends Controller
+{
+    /**
+     * Der Log-Kanal des Aufruf-Zaehlers, siehe {@see self::countRequest()}.
+     */
+    private const COUNTER_CHANNEL = 'api-changes';
+
+    /**
+     * List changes since a cursor
+     *
+     * Public change log of the six API resources (meetup, meetup-event, city, course,
+     * course-event, lecturer). Every entry carries the complete object, so nothing has
+     * to be fetched afterwards — including deletions, which are invisible anywhere else
+     * because no resource uses soft deletes.
+     *
+     * Unlike the other read endpoints, which return a bare array, this one wraps the
+     * list in an object: the cursor has to travel with it. `changes` holds the entries
+     * in ascending `sequence` order, `next_since` is the cursor to send on the next
+     * call, and `has_more` says whether the page was cut off by `limit`. Poll until
+     * `has_more` is false, then keep polling with the last `next_since`.
+     *
+     * Without `since` the newest `limit` entries are returned (`has_more` is then
+     * false) so a new consumer can pick up a starting cursor without reading the whole
+     * table.
+     *
+     * `cursor_expired` is the one field you must not ignore. The log is pruned after 30
+     * days, so a cursor older than the oldest entry still on file cannot be resumed:
+     * changes — deletions above all — happened that this endpoint can no longer hand
+     * out. The field is `true` exactly then, and `false` in every other answer,
+     * including when no cursor was sent at all, so it can be read without checking
+     * whether it is present. On `true`, do a full read of the regular endpoints and
+     * then continue from the `next_since` of this very answer. Without the field an
+     * expired cursor would return an empty list — indistinguishable from "nothing
+     * changed", and the consumer would keep a stale cache believing it is current.
+     *
+     * @return array{changes: list<array<string, mixed>>, next_since: int|null, has_more: bool, cursor_expired: bool}
+     */
+    public function index(IndexChangeRequest $request): array
+    {
+        /*
+         * Abweichung von den Nachbar-Controllern, mit Absicht: die Query-Parameter
+         * sind hier NICHT per #[QueryParameter] beschrieben, sondern als Kommentar
+         * ueber der jeweiligen Regel in {@see IndexChangeRequest::rules()}. Scramble
+         * leitet die Parameter aus dem Form Request ab, sobald es einen gibt, und
+         * ueberschreibt die Attribute dabei stillschweigend — gemessen: mit beidem
+         * zugleich stand `since` ohne Beschreibung im Dokument. Die Nachbarn haben
+         * keinen Form Request, dort greifen die Attribute.
+         */
+        $limit = $request->limit();
+        $sequence = $request->cursorSequence();
+        $timestamp = $request->cursorTimestamp();
+        $resources = $request->resourceFilter();
+
+        $query = ApiChange::query()
+            // Ausdrueckliche Spaltenliste statt select('*'): ausgegeben wird nur
+            // `payload`, und `id` ist der Cursor. Die uebrigen Spalten sind
+            // Filterkriterien und muessen dafuer nicht mitgelesen werden.
+            ->select('id', 'payload')
+            ->when(
+                $resources !== [],
+                fn (Builder $query) => $query->whereIn('resource', $resources),
+            );
+
+        if ($sequence !== null) {
+            // Exklusiv: der Konsument hat die Zeile mit genau dieser Sequenz schon.
+            $query->where('id', '>', $sequence);
+        } elseif ($timestamp !== null) {
+            $query->where('occurred_at', '>', $timestamp);
+        }
+
+        if ($sequence !== null || $timestamp !== null) {
+            /*
+             * limit + 1 gelesen, limit ausgegeben: `has_more` steht damit fest, ohne
+             * eine zweite COUNT-Query ueber eine Tabelle, die im Betrieb waechst.
+             */
+            $rows = $query->orderBy('id')->limit($limit + 1)->get();
+            $hasMore = $rows->count() > $limit;
+            $rows = $rows->take($limit)->values();
+        } else {
+            /*
+             * Ohne Cursor NICHT die ganze Tabelle: ein Neueinsteiger will nicht 30 Tage
+             * Historie, er will einen Startpunkt. Also die juengsten `limit` Zeilen —
+             * absteigend gelesen, aufsteigend ausgegeben, damit die Sortierung der
+             * Antwort dieselbe ist wie in jedem anderen Fall. `has_more` ist hier
+             * immer false: jenseits der juengsten Zeile gibt es nichts mehr, und was
+             * davor liegt, holt der Aufrufer nicht mit demselben Vorwaertscursor.
+             */
+            $rows = $query->orderByDesc('id')->limit($limit)->get()->reverse()->values();
+            $hasMore = false;
+        }
+
+        $this->countRequest($request, $rows->count());
+
+        return [
+            'changes' => ApiChangeResource::collection($rows)
+                /*
+                 * ->resolve() wie in den uebrigen Controllern: ::collection() haengt
+                 * sonst einen "data"-Schluessel um die Liste, und der waere hier
+                 * doppelt irrefuehrend — jeder EINTRAG traegt bereits ein eigenes
+                 * `data`-Feld mit dem Objekt.
+                 */
+                ->resolve(),
+            /*
+             * Der Cursor fuer den naechsten Aufruf. Bei einer leeren Seite bleibt die
+             * mitgeschickte Sequenz stehen, statt auf null zu fallen — sonst spulte
+             * ein Konsument, der einmal nichts vorfindet, an den Anfang zurueck.
+             */
+            'next_since' => $rows->last()?->id ?? $sequence,
+            'has_more' => $hasMore,
+            'cursor_expired' => $this->cursorExpired($sequence, $timestamp),
+        ];
+    }
+
+    /**
+     * Der Aufruf-Zaehler (Plan-Schritt 8).
+     *
+     * Die nginx-Konfig der Produktions-Site hat `access_log off`; ohne diese Zeile
+     * gibt es keine Spur eines Aufrufs, und P3 ("14 Tage messen, dann entscheiden, ob
+     * Reverb gebaut wird") haette keine Zahl. Bewusst ein Log-Eintrag und KEIN
+     * Datenbank-Schreibvorgang: der Endpunkt wird gepollt, ein INSERT je Poll erzeugte
+     * genau die Schreiblast, die hier gemessen werden soll.
+     *
+     * Bewusst ein eigener Kanal mit fest verdrahtetem Level `info` statt des
+     * Default-Stacks: steht `LOG_LEVEL` auf Produktion auf `error`, faellt ein
+     * `Log::info` still aus — die Messung waere weg und ihr Fehlen unsichtbar.
+     */
+    private function countRequest(IndexChangeRequest $request, int $returned): void
+    {
+        Log::channel(self::COUNTER_CHANNEL)->info('api-changes.request', [
+            'since' => $request->input('since'),
+            'resource' => $request->resourceFilter(),
+            'limit' => $request->limit(),
+            'returned' => $returned,
+            'client' => self::clientFingerprint($request->ip()),
+            // Gekuerzt: der Wert dient dazu, Konsumenten auseinanderzuhalten, nicht
+            // dazu, beliebig lange Header in die Logdatei zu schreiben. Anders als die
+            // IP ist er keine Angabe ueber eine Person, sondern ueber ein Programm.
+            'user_agent' => mb_substr((string) $request->userAgent(), 0, 200),
+        ]);
+    }
+
+    /**
+     * Ein stabiles Pseudonym des Aufrufers — keine IP im Klartext.
+     *
+     * P3 fragt "wie viele verschiedene Konsumenten rufen ab und wie oft", nicht "wer".
+     * Fuer die erste Frage genuegt ein Wert, der ueber Wochen derselbe bleibt und zwei
+     * Aufrufer unterscheidbar macht; die zweite beantwortet diese Site bewusst nicht —
+     * ihre nginx-Konfig hat `access_log off`, und ein eigener Zaehler waere ein
+     * schlechter Anlass, das zurueckzunehmen.
+     *
+     * HMAC mit `app.key` und nicht ein blankes `hash()`: der IPv4-Raum hat rund vier
+     * Milliarden Adressen und ist damit in Minuten durchprobiert. Ein ungeschluesselter
+     * Hash waere ruecktauschbar und damit dieselbe Angabe in unleserlich. Auf 12
+     * Zeichen gekuerzt: das unterscheidet Konsumenten (P3 erwartet eine einstellige
+     * Zahl davon) und laesst nichts mehr rekonstruieren.
+     */
+    private static function clientFingerprint(?string $ip): ?string
+    {
+        if ($ip === null || $ip === '') {
+            return null;
+        }
+
+        return substr(hash_hmac('sha256', $ip, (string) config('app.key')), 0, 12);
+    }
+
+    /**
+     * Ist der mitgeschickte Cursor aelter als alles, was noch im Log steht?
+     *
+     * Dann fehlen dem Konsumenten Aenderungen, die der Prune-Lauf abgeraeumt hat, und
+     * er MUSS das erfahren: ohne diese Antwort saehe der Fall aus wie "es hat sich
+     * nichts geaendert" — und weil kein Model SoftDeletes nutzt, waeren gerade die
+     * Loeschungen die Eintraege, von denen er nie erfaehrt.
+     *
+     * Bewusst KEIN 410: der Request ist nicht falsch, die Antwort ist unvollstaendig.
+     * Ein Statuscode-Wechsel traefe bestehende Clients haerter als ein Feld, das sie
+     * heute noch ignorieren duerfen.
+     *
+     * Die Grenze ist bewusst streng gezogen (`<` gegen das aelteste vorhandene
+     * Element): ist die Zeile, deren Sequenz der Konsument mitschickt, selbst schon
+     * geprunt, meldet das Feld `true`, auch wenn zwischen ihr und der aeltesten
+     * verbliebenen Zeile zufaellig nichts lag. Der Preis dafuer ist ein
+     * ueberfluessiger Vollabgleich, der Preis der umgekehrten Ungenauigkeit waere ein
+     * stiller Datenverlust — und der ist die Fehlerklasse, gegen die dieses Feld
+     * ueberhaupt gebaut ist.
+     *
+     * Die Aggregatabfrage laeuft nur, wenn ueberhaupt ein Cursor kam, und trifft den
+     * Index auf `id` bzw. `occurred_at`. Sie ist NICHT nach `resource` gefiltert: der
+     * Cursor ist global, und geprunt wird nach Alter — was vor dem aeltesten Eintrag
+     * liegt, ist fuer jede Ressource weg.
+     */
+    private function cursorExpired(?int $sequence, ?CarbonInterface $timestamp): bool
+    {
+        if ($sequence !== null) {
+            $oldest = ApiChange::query()->min('id');
+
+            // Leeres Log: es ist nichts abgelaufen, es ist nur nichts da.
+            return $oldest !== null && $sequence < (int) $oldest;
+        }
+
+        if ($timestamp !== null) {
+            $oldest = ApiChange::query()->min('occurred_at');
+
+            return $oldest !== null && $timestamp->lt(Carbon::parse($oldest));
+        }
+
+        return false;
+    }
+}

--- a/app/Http/Requests/Api/IndexChangeRequest.php
+++ b/app/Http/Requests/Api/IndexChangeRequest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace App\Http\Requests\Api;
+
+use App\Support\Broadcasting\ChangeRecorder;
+use Carbon\CarbonImmutable;
+use Carbon\Exceptions\InvalidFormatException;
+use Closure;
+use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
+
+/**
+ * Reads the change log of the public API (`GET /api/changes`).
+ *
+ * The cursor accepts two shapes on purpose: a numeric `sequence` (the row id, the
+ * exact and gap-free cursor) and an ISO-8601 timestamp (the entry point for a
+ * consumer who only knows when it last synced). Anything else is a validation error
+ * rather than a silently empty page.
+ */
+class IndexChangeRequest extends FormRequest
+{
+    /**
+     * Der Vorgabewert von `limit`, wenn der Aufrufer keinen mitschickt.
+     */
+    public const DEFAULT_LIMIT = 100;
+
+    /**
+     * Die Obergrenze von `limit`. Ueber 1000 Zeilen je Antwort waere das Payload
+     * (jede Zeile traegt ein vollstaendiges Objekt) mehrere Megabyte gross.
+     */
+    public const MAX_LIMIT = 1000;
+
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * `?resource=city,meetup` und `?resource[]=city&resource[]=meetup` sollen
+     * dasselbe bedeuten — die Komma-Form ist die, die ein Mensch von Hand tippt.
+     */
+    protected function prepareForValidation(): void
+    {
+        if (! $this->has('resource')) {
+            return;
+        }
+
+        $resource = $this->input('resource');
+
+        if (! is_string($resource)) {
+            return;
+        }
+
+        $this->merge([
+            'resource' => array_values(array_filter(
+                array_map('trim', explode(',', $resource)),
+                static fn (string $value): bool => $value !== '',
+            )),
+        ]);
+    }
+
+    /**
+     * @return array<string, array<int, mixed>>
+     */
+    public function rules(): array
+    {
+        return [
+            /** Cursor: either a sequence number (exclusive — returns everything after it) or an ISO-8601 timestamp (returns everything that occurred after it). Omit it to receive the newest entries. */
+            'since' => ['nullable', 'string', $this->cursorRule()],
+            'resource' => ['sometimes', 'array'],
+            /** Restrict to one or more resources. Repeatable (resource[]=city&resource[]=meetup) or comma separated (resource=city,meetup). */
+            'resource.*' => ['string', Rule::in(ChangeRecorder::resourceNames())],
+            /** Maximum number of entries per page. Defaults to 100. */
+            'limit' => ['nullable', 'integer', 'min:1', 'max:'.self::MAX_LIMIT],
+        ];
+    }
+
+    /**
+     * Der Cursor als Sequenz, oder null, wenn keine oder eine Zeit-Angabe kam.
+     */
+    public function cursorSequence(): ?int
+    {
+        $since = $this->input('since');
+
+        if ($since === null || ! is_numeric($since)) {
+            return null;
+        }
+
+        return (int) $since;
+    }
+
+    /**
+     * Der Cursor als Zeitpunkt, oder null, wenn keine oder eine Sequenz kam.
+     *
+     * Umgerechnet auf die App-Zeitzone: `occurred_at` steht so in der Spalte, und ein
+     * Vergleich gegen einen Wert mit fremdem Offset laege sonst um Stunden daneben.
+     */
+    public function cursorTimestamp(): ?CarbonImmutable
+    {
+        $since = $this->input('since');
+
+        if ($since === null || is_numeric($since)) {
+            return null;
+        }
+
+        return CarbonImmutable::parse((string) $since)->setTimezone(config('app.timezone'));
+    }
+
+    /**
+     * Die gewaehlten Ressourcen-Namen; ein leeres Array heisst "alle".
+     *
+     * @return array<int, string>
+     */
+    public function resourceFilter(): array
+    {
+        $resource = $this->input('resource', []);
+
+        return array_values(array_unique(is_array($resource) ? $resource : [$resource]));
+    }
+
+    public function limit(): int
+    {
+        $limit = $this->input('limit');
+
+        return $limit === null ? self::DEFAULT_LIMIT : (int) $limit;
+    }
+
+    /**
+     * `since` ist entweder eine Sequenz oder ein Zeitpunkt — beides wird hier
+     * geprueft, damit der Controller die Unterscheidung nur noch treffen muss.
+     */
+    private function cursorRule(): Closure
+    {
+        return static function (string $attribute, mixed $value, Closure $fail): void {
+            if (is_numeric($value)) {
+                if ((float) $value < 0 || (float) $value !== floor((float) $value)) {
+                    $fail('The :attribute cursor must be a non-negative sequence number.');
+                }
+
+                return;
+            }
+
+            try {
+                CarbonImmutable::parse((string) $value);
+            } catch (InvalidFormatException) {
+                $fail('The :attribute cursor must be a sequence number or an ISO-8601 timestamp.');
+            }
+        };
+    }
+}

--- a/app/Http/Resources/ApiChangeResource.php
+++ b/app/Http/Resources/ApiChangeResource.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Http\Resources;
+
+use App\Models\ApiChange;
+use App\Support\Broadcasting\ChangeRecorder;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * One recorded change, exactly as it was stored.
+ *
+ * @property-read ApiChange $resource
+ */
+class ApiChangeResource extends JsonResource
+{
+    /**
+     * Gibt das gespeicherte Envelope 1:1 zurueck.
+     *
+     * KEINE zweite Gestalt, keine Umsortierung, kein nachtraeglich gefuelltes Feld:
+     * das Payload wurde genau einmal gebaut ({@see ChangeRecorder::record()}), und
+     * ein Konsument, der einen verpassten Eintrag hier nachholt, muss byte-gleich
+     * dasselbe sehen wie der, der ihn ab P4 ueber den Kanal bekommen hat. Baute diese
+     * Klasse das Envelope aus den Spalten neu zusammen, waeren es zwei Formate, die
+     * sich nur so lange gleichen, wie jemand beide zugleich pflegt — und die
+     * Abweichung faellt beim Konsumenten auf, nicht hier.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return $this->resource->payload;
+    }
+}

--- a/app/Models/ApiChange.php
+++ b/app/Models/ApiChange.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace App\Models;
+
+use App\Support\Broadcasting\ChangeRecorder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Carbon;
+
+/**
+ * Eine aufgezeichnete Aenderung an einer oeffentlichen API-Ressource (Issue #29).
+ *
+ * Geschrieben wird ausschliesslich vom {@see ChangeRecorder}; dieses Model ist der
+ * Lesezugriff darauf. `id` ist zugleich der `sequence`-Cursor, den ein Konsument nach
+ * einem Verbindungsabriss mitschickt.
+ *
+ * Die Zeile traegt IMMER das vollstaendige Payload. Was ueber einen WebSocket gehen
+ * darf, ist eine andere Frage — die beantwortet {@see self::broadcastPayload()}.
+ *
+ * @property int $id
+ * @property string $resource
+ * @property int $resource_id
+ * @property string $action
+ * @property string|null $country_code
+ * @property int|null $city_id
+ * @property array<string, mixed> $payload
+ * @property Carbon $occurred_at
+ */
+class ApiChange extends Model
+{
+    use HasFactory;
+
+    /**
+     * Die Tabelle hat bewusst keine created_at/updated_at-Spalten: eine Zeile im
+     * Aenderungs-Log wird nie geaendert, und `occurred_at` ist der einzige Zeitpunkt,
+     * der etwas bedeutet.
+     */
+    public $timestamps = false;
+
+    /**
+     * @var array<int, string>
+     */
+    protected $fillable = [
+        'resource',
+        'resource_id',
+        'action',
+        'country_code',
+        'city_id',
+        'payload',
+        'occurred_at',
+    ];
+
+    /**
+     * @return array<string, string>
+     */
+    protected function casts(): array
+    {
+        return [
+            'id' => 'integer',
+            'resource_id' => 'integer',
+            'city_id' => 'integer',
+            'payload' => 'array',
+            'occurred_at' => 'datetime',
+        ];
+    }
+
+    /**
+     * Das Payload in der Gestalt, in der es ueber einen WebSocket gehen darf.
+     *
+     * Ab P4 liest der Broadcast genau diese Methode. In P1 existiert sie, damit die
+     * 10-KB-Kuerzung getestet ist, bevor der erste Kanal steht — der Fallback, der erst
+     * in Produktion das erste Mal laeuft, ist der, der dort nicht laeuft.
+     *
+     * @return array<string, mixed>
+     */
+    public function broadcastPayload(): array
+    {
+        return ChangeRecorder::broadcastPayload($this->payload);
+    }
+}

--- a/app/Models/City.php
+++ b/app/Models/City.php
@@ -5,6 +5,8 @@ namespace App\Models;
 use Akuechler\Geoly;
 use App\Models\Concerns\HasOsmReference;
 use App\Models\Concerns\SetsCreatedBy;
+use App\Observers\ApiChangeObserver;
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -13,6 +15,7 @@ use Illuminate\Database\UniqueConstraintViolationException;
 use Spatie\Sluggable\HasSlug;
 use Spatie\Sluggable\SlugOptions;
 
+#[ObservedBy([ApiChangeObserver::class])]
 class City extends Model
 {
     use Geoly;

--- a/app/Models/Course.php
+++ b/app/Models/Course.php
@@ -3,6 +3,8 @@
 namespace App\Models;
 
 use App\Models\Concerns\SetsCreatedBy;
+use App\Observers\ApiChangeObserver;
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -14,6 +16,7 @@ use Spatie\MediaLibrary\InteractsWithMedia;
 use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use Spatie\Tags\HasTags;
 
+#[ObservedBy([ApiChangeObserver::class])]
 class Course extends Model implements HasMedia
 {
     use HasFactory;

--- a/app/Models/CourseEvent.php
+++ b/app/Models/CourseEvent.php
@@ -3,12 +3,15 @@
 namespace App\Models;
 
 use App\Models\Concerns\SetsCreatedBy;
+use App\Observers\ApiChangeObserver;
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Spatie\Tags\HasTags;
 
+#[ObservedBy([ApiChangeObserver::class])]
 class CourseEvent extends Model
 {
     use HasFactory;

--- a/app/Models/Lecturer.php
+++ b/app/Models/Lecturer.php
@@ -3,6 +3,8 @@
 namespace App\Models;
 
 use App\Models\Concerns\SetsCreatedBy;
+use App\Observers\ApiChangeObserver;
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -15,6 +17,7 @@ use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use Spatie\Sluggable\HasSlug;
 use Spatie\Sluggable\SlugOptions;
 
+#[ObservedBy([ApiChangeObserver::class])]
 class Lecturer extends Model implements HasMedia
 {
     use HasFactory;

--- a/app/Models/Meetup.php
+++ b/app/Models/Meetup.php
@@ -3,6 +3,9 @@
 namespace App\Models;
 
 use App\Models\Concerns\SetsCreatedBy;
+use App\Observers\ApiChangeObserver;
+use App\Support\Broadcasting\ChangeRecorder;
+use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Casts\Attribute;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
@@ -19,6 +22,7 @@ use Spatie\MediaLibrary\MediaCollections\Models\Media;
 use Spatie\Sluggable\HasSlug;
 use Spatie\Sluggable\SlugOptions;
 
+#[ObservedBy([ApiChangeObserver::class])]
 class Meetup extends Model implements HasMedia
 {
     use HasFactory;
@@ -437,6 +441,28 @@ class Meetup extends Model implements HasMedia
         $this->forceFill([
             'is_active' => $isActive,
             'last_event_at' => $lastEventAt,
-        ])->saveQuietly();
+        ]);
+
+        /*
+         * Der Aktivitaetswechsel muss von Hand gemeldet werden (Issue #29).
+         *
+         * `saveQuietly()` unterdrueckt jedes Model-Event, also auch das `updated`, an
+         * dem der ApiChangeObserver haengt. `is_active` und `last_event_at` stehen aber
+         * beide im MeetupResource und aendern sich naechtlich fuer viele Meetups —
+         * ohne diesen Aufruf veraltet jeder Listen-Cache still an genau diesen zwei
+         * Feldern, ohne Fehler und ohne dass es jemandem auffiele.
+         *
+         * `isDirty()` wird VOR dem Speichern gefragt: danach sind die neuen Werte die
+         * originalen und der Vergleich waere immer falsch. Damit erzeugt ein Lauf, der
+         * nichts aendert — der Normalfall des naechtlichen Commands ueber alle Meetups —
+         * auch keine Zeile.
+         */
+        $activityChanged = $this->isDirty(['is_active', 'last_event_at']);
+
+        $this->saveQuietly();
+
+        if ($activityChanged) {
+            ChangeRecorder::record($this, 'updated');
+        }
     }
 }

--- a/app/Models/MeetupEvent.php
+++ b/app/Models/MeetupEvent.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use App\Enums\RecurrenceType;
 use App\Enums\RsvpStatus;
 use App\Models\Concerns\SetsCreatedBy;
+use App\Observers\ApiChangeObserver;
 use App\Observers\MeetupEventObserver;
 use Illuminate\Database\Eloquent\Attributes\ObservedBy;
 use Illuminate\Database\Eloquent\Builder;
@@ -14,7 +15,7 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Collection;
 use Spatie\Tags\HasTags;
 
-#[ObservedBy([MeetupEventObserver::class])]
+#[ObservedBy([MeetupEventObserver::class, ApiChangeObserver::class])]
 class MeetupEvent extends Model
 {
     use HasFactory;

--- a/app/Observers/ApiChangeObserver.php
+++ b/app/Observers/ApiChangeObserver.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace App\Observers;
+
+use App\Models\MeetupEvent;
+use App\Support\Broadcasting\ChangeRecorder;
+use Illuminate\Database\Eloquent\Model;
+
+/**
+ * Haengt das Aenderungs-Log (Issue #29) an die sechs API-Ressourcen.
+ *
+ * WARUM EIN OBSERVER UND KEIN TRAIT: Geschrieben wird auf vier Wegen — die
+ * API-Controller unter `app/Http/Controllers/Api/`, die MCP-Tools unter
+ * `app/Mcp/Tools/`, die Livewire-Volt-Views unter `resources/views/livewire/` und die
+ * Artisan-Commands unter `app/Console/Commands/`. Ein Hook an einem dieser Wege haette
+ * die anderen drei stillschweigend uebersprungen; nur das Model-Event sieht alle vier.
+ * Zwischen Trait und Observer entscheidet die Hausordnung: Lebenszyklus-Reaktionen
+ * liegen hier in `app/Observers/` und werden per `#[ObservedBy]` am Model registriert
+ * ({@see MeetupEventObserver}, {@see MeetupEvent}). Die beiden Traits unter
+ * `app/Models/Concerns/` sind etwas anderes: `HasOsmReference` liefert Accessoren,
+ * `SetsCreatedBy` fuellt ein eigenes Feld des Models. Hier wird nichts am Model
+ * gefuellt, sondern woanders etwas notiert — das ist ein Beobachter.
+ *
+ * Ein Observer statt sechs: die Ressourcen-Zuordnung steht ohnehin schon zentral in
+ * {@see ChangeRecorder}, und sechs identische Klassen waeren sechs Orte, an denen eine
+ * kuenftige Aenderung vergessen werden kann.
+ *
+ * `MeetupEvent` traegt diesen Observer ZUSAETZLICH zu {@see MeetupEventObserver}; die
+ * beiden beruehren sich nicht.
+ *
+ * NICHT abgedeckt — bewusst, weil kein Model-Event feuert:
+ *  - `Meetup::recalculateActivity()` endet auf `saveQuietly()`. Deshalb ruft die
+ *    Methode den Recorder selbst auf.
+ *  - Query-Builder-Updates, etwa `MergeUserAccounts`. Dort aendern sich nur interne
+ *    `created_by`-Zeiger; im Plan als hingenommene Luecke festgehalten.
+ */
+class ApiChangeObserver
+{
+    public function created(Model $model): void
+    {
+        ChangeRecorder::record($model, 'created');
+    }
+
+    public function updated(Model $model): void
+    {
+        ChangeRecorder::record($model, 'updated');
+    }
+
+    public function deleted(Model $model): void
+    {
+        ChangeRecorder::record($model, 'deleted');
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,10 @@
 namespace App\Providers;
 
 use App\Support\Carbon;
+use Dedoc\Scramble\DocumentTransformers\AddDocumentTags;
+use Dedoc\Scramble\Scramble;
+use Dedoc\Scramble\Support\Generator\OpenApi;
+use Dedoc\Scramble\Support\Generator\Tag;
 use Illuminate\Cache\RateLimiting\Limit;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Database\Eloquent\Model;
@@ -41,6 +45,8 @@ class AppServiceProvider extends ServiceProvider
 
         Gate::define('viewApiDocs', fn (?Authenticatable $user = null): bool => true);
 
+        $this->documentWebSocketChannels();
+
         // OAuth-2.1-Flow des MCP-Servers (Claude.ai Web-Connector).
         Passport::authorizationView(fn ($parameters) => view('mcp.authorize', $parameters));
 
@@ -68,6 +74,42 @@ class AppServiceProvider extends ServiceProvider
         });
 
         Model::preventLazyLoading(app()->environment('local'));
+    }
+
+    /**
+     * Traegt die WebSocket-Kanaele als eigenen Tag in die OpenAPI-Beschreibung ein.
+     *
+     * Die Kanaele sind keine Laravel-Routen, Scramble kann sie also nicht generieren —
+     * und ein `webhooks`-Objekt gibt der Generator nicht her ({@see OpenApi::toArray()}
+     * schreibt sechs feste Schluessel). Der Tag ist deshalb der einzige Weg, in der
+     * Referenz selbst auf /docs/websockets zu zeigen, statt nur in der Einleitung.
+     *
+     * BEWUSST ueber `afterOpenApiGenerated()` und NICHT ueber `Scramble::configure()`
+     * mit `->expose(...)`: ein String-Argument an `expose()` ueberschreibt die
+     * Routen-Registrierung und loescht dabei die Routennamen `scramble.docs.ui` und
+     * `scramble.docs.document`, auf die `tests/Feature/Api/ApiDocsAccessTest.php`
+     * baut. `afterOpenApiGenerated()` haengt lediglich einen Document-Transformer
+     * hinten an die Liste — hinten, damit er nach {@see AddDocumentTags}
+     * laeuft, das `$document->tags` komplett neu setzt und ein frueher angehaengtes
+     * Element wieder verwerfen wuerde.
+     */
+    protected function documentWebSocketChannels(): void
+    {
+        Scramble::afterOpenApiGenerated(function (OpenApi $document): void {
+            $document->tags[] = new Tag(
+                'WebSockets',
+                <<<'MARKDOWN'
+                Two public WebSocket channels — `portal` (every change of every resource) and
+                `meetup-events` (meetup dates only) — carry the same envelope as
+                `GET /api/changes`, within milliseconds and without authentication.
+
+                They are not HTTP routes, so they have no operations in this document.
+                Channel names, event names, the payload contract, a working TypeScript client
+                and the accepted gaps are documented at
+                [/docs/websockets](/docs/websockets).
+                MARKDOWN
+            );
+        });
     }
 
     /**

--- a/app/Support/Broadcasting/ChangeRecorder.php
+++ b/app/Support/Broadcasting/ChangeRecorder.php
@@ -1,0 +1,396 @@
+<?php
+
+namespace App\Support\Broadcasting;
+
+use App\Http\Resources\CityResource;
+use App\Http\Resources\CourseEventResource;
+use App\Http\Resources\CourseResource;
+use App\Http\Resources\LecturerResource;
+use App\Http\Resources\MeetupEventResource;
+use App\Http\Resources\MeetupResource;
+use App\Models\ApiChange;
+use App\Models\City;
+use App\Models\Course;
+use App\Models\CourseEvent;
+use App\Models\Lecturer;
+use App\Models\Meetup;
+use App\Models\MeetupEvent;
+use Closure;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Facades\Route;
+
+/**
+ * Die einzige Stelle, an der ein Aenderungs-Payload entsteht (Issue #29).
+ *
+ * Der Recorder laeuft SYNCHRON im Observer, im selben Request wie das Schreiben. Das
+ * ist keine Bequemlichkeit, sondern die Bedingung dafuer, dass der Vertrag haelt:
+ *
+ *  - Ein `deleted` traegt ein Array, niemals ein Model. Laravels Broadcast-Job setzt
+ *    `deleteWhenMissingModels = true`; ein Event, das ein geloeschtes Model in die
+ *    Queue traegt, wird beim Ausfuehren still verworfen — kein Fehler, kein
+ *    `failed_jobs`-Eintrag. Kein Model nutzt SoftDeletes, der Datensatz ist wirklich weg.
+ *  - Ein `updated`-Payload ist der Stand ZUM ZEITPUNKT der Aenderung, nicht der Stand
+ *    zur Sendezeit. Ein Job, der das Model nachlaedt, liefert bei zehn parallelen
+ *    Horizon-Prozessen Payloads in falscher Reihenfolge.
+ *  - `sequence` steht fest, bevor irgendetwas dispatcht wird.
+ *
+ * In P1 wird nur die Zeile geschrieben. Der Dispatch kommt in P4 an die markierte
+ * Stelle in {@see self::record()} und liest {@see ApiChange::broadcastPayload()}.
+ */
+class ChangeRecorder
+{
+    /**
+     * Reverb weist Requests ueber `max_request_size` (Default 10 000 Bytes) mit HTTP 413
+     * ab. Ueber der Grenze geht das Event ohne `data` raus; die `api_changes`-Zeile
+     * behaelt das vollstaendige Objekt und der Konsument holt es ueber /api/changes.
+     */
+    public const MAX_BROADCAST_BYTES = 10000;
+
+    /**
+     * DIE KANONISCHE RELATIONSGESTALT — der Vertrag zum externen Konsumenten.
+     *
+     * Eine `JsonResource` hat in diesem Projekt mehrere Gestalten: `MeetupEventResource`
+     * liefert `tags` nur bei geladener Relation, `MeetupResource` liefert `is_leader` nur
+     * bei geladenem `meetup_user`-Pivot. Welche Gestalt im Log landet, ist deshalb eine
+     * Entscheidung und keine Nebenwirkung — ohne sie ist "das Payload ist gleich der
+     * Resource" nicht pruefbar, weil beide Seiten wahr waeren.
+     *
+     * Die Regeln, nach denen `relations` gefuellt ist:
+     *
+     *  - `tags` JA. Sie gehoeren fachlich zum Termin, sind oeffentlich, und ein
+     *    Konsument, der sie aus dem Payload nicht sieht, muesste jede Aenderung
+     *    nachladen — genau das soll das Log ersparen.
+     *  - Nachbar-Objekte (`course`, `city` am CourseEvent) JA. Sie liefern nur `id` und
+     *    `name` und stehen so auch in `GET /api/course-events`.
+     *  - `media` JA, obwohl es die Ausgabe nicht veraendert: `getFirstMediaUrl()` laedt
+     *    die Relation sonst lazy nach, einmal pro Schreibvorgang.
+     *  - Pivot- und Auth-abhaengige Felder NEIN. `is_leader` beantwortet die Frage "darf
+     *    DIESER Token-Inhaber das bearbeiten" — auf einem oeffentlichen Kanal gibt es
+     *    kein "dieser", die Antwort waere sinnlos und irrefuehrend zugleich.
+     *  - `country` am City NEIN. `CityResource` gibt es nicht aus; die Relation nur zu
+     *    laden, um `api_changes.country_code` zu fuellen, waere eine zusaetzliche Query
+     *    pro Schreibvorgang fuer eine Spalte, die erst P7 liest.
+     *
+     * `self_route` ist der Name der `show`-Route, falls es sie gibt. Heute haben nur
+     * `courses` und `lecturers` eine — fuer die uebrigen vier ist `links.self` null,
+     * statt eine URL zuzusagen, die 404 liefert. Sobald P2 /api/changes und spaeter die
+     * fehlenden show-Endpunkte liefert, gehoert der Routenname hier hinein.
+     *
+     * `previous` sind die Identifikatoren, die ein `deleted` mitgibt: der Schluessel zum
+     * gezielten Cache-Invalidieren, wenn das Objekt selbst nicht mehr existiert.
+     * `courses` hat keine Slug-Spalte, `meetup_events` auch nicht.
+     *
+     * @var array<class-string<Model>, array{
+     *     name: string,
+     *     resource: class-string<JsonResource>,
+     *     relations: array<int, string>,
+     *     self_route: string|null,
+     *     previous: array<int, string>,
+     *     city_id: string|null,
+     * }>
+     */
+    private const RESOURCES = [
+        Meetup::class => [
+            'name' => 'meetup',
+            'resource' => MeetupResource::class,
+            'relations' => ['media'],
+            'self_route' => null,
+            'previous' => ['slug', 'city_id'],
+            'city_id' => 'city_id',
+        ],
+        MeetupEvent::class => [
+            'name' => 'meetup-event',
+            'resource' => MeetupEventResource::class,
+            'relations' => ['tags'],
+            'self_route' => null,
+            'previous' => ['meetup_id'],
+            'city_id' => null,
+        ],
+        City::class => [
+            'name' => 'city',
+            'resource' => CityResource::class,
+            'relations' => [],
+            'self_route' => null,
+            'previous' => ['slug', 'country_id'],
+            'city_id' => 'id',
+        ],
+        Course::class => [
+            'name' => 'course',
+            'resource' => CourseResource::class,
+            'relations' => ['media'],
+            'self_route' => 'api.courses.show',
+            'previous' => ['lecturer_id'],
+            'city_id' => null,
+        ],
+        CourseEvent::class => [
+            'name' => 'course-event',
+            'resource' => CourseEventResource::class,
+            'relations' => ['tags', 'course', 'city'],
+            'self_route' => null,
+            'previous' => ['course_id', 'city_id'],
+            'city_id' => 'city_id',
+        ],
+        Lecturer::class => [
+            'name' => 'lecturer',
+            'resource' => LecturerResource::class,
+            'relations' => ['media'],
+            'self_route' => 'api.lecturers.show',
+            'previous' => ['slug'],
+            'city_id' => null,
+        ],
+    ];
+
+    /**
+     * Blockweise Stummschaltung fuer Seeder und Import-Commands, siehe {@see self::muted()}.
+     */
+    private static bool $muted = false;
+
+    /**
+     * Zeichnet eine Aenderung auf und gibt die geschriebene Zeile zurueck.
+     *
+     * Gibt null zurueck, wenn das Log aus ist, der Block stummgeschaltet ist oder das
+     * Model gar keine API-Ressource hat.
+     *
+     * @param  'created'|'updated'|'deleted'  $action
+     */
+    public static function record(Model $model, string $action): ?ApiChange
+    {
+        if (! self::enabled()) {
+            return null;
+        }
+
+        $definition = self::RESOURCES[$model::class] ?? null;
+
+        if ($definition === null) {
+            return null;
+        }
+
+        $occurredAt = now();
+
+        $envelope = [
+            'action' => $action,
+            'resource' => $definition['name'],
+            'id' => (int) $model->getKey(),
+            // Wird nach dem Insert nachgetragen — die Sequenz IST die Zeilen-ID.
+            'sequence' => null,
+            'occurred_at' => $occurredAt->toIso8601String(),
+            'api_version' => (string) config('scramble.info.version'),
+            'data' => $action === 'deleted' ? null : self::data($model, $definition),
+            'links' => ['self' => self::selfLink($model, $definition)],
+        ];
+
+        if ($action === 'deleted') {
+            $envelope['previous'] = self::previous($model, $definition);
+        }
+
+        $change = ApiChange::create([
+            'resource' => $definition['name'],
+            'resource_id' => (int) $model->getKey(),
+            'action' => $action,
+            'country_code' => self::countryCode($model),
+            'city_id' => self::cityId($model, $definition),
+            'payload' => $envelope,
+            'occurred_at' => $occurredAt,
+        ]);
+
+        /*
+         * Zweiter Schreibvorgang, mit Absicht: `sequence` ist die Zeilen-ID und steht
+         * erst nach dem Insert fest. Die Alternative waere, sie beim Lesen aus `id`
+         * einzusetzen — dann laege im Payload-Feld etwas anderes als das, was der
+         * Konsument bekommt, und ein Blick per SQL in die Spalte wuerde ueber den
+         * Vertrag luegen. Ein UPDATE auf eine gerade geschriebene Zeile ist billiger
+         * als eine Tabelle, deren Inhalt man nicht beim Wort nehmen kann.
+         */
+        $envelope['sequence'] = $change->id;
+        $change->forceFill(['payload' => $envelope])->save();
+
+        /*
+         * P4 haengt hier den Dispatch an:
+         *
+         *     event(new ResourceChanged($change->broadcastPayload()));
+         *
+         * Nach dem Schreiben der Zeile, nicht davor — ein fehlgeschlagener Broadcast
+         * darf das Log nicht mitreissen, und mit `'tries' => 1` (config/horizon.php:225)
+         * ist die Zeile das einzige Netz darunter.
+         */
+
+        return $change;
+    }
+
+    /**
+     * Fuehrt einen Block aus, ohne Aenderungen aufzuzeichnen.
+     *
+     * Fuer Seeder und Import-Commands: ein `DatabaseSeeder`-Lauf erzeugt ueber 250
+     * Datensaetze, die niemand als "Aenderung" abonniert hat. `finally` stellt den
+     * vorherigen Zustand auch dann wieder her, wenn der Block wirft — sonst bliebe das
+     * Log nach einem abgebrochenen Import bis zum Prozessende stumm.
+     *
+     * @template TReturn
+     *
+     * @param  Closure(): TReturn  $callback
+     * @return TReturn
+     */
+    public static function muted(Closure $callback): mixed
+    {
+        $previous = self::$muted;
+        self::$muted = true;
+
+        try {
+            return $callback();
+        } finally {
+            self::$muted = $previous;
+        }
+    }
+
+    /**
+     * Ist das Aufzeichnen gerade scharf?
+     */
+    public static function enabled(): bool
+    {
+        return ! self::$muted && (bool) config('einundzwanzig.change_log.enabled', false);
+    }
+
+    /**
+     * Die Ressourcen-Namen, die im Aenderungs-Log ueberhaupt vorkommen koennen.
+     *
+     * Additiv fuer P2: `GET /api/changes?resource=` weist einen unbekannten Wert mit
+     * 422 ab statt mit einer leeren Liste. Die Liste dafuer wird hier gelesen und
+     * NICHT im Validator noch einmal hingeschrieben — sonst kaeme eine siebte
+     * Ressource im Log an, die der Endpunkt als Tippfehler zurueckweist, und der
+     * Fehler waere von aussen nicht von "es ist nichts passiert" zu unterscheiden.
+     *
+     * @return array<int, string>
+     */
+    public static function resourceNames(): array
+    {
+        return array_values(array_column(self::RESOURCES, 'name'));
+    }
+
+    /**
+     * Das Payload in der Gestalt, in der es ueber einen WebSocket gehen darf.
+     *
+     * Ueber {@see self::MAX_BROADCAST_BYTES} faellt `data` weg und `truncated` kommt
+     * dazu. Gemessen wird das VOLLSTAENDIGE Envelope, nicht nur `data` — Reverb misst
+     * den ganzen Request.
+     *
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    public static function broadcastPayload(array $payload): array
+    {
+        $encoded = json_encode($payload);
+
+        if ($encoded !== false && strlen($encoded) <= self::MAX_BROADCAST_BYTES) {
+            return $payload;
+        }
+
+        return [
+            ...$payload,
+            'data' => null,
+            'truncated' => true,
+        ];
+    }
+
+    /**
+     * Das Resource-Ergebnis als nacktes Array, ohne `data`-Wrapper.
+     *
+     * `resolve()` filtert die `MissingValue`-Platzhalter heraus, die `whenLoaded()` und
+     * `whenPivotLoaded()` hinterlassen. Der json-Roundtrip danach ist kein Umweg: er
+     * loest verschachtelte Resource-Collections und Carbon-Instanzen genau so auf, wie
+     * es die HTTP-Antwort tut. Ohne ihn laege in `payload` ein PHP-Objektgraph, der beim
+     * Serialisieren nochmal anders aussehen koennte als das, was der Konsument sieht.
+     *
+     * Gelesen wird ueber `fresh()`, nicht vom beobachteten Model. Das kostet eine Query
+     * und kauft dafuer zwei Dinge: die Relationen landen nicht ungefragt am Model des
+     * Aufrufers, und die Zeitstempel stimmen. Ein `created_at`, das Laravel gerade in
+     * Erinnerung hat, traegt Mikrosekunden; die Spalte in der Datenbank tut es nicht.
+     * Ohne `fresh()` haette dasselbe Objekt im Log eine andere Uhrzeit als in
+     * `GET /api/…` — genau die Sorte Abweichung, die ein Konsument als Aenderung liest.
+     * Alle Schreib-Endpunkte unter `app/Http/Controllers/Api/` antworten aus demselben
+     * Grund mit `->fresh()`.
+     *
+     * @param  array{relations: array<int, string>, resource: class-string<JsonResource>, ...}  $definition
+     * @return array<string, mixed>
+     */
+    private static function data(Model $model, array $definition): array
+    {
+        // Fallback auf eine Kopie, falls die Zeile zwischen Event und Lesen verschwunden
+        // ist. `load()` auf dem beobachteten Model selbst waere ein Nebeneffekt beim
+        // Aufrufer.
+        $subject = $model->fresh($definition['relations']) ?? (clone $model)->load($definition['relations']);
+
+        /** @var JsonResource $resource */
+        $resource = $definition['resource']::make($subject);
+
+        return json_decode(json_encode($resource->resolve(request())) ?: '{}', true);
+    }
+
+    /**
+     * Die letzten bekannten Identifikatoren eines geloeschten Datensatzes.
+     *
+     * @param  array{previous: array<int, string>, ...}  $definition
+     * @return array<string, mixed>
+     */
+    private static function previous(Model $model, array $definition): array
+    {
+        $previous = [];
+
+        foreach ($definition['previous'] as $attribute) {
+            $previous[$attribute] = $model->getAttribute($attribute);
+        }
+
+        return $previous;
+    }
+
+    /**
+     * @param  array{self_route: string|null, ...}  $definition
+     */
+    private static function selfLink(Model $model, array $definition): ?string
+    {
+        if ($definition['self_route'] === null || ! Route::has($definition['self_route'])) {
+            return null;
+        }
+
+        return route($definition['self_route'], $model->getKey());
+    }
+
+    /**
+     * @param  array{city_id: string|null, ...}  $definition
+     */
+    private static function cityId(Model $model, array $definition): ?int
+    {
+        if ($definition['city_id'] === null) {
+            return null;
+        }
+
+        $value = $model->getAttribute($definition['city_id']);
+
+        return $value === null ? null : (int) $value;
+    }
+
+    /**
+     * Der Laendercode, aber nur wenn er ohne eine zusaetzliche Query zu haben ist.
+     *
+     * Heute heisst das: praktisch nie. Erst wenn P7 die Geo-Kanaele baut und dafuer
+     * ohnehin `city.country` eager laedt, faellt der Wert nebenbei ab. Bis dahin ist
+     * null die ehrliche Antwort — eine Spalte zu fuellen, die niemand liest, ist keine
+     * Extra-Query je Schreibvorgang wert.
+     */
+    private static function countryCode(Model $model): ?string
+    {
+        if ($model->relationLoaded('country')) {
+            return $model->getRelation('country')?->code;
+        }
+
+        if ($model->relationLoaded('city')) {
+            $city = $model->getRelation('city');
+
+            if ($city !== null && $city->relationLoaded('country')) {
+                return $city->getRelation('country')?->code;
+            }
+        }
+
+        return null;
+    }
+}

--- a/app/Support/Broadcasting/ChangeRecorder.php
+++ b/app/Support/Broadcasting/ChangeRecorder.php
@@ -2,6 +2,7 @@
 
 namespace App\Support\Broadcasting;
 
+use App\Events\ResourceChanged;
 use App\Http\Resources\CityResource;
 use App\Http\Resources\CourseEventResource;
 use App\Http\Resources\CourseResource;
@@ -18,7 +19,9 @@ use App\Models\MeetupEvent;
 use Closure;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Route;
+use Throwable;
 
 /**
  * Die einzige Stelle, an der ein Aenderungs-Payload entsteht (Issue #29).
@@ -35,8 +38,10 @@ use Illuminate\Support\Facades\Route;
  *    Horizon-Prozessen Payloads in falscher Reihenfolge.
  *  - `sequence` steht fest, bevor irgendetwas dispatcht wird.
  *
- * In P1 wird nur die Zeile geschrieben. Der Dispatch kommt in P4 an die markierte
- * Stelle in {@see self::record()} und liest {@see ApiChange::broadcastPayload()}.
+ * {@see self::record()} schreibt die Zeile und dispatcht danach
+ * {@see ResourceChanged} mit {@see ApiChange::broadcastPayload()} — dem gekuerzten
+ * Versand-Umschlag. Der Recorder kennt dabei keine Kanaele: welcher Kanal welches
+ * Ereignis traegt, entscheidet das Event.
  */
 class ChangeRecorder
 {
@@ -206,14 +211,41 @@ class ChangeRecorder
         $change->forceFill(['payload' => $envelope])->save();
 
         /*
-         * P4 haengt hier den Dispatch an:
+         * Erst jetzt der Broadcast (P4), nach dem Schreiben der Zeile und nicht davor —
+         * ein fehlgeschlagener Broadcast darf das Log nicht mitreissen, und mit
+         * `'tries' => 1` (config/horizon.php:225) ist die Zeile das einzige Netz
+         * darunter. Ueber die Leitung geht die gekuerzte Variante: Reverb weist alles
+         * ueber `max_request_size` mit HTTP 413 ab, die Zeile behaelt das volle Objekt.
          *
-         *     event(new ResourceChanged($change->broadcastPayload()));
-         *
-         * Nach dem Schreiben der Zeile, nicht davor — ein fehlgeschlagener Broadcast
-         * darf das Log nicht mitreissen, und mit `'tries' => 1` (config/horizon.php:225)
-         * ist die Zeile das einzige Netz darunter.
+         * Der Kill-Switch oben deckt das mit ab: wer nicht aufzeichnet, sendet auch
+         * nicht — sonst gaebe es ein Ereignis auf dem Kanal, zu dem kein Resync-Eintrag
+         * existiert, und ein Konsument, der es verpasst, erfuehre nie davon.
          */
+        try {
+            event(new ResourceChanged($change->broadcastPayload()));
+        } catch (Throwable $e) {
+            /*
+             * "Darf das Log nicht mitreissen" ist woertlich gemeint, und es geht nicht
+             * nur um das Log: der Recorder laeuft im Observer, also mitten im
+             * Schreib-Request. Eine Ausnahme von hier schluege durch `save()` bis in
+             * den Controller durch — und liefe der Write in einer Transaktion, risse sie den
+             * fachlichen Datensatz gleich mit zurueck. Ein nicht erreichbarer Reverb
+             * (oder eine volle Queue) wuerde damit jedes Speichern im Portal
+             * verhindern. Das waere ein schlechterer Zustand als vor P4.
+             *
+             * Verloren ist dabei nichts, was nicht wiederholbar waere: die
+             * `api_changes`-Zeile steht bereits, `/api/changes` liefert sie aus, und
+             * genau dafuer ist sie da. Still ist es trotzdem nicht — der Log-Eintrag
+             * nennt die Sequenz, ueber die sich der Ausfall nachvollziehen laesst.
+             */
+            Log::warning('Broadcast der Aenderung fehlgeschlagen', [
+                'sequence' => $change->id,
+                'resource' => $change->resource,
+                'action' => $change->action,
+                'exception' => $e::class,
+                'message' => $e->getMessage(),
+            ]);
+        }
 
         return $change;
     }

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -22,6 +22,7 @@ return Application::configure(basePath: dirname(__DIR__))
         web: __DIR__.'/../routes/web.php',
         api: __DIR__.'/../routes/api.php',
         commands: __DIR__.'/../routes/console.php',
+        channels: __DIR__.'/../routes/channels.php',
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {

--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
         "laravel/mcp": "^0.9.0",
         "laravel/nightwatch": "^1.18",
         "laravel/passport": "^13.7",
+        "laravel/reverb": "^1.11",
         "laravel/sanctum": "^4.0",
         "laravel/tinker": "^3.0",
         "league/glide": "^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5767d3863727cca4b88dc2993761de9b",
+    "content-hash": "1cf8f2bfd9b62be950334ce5ab66ed54",
     "packages": [
         {
             "name": "akuechler/laravel-geoly",
@@ -511,6 +511,136 @@
                 }
             ],
             "time": "2024-02-09T16:56:22+00:00"
+        },
+        {
+            "name": "clue/redis-protocol",
+            "version": "v0.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/clue/redis-protocol.git",
+                "reference": "6f565332f5531b7722d1e9c445314b91862f6d6c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/clue/redis-protocol/zipball/6f565332f5531b7722d1e9c445314b91862f6d6c",
+                "reference": "6f565332f5531b7722d1e9c445314b91862f6d6c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Clue\\Redis\\Protocol\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@lueck.tv"
+                }
+            ],
+            "description": "A streaming Redis protocol (RESP) parser and serializer written in pure PHP.",
+            "homepage": "https://github.com/clue/redis-protocol",
+            "keywords": [
+                "parser",
+                "protocol",
+                "redis",
+                "resp",
+                "serializer",
+                "streaming"
+            ],
+            "support": {
+                "issues": "https://github.com/clue/redis-protocol/issues",
+                "source": "https://github.com/clue/redis-protocol/tree/v0.3.2"
+            },
+            "funding": [
+                {
+                    "url": "https://clue.engineering/support",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/clue",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-08-07T11:06:28+00:00"
+        },
+        {
+            "name": "clue/redis-react",
+            "version": "v2.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/clue/reactphp-redis.git",
+                "reference": "84569198dfd5564977d2ae6a32de4beb5a24bdca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/clue/reactphp-redis/zipball/84569198dfd5564977d2ae6a32de4beb5a24bdca",
+                "reference": "84569198dfd5564977d2ae6a32de4beb5a24bdca",
+                "shasum": ""
+            },
+            "require": {
+                "clue/redis-protocol": "^0.3.2",
+                "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
+                "php": ">=5.3",
+                "react/event-loop": "^1.2",
+                "react/promise": "^3.2 || ^2.0 || ^1.1",
+                "react/promise-timer": "^1.11",
+                "react/socket": "^1.16"
+            },
+            "require-dev": {
+                "clue/block-react": "^1.5",
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Clue\\React\\Redis\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering"
+                }
+            ],
+            "description": "Async Redis client implementation, built on top of ReactPHP.",
+            "homepage": "https://github.com/clue/reactphp-redis",
+            "keywords": [
+                "async",
+                "client",
+                "database",
+                "reactphp",
+                "redis"
+            ],
+            "support": {
+                "issues": "https://github.com/clue/reactphp-redis/issues",
+                "source": "https://github.com/clue/reactphp-redis/tree/v2.8.0"
+            },
+            "funding": [
+                {
+                    "url": "https://clue.engineering/support",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/clue",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-01-03T16:18:33+00:00"
         },
         {
             "name": "composer/semver",
@@ -1286,6 +1416,53 @@
                 }
             ],
             "time": "2025-03-06T22:45:56+00:00"
+        },
+        {
+            "name": "evenement/evenement",
+            "version": "v3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/igorw/evenement.git",
+                "reference": "0a16b0d71ab13284339abb99d9d2bd813640efbc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/igorw/evenement/zipball/0a16b0d71ab13284339abb99d9d2bd813640efbc",
+                "reference": "0a16b0d71ab13284339abb99d9d2bd813640efbc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9 || ^6"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Evenement\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Igor Wiedler",
+                    "email": "igor@wiedler.ch"
+                }
+            ],
+            "description": "Événement is a very simple event dispatching library for PHP",
+            "keywords": [
+                "event-dispatcher",
+                "event-emitter"
+            ],
+            "support": {
+                "issues": "https://github.com/igorw/evenement/issues",
+                "source": "https://github.com/igorw/evenement/tree/v3.0.2"
+            },
+            "time": "2023-08-08T05:53:35+00:00"
         },
         {
             "name": "ezadr/lnurl-php",
@@ -2785,6 +2962,85 @@
                 "source": "https://github.com/laravel/prompts/tree/v0.3.22"
             },
             "time": "2026-08-04T14:50:50+00:00"
+        },
+        {
+            "name": "laravel/reverb",
+            "version": "v1.11.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laravel/reverb.git",
+                "reference": "52ce5fd88cd1d7eacfdcf6b91cea4704cc546f27"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laravel/reverb/zipball/52ce5fd88cd1d7eacfdcf6b91cea4704cc546f27",
+                "reference": "52ce5fd88cd1d7eacfdcf6b91cea4704cc546f27",
+                "shasum": ""
+            },
+            "require": {
+                "clue/redis-react": "^2.6",
+                "guzzlehttp/psr7": "^2.6",
+                "illuminate/console": "^10.47|^11.0|^12.0|^13.0",
+                "illuminate/contracts": "^10.47|^11.0|^12.0|^13.0",
+                "illuminate/http": "^10.47|^11.0|^12.0|^13.0",
+                "illuminate/support": "^10.47|^11.0|^12.0|^13.0",
+                "laravel/prompts": "^0.1.15|^0.2.0|^0.3.0",
+                "php": "^8.2",
+                "pusher/pusher-php-server": "^7.2",
+                "ratchet/rfc6455": "^0.4",
+                "react/promise-timer": "^1.10",
+                "react/socket": "^1.14",
+                "symfony/console": "^6.0|^7.0|^8.0",
+                "symfony/http-foundation": "^6.3|^7.0|^8.0"
+            },
+            "require-dev": {
+                "orchestra/testbench": "^8.36|^9.15|^10.8|^11.0",
+                "pestphp/pest": "^2.0|^3.0|^4.0",
+                "phpstan/phpstan": "^1.10",
+                "ratchet/pawl": "^0.4.1",
+                "react/async": "^4.2",
+                "react/http": "^1.9"
+            },
+            "type": "library",
+            "extra": {
+                "laravel": {
+                    "providers": [
+                        "Laravel\\Reverb\\ApplicationManagerServiceProvider",
+                        "Laravel\\Reverb\\ReverbServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laravel\\Reverb\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Taylor Otwell",
+                    "email": "taylor@laravel.com"
+                },
+                {
+                    "name": "Joe Dixon",
+                    "email": "joe@laravel.com"
+                }
+            ],
+            "description": "Laravel Reverb provides a real-time WebSocket communication backend for Laravel applications.",
+            "keywords": [
+                "WebSockets",
+                "laravel",
+                "real-time",
+                "websocket"
+            ],
+            "support": {
+                "issues": "https://github.com/laravel/reverb/issues",
+                "source": "https://github.com/laravel/reverb/tree/v1.11.1"
+            },
+            "time": "2026-08-06T14:48:58+00:00"
         },
         {
             "name": "laravel/sanctum",
@@ -6739,6 +6995,69 @@
             "time": "2026-06-29T15:41:09+00:00"
         },
         {
+            "name": "pusher/pusher-php-server",
+            "version": "7.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pusher/pusher-http-php.git",
+                "reference": "058d8464246118110a341fc2e6e70c7c8b6a7f2c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pusher/pusher-http-php/zipball/058d8464246118110a341fc2e6e70c7c8b6a7f2c",
+                "reference": "058d8464246118110a341fc2e6e70c7c8b6a7f2c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-curl": "*",
+                "ext-json": "*",
+                "guzzlehttp/guzzle": "^7.8.2 || ^8.0",
+                "guzzlehttp/promises": "^2.0.3 || ^3.0",
+                "guzzlehttp/psr7": "^2.6.3 || ^3.0",
+                "php": "^7.3|^8.0",
+                "psr/http-client": "^1.0",
+                "psr/log": "^1.0 || ^2.0 || ^3.0"
+            },
+            "require-dev": {
+                "overtrue/phplint": "^2.3",
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Pusher\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Library for interacting with the Pusher REST API",
+            "keywords": [
+                "events",
+                "messaging",
+                "php-pusher-server",
+                "publish",
+                "push",
+                "pusher",
+                "real time",
+                "real-time",
+                "realtime",
+                "rest",
+                "trigger"
+            ],
+            "support": {
+                "issues": "https://github.com/pusher/pusher-http-php/issues",
+                "source": "https://github.com/pusher/pusher-http-php/tree/7.3.0"
+            },
+            "time": "2026-08-07T12:47:11+00:00"
+        },
+        {
             "name": "ralouphie/getallheaders",
             "version": "3.0.3",
             "source": {
@@ -7087,6 +7406,595 @@
                 "source": "https://github.com/ramsey/uuid/tree/4.9.3"
             },
             "time": "2026-06-18T03:57:49+00:00"
+        },
+        {
+            "name": "ratchet/rfc6455",
+            "version": "v0.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ratchetphp/RFC6455.git",
+                "reference": "9b05f371219cbaf9748b505f139617dd0715592b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ratchetphp/RFC6455/zipball/9b05f371219cbaf9748b505f139617dd0715592b",
+                "reference": "9b05f371219cbaf9748b505f139617dd0715592b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4",
+                "psr/http-factory-implementation": "^1.0",
+                "symfony/polyfill-php80": "^1.15"
+            },
+            "require-dev": {
+                "guzzlehttp/psr7": "^2.7",
+                "phpunit/phpunit": "^9.5",
+                "react/socket": "^1.3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Ratchet\\RFC6455\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Matt Bonneau",
+                    "role": "Developer"
+                }
+            ],
+            "description": "RFC6455 WebSocket protocol handler",
+            "homepage": "http://socketo.me",
+            "keywords": [
+                "WebSockets",
+                "rfc6455",
+                "websocket"
+            ],
+            "support": {
+                "chat": "https://gitter.im/reactphp/reactphp",
+                "issues": "https://github.com/ratchetphp/RFC6455/issues",
+                "source": "https://github.com/ratchetphp/RFC6455/tree/v0.4.1"
+            },
+            "time": "2026-06-06T14:34:23+00:00"
+        },
+        {
+            "name": "react/cache",
+            "version": "v1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/cache.git",
+                "reference": "d47c472b64aa5608225f47965a484b75c7817d5b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/cache/zipball/d47c472b64aa5608225f47965a484b75c7817d5b",
+                "reference": "d47c472b64aa5608225f47965a484b75c7817d5b",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0",
+                "react/promise": "^3.0 || ^2.0 || ^1.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5 || ^5.7 || ^4.8.35"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Cache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Async, Promise-based cache interface for ReactPHP",
+            "keywords": [
+                "cache",
+                "caching",
+                "promise",
+                "reactphp"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/cache/issues",
+                "source": "https://github.com/reactphp/cache/tree/v1.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2022-11-30T15:59:55+00:00"
+        },
+        {
+            "name": "react/dns",
+            "version": "v1.14.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/dns.git",
+                "reference": "7562c05391f42701c1fccf189c8225fece1cd7c3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/dns/zipball/7562c05391f42701c1fccf189c8225fece1cd7c3",
+                "reference": "7562c05391f42701c1fccf189c8225fece1cd7c3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0",
+                "react/cache": "^1.0 || ^0.6 || ^0.5",
+                "react/event-loop": "^1.2",
+                "react/promise": "^3.2 || ^2.7 || ^1.2.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36",
+                "react/async": "^4.3 || ^3 || ^2",
+                "react/promise-timer": "^1.11"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Dns\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Async DNS resolver for ReactPHP",
+            "keywords": [
+                "async",
+                "dns",
+                "dns-resolver",
+                "reactphp"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/dns/issues",
+                "source": "https://github.com/reactphp/dns/tree/v1.14.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2025-11-18T19:34:28+00:00"
+        },
+        {
+            "name": "react/event-loop",
+            "version": "v1.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/event-loop.git",
+                "reference": "ba276bda6083df7e0050fd9b33f66ad7a4ac747a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/event-loop/zipball/ba276bda6083df7e0050fd9b33f66ad7a4ac747a",
+                "reference": "ba276bda6083df7e0050fd9b33f66ad7a4ac747a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
+            },
+            "suggest": {
+                "ext-pcntl": "For signal handling support when using the StreamSelectLoop"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\EventLoop\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "ReactPHP's core reactor event loop that libraries can use for evented I/O.",
+            "keywords": [
+                "asynchronous",
+                "event-loop"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/event-loop/issues",
+                "source": "https://github.com/reactphp/event-loop/tree/v1.6.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2025-11-17T20:46:25+00:00"
+        },
+        {
+            "name": "react/promise",
+            "version": "v3.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/promise.git",
+                "reference": "23444f53a813a3296c1368bb104793ce8d88f04a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/promise/zipball/23444f53a813a3296c1368bb104793ce8d88f04a",
+                "reference": "23444f53a813a3296c1368bb104793ce8d88f04a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1.0"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "1.12.28 || 1.4.10",
+                "phpunit/phpunit": "^9.6 || ^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "React\\Promise\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "A lightweight implementation of CommonJS Promises/A for PHP",
+            "keywords": [
+                "promise",
+                "promises"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/promise/issues",
+                "source": "https://github.com/reactphp/promise/tree/v3.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2025-08-19T18:57:03+00:00"
+        },
+        {
+            "name": "react/promise-timer",
+            "version": "v1.11.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/promise-timer.git",
+                "reference": "4f70306ed66b8b44768941ca7f142092600fafc1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/promise-timer/zipball/4f70306ed66b8b44768941ca7f142092600fafc1",
+                "reference": "4f70306ed66b8b44768941ca7f142092600fafc1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3",
+                "react/event-loop": "^1.2",
+                "react/promise": "^3.2 || ^2.7.0 || ^1.2.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/functions_include.php"
+                ],
+                "psr-4": {
+                    "React\\Promise\\Timer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "A trivial implementation of timeouts for Promises, built on top of ReactPHP.",
+            "homepage": "https://github.com/reactphp/promise-timer",
+            "keywords": [
+                "async",
+                "event-loop",
+                "promise",
+                "reactphp",
+                "timeout",
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/promise-timer/issues",
+                "source": "https://github.com/reactphp/promise-timer/tree/v1.11.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2024-06-04T14:27:45+00:00"
+        },
+        {
+            "name": "react/socket",
+            "version": "v1.17.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/socket.git",
+                "reference": "ef5b17b81f6f60504c539313f94f2d826c5faa08"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/socket/zipball/ef5b17b81f6f60504c539313f94f2d826c5faa08",
+                "reference": "ef5b17b81f6f60504c539313f94f2d826c5faa08",
+                "shasum": ""
+            },
+            "require": {
+                "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
+                "php": ">=5.3.0",
+                "react/dns": "^1.13",
+                "react/event-loop": "^1.2",
+                "react/promise": "^3.2 || ^2.6 || ^1.2.1",
+                "react/stream": "^1.4"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36",
+                "react/async": "^4.3 || ^3.3 || ^2",
+                "react/promise-stream": "^1.4",
+                "react/promise-timer": "^1.11"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Socket\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Async, streaming plaintext TCP/IP and secure TLS socket server and client connections for ReactPHP",
+            "keywords": [
+                "Connection",
+                "Socket",
+                "async",
+                "reactphp",
+                "stream"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/socket/issues",
+                "source": "https://github.com/reactphp/socket/tree/v1.17.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2025-11-19T20:47:34+00:00"
+        },
+        {
+            "name": "react/stream",
+            "version": "v1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/reactphp/stream.git",
+                "reference": "1e5b0acb8fe55143b5b426817155190eb6f5b18d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/reactphp/stream/zipball/1e5b0acb8fe55143b5b426817155190eb6f5b18d",
+                "reference": "1e5b0acb8fe55143b5b426817155190eb6f5b18d",
+                "shasum": ""
+            },
+            "require": {
+                "evenement/evenement": "^3.0 || ^2.0 || ^1.0",
+                "php": ">=5.3.8",
+                "react/event-loop": "^1.2"
+            },
+            "require-dev": {
+                "clue/stream-filter": "~1.2",
+                "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "React\\Stream\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering",
+                    "homepage": "https://clue.engineering/"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "reactphp@ceesjankiewiet.nl",
+                    "homepage": "https://wyrihaximus.net/"
+                },
+                {
+                    "name": "Jan Sorgalla",
+                    "email": "jsorgalla@gmail.com",
+                    "homepage": "https://sorgalla.com/"
+                },
+                {
+                    "name": "Chris Boden",
+                    "email": "cboden@gmail.com",
+                    "homepage": "https://cboden.dev/"
+                }
+            ],
+            "description": "Event-driven readable and writable streams for non-blocking I/O in ReactPHP",
+            "keywords": [
+                "event-driven",
+                "io",
+                "non-blocking",
+                "pipe",
+                "reactphp",
+                "readable",
+                "stream",
+                "writable"
+            ],
+            "support": {
+                "issues": "https://github.com/reactphp/stream/issues",
+                "source": "https://github.com/reactphp/stream/tree/v1.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://opencollective.com/reactphp",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2024-06-11T12:45:25+00:00"
         },
         {
             "name": "simplesoftwareio/simple-qrcode",

--- a/config/broadcasting.php
+++ b/config/broadcasting.php
@@ -1,0 +1,95 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default Broadcaster
+    |--------------------------------------------------------------------------
+    |
+    | This option controls the default broadcaster that will be used by the
+    | framework when an event needs to be broadcast. You may set this to
+    | any of the connections defined in the "connections" array below.
+    |
+    | Supported: "reverb", "pusher", "ably", "redis", "log", "null"
+    |
+    */
+
+    'default' => env('BROADCAST_CONNECTION', 'null'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Broadcast Connections
+    |--------------------------------------------------------------------------
+    |
+    | Here you may define all of the broadcast connections that will be used
+    | to broadcast events to other systems or over WebSockets. Samples of
+    | each available type of connection are provided inside this array.
+    |
+    */
+
+    'connections' => [
+
+        'reverb' => [
+            'driver' => 'reverb',
+            'key' => env('REVERB_APP_KEY'),
+            'secret' => env('REVERB_APP_SECRET'),
+            'app_id' => env('REVERB_APP_ID'),
+            'options' => [
+                /*
+                 * WOHIN DIE ANWENDUNG PUBLIZIERT — nicht, wohin der Browser verbindet.
+                 *
+                 * Auf Produktion steht hier 127.0.0.1:8080/http (P5), nicht der
+                 * oeffentliche Hostname: sonst schickte jeder Broadcast einen
+                 * TLS-Roundtrip durch nginx auf denselben Server zurueck.
+                 */
+                'host' => env('REVERB_HOST'),
+                'port' => env('REVERB_PORT', 443),
+                'scheme' => env('REVERB_SCHEME', 'https'),
+                'useTLS' => env('REVERB_SCHEME', 'https') === 'https',
+                /*
+                 * Muss zu `--path` des Daemons passen. Die Site hat bereits eine Route
+                 * `GET app/auth` (Mobile-Login-Handoff); ein Reverb unter dem Default
+                 * `/app` wuerde sie beim nginx-Proxy verdecken. Deshalb `reverb`.
+                 */
+                'path' => env('REVERB_SERVER_PATH', ''),
+            ],
+            'client_options' => [
+                // Guzzle client options: https://docs.guzzlephp.org/en/stable/request-options.html
+            ],
+        ],
+
+        'pusher' => [
+            'driver' => 'pusher',
+            'key' => env('PUSHER_APP_KEY'),
+            'secret' => env('PUSHER_APP_SECRET'),
+            'app_id' => env('PUSHER_APP_ID'),
+            'options' => [
+                'cluster' => env('PUSHER_APP_CLUSTER'),
+                'host' => env('PUSHER_HOST') ?: 'api-'.env('PUSHER_APP_CLUSTER', 'mt1').'.pusher.com',
+                'port' => env('PUSHER_PORT', 443),
+                'scheme' => env('PUSHER_SCHEME', 'https'),
+                'encrypted' => true,
+                'useTLS' => env('PUSHER_SCHEME', 'https') === 'https',
+            ],
+            'client_options' => [
+                // Guzzle client options: https://docs.guzzlephp.org/en/stable/request-options.html
+            ],
+        ],
+
+        'ably' => [
+            'driver' => 'ably',
+            'key' => env('ABLY_KEY'),
+        ],
+
+        'log' => [
+            'driver' => 'log',
+        ],
+
+        'null' => [
+            'driver' => 'null',
+        ],
+
+    ],
+
+];

--- a/config/einundzwanzig.php
+++ b/config/einundzwanzig.php
@@ -65,4 +65,38 @@ return [
 
     'tags_required_countries' => ['cz'],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Change log for API consumers
+    |--------------------------------------------------------------------------
+    |
+    | Issue #29: every create, update and delete on one of the six public API
+    | resources is written to `api_changes`, so a consumer can resync from a
+    | cursor instead of diffing a fresh export against an old cache.
+    |
+    | `enabled` is the kill switch. Off means the recorder returns before it
+    | builds anything — no resource is resolved, no row is written, and nothing
+    | queues up for later. Turning it back on does NOT backfill; the gap stays a
+    | gap, which is exactly why the switch is here and not a runtime guess.
+    |
+    | Off by default in the test environment (see phpunit.xml). Not for speed
+    | alone: DatabaseSeeder creates over 250 records, and every one of them would
+    | otherwise resolve a JsonResource and write a row that no test asked for.
+    | Tests that DO test the log turn it on themselves.
+    |
+    | For a single block — a seeder, an import command — there is
+    | ChangeRecorder::muted(fn () => ...), which restores the previous state even
+    | when the block throws.
+    |
+    | `prune_days` is how long a row survives. It bounds the table and, with it,
+    | how far back /api/changes can resync. Shortening it silently shortens that
+    | window for every consumer, so it belongs in the docs, not just here.
+    |
+    */
+
+    'change_log' => [
+        'enabled' => env('CHANGE_LOG_ENABLED', true),
+        'prune_days' => (int) env('CHANGE_LOG_PRUNE_DAYS', 30),
+    ],
+
 ];

--- a/config/logging.php
+++ b/config/logging.php
@@ -118,6 +118,25 @@ return [
             'replace_placeholders' => true,
         ],
 
+        /*
+         * Der Aufruf-Zaehler von GET /api/changes (Issue #29).
+         *
+         * Ein eigener Kanal, weil die nginx-Konfig der Produktions-Site `access_log
+         * off` hat: diese Datei IST die Messung, mit der entschieden wird, ob der
+         * Reverb-Server ueberhaupt gebaut wird. `level` steht deshalb fest auf `info`
+         * und liest NICHT `LOG_LEVEL` — stuende das auf Produktion auf `error`, fiele
+         * die Messung still aus und ihr Fehlen waere von "niemand ruft ab" nicht zu
+         * unterscheiden. Getrennt vom Stack, damit `wc -l` die Antwort gibt, ohne
+         * durch den uebrigen Anwendungs-Log zu greppen.
+         */
+        'api-changes' => [
+            'driver' => 'daily',
+            'path' => storage_path('logs/api-changes.log'),
+            'level' => 'info',
+            'days' => (int) env('LOG_API_CHANGES_DAYS', 90),
+            'replace_placeholders' => true,
+        ],
+
         'null' => [
             'driver' => 'monolog',
             'handler' => NullHandler::class,

--- a/config/reverb.php
+++ b/config/reverb.php
@@ -1,0 +1,133 @@
+<?php
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Default Reverb Server
+    |--------------------------------------------------------------------------
+    |
+    | This option controls the default server used by Reverb to handle
+    | incoming messages as well as broadcasting message to all your
+    | connected clients. At this time only "reverb" is supported.
+    |
+    */
+
+    'default' => env('REVERB_SERVER', 'reverb'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Reverb Servers
+    |--------------------------------------------------------------------------
+    |
+    | Here you may define details for each of the supported Reverb servers.
+    | Each server has its own configuration options that are defined in
+    | the array below. You should ensure all the options are present.
+    |
+    */
+
+    'servers' => [
+
+        'reverb' => [
+            'host' => env('REVERB_SERVER_HOST', '0.0.0.0'),
+            'port' => env('REVERB_SERVER_PORT', 8080),
+            'path' => env('REVERB_SERVER_PATH', ''),
+            'hostname' => env('REVERB_HOST'),
+            'options' => [
+                'tls' => [],
+            ],
+            'max_request_size' => env('REVERB_MAX_REQUEST_SIZE', 10_000),
+            'scaling' => [
+                'enabled' => env('REVERB_SCALING_ENABLED', false),
+                'channel' => env('REVERB_SCALING_CHANNEL', 'reverb'),
+                'server' => [
+                    'url' => env('REDIS_URL'),
+                    'host' => env('REDIS_HOST', '127.0.0.1'),
+                    'port' => env('REDIS_PORT', '6379'),
+                    'username' => env('REDIS_USERNAME'),
+                    'password' => env('REDIS_PASSWORD'),
+                    'database' => env('REDIS_DB', '0'),
+                    'timeout' => env('REDIS_TIMEOUT', 60),
+                ],
+            ],
+            'pulse_ingest_interval' => env('REVERB_PULSE_INGEST_INTERVAL', 15),
+            'telescope_ingest_interval' => env('REVERB_TELESCOPE_INGEST_INTERVAL', 15),
+        ],
+
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Reverb Applications
+    |--------------------------------------------------------------------------
+    |
+    | Here you may define how Reverb applications are managed. If you choose
+    | to use the "config" provider, you may define an array of apps which
+    | your server will support, including their connection credentials.
+    |
+    */
+
+    'apps' => [
+
+        'provider' => 'config',
+
+        'apps' => [
+            [
+                'key' => env('REVERB_APP_KEY'),
+                'secret' => env('REVERB_APP_SECRET'),
+                'app_id' => env('REVERB_APP_ID'),
+                'options' => [
+                    'host' => env('REVERB_HOST'),
+                    'port' => env('REVERB_PORT', 443),
+                    'scheme' => env('REVERB_SCHEME', 'https'),
+                    'useTLS' => env('REVERB_SCHEME', 'https') === 'https',
+                ],
+                /*
+                 * WER SICH VERBINDEN DARF — bewusst offen, per Env einschraenkbar.
+                 *
+                 * Kommagetrennte Hostnamen, Wildcards erlaubt (`Str::is`), etwa
+                 * `einundzwanzig.space,*.einundzwanzig.space`. Leer oder ungesetzt
+                 * heisst `*`.
+                 *
+                 * ES BLEIBT AUF `*`, UND ZWAR AUS ZWEI GRUENDEN:
+                 *
+                 * 1. Gemessen am 2026-08-23 gegen `reverb:start` (v1.11.1): ein Client
+                 *    OHNE `Origin`-Header wird abgewiesen, sobald hier eine konkrete
+                 *    Liste steht. `Server::verifyOrigin()` liest
+                 *    `parse_url($connection->origin(), PHP_URL_HOST)` — ohne Header ist
+                 *    das null, und `Str::is('einundzwanzig.space', null)` ist false.
+                 *    Genau der angefragte Konsument ist aber ein SERVERSEITIGER
+                 *    (einundzwanzig.space holt Termine ab, kein Browser) und schickt
+                 *    typischerweise keinen Origin. Eine konkrete Liste spraeche also
+                 *    denjenigen aus, fuer den das Ganze gebaut wird.
+                 * 2. Der Origin-Header ist hier ohnehin keine Sicherheitsgrenze. Er
+                 *    kommt vom Client und laesst sich von allem faelschen, was kein
+                 *    Browser ist; er haelt nur fremde WEBSEITEN ab. Auf diesen Kanaelen
+                 *    liegen ausschliesslich Daten, die die REST-API oeffentlich und
+                 *    ohne Token ausliefert — es gibt nichts abzuhalten.
+                 *
+                 * Wer die Liste doch einengt, nimmt Punkt 1 in Kauf und sollte wissen:
+                 * ein abgewiesener Konsument sieht einen geschlossenen Socket, keine
+                 * Begruendung.
+                 */
+                'allowed_origins' => array_values(array_filter(array_map(
+                    'trim',
+                    explode(',', (string) env('REVERB_APP_ALLOWED_ORIGINS', '*'))
+                ))) ?: ['*'],
+                'ping_interval' => env('REVERB_APP_PING_INTERVAL', 60),
+                'activity_timeout' => env('REVERB_APP_ACTIVITY_TIMEOUT', 30),
+                'max_connections' => env('REVERB_APP_MAX_CONNECTIONS'),
+                'max_message_size' => env('REVERB_APP_MAX_MESSAGE_SIZE', 10_000),
+                'accept_client_events_from' => env('REVERB_APP_ACCEPT_CLIENT_EVENTS_FROM', 'members'),
+                'rate_limiting' => [
+                    'enabled' => env('REVERB_APP_RATE_LIMITING_ENABLED', false),
+                    'max_attempts' => env('REVERB_APP_RATE_LIMIT_MAX_ATTEMPTS', 60),
+                    'decay_seconds' => env('REVERB_APP_RATE_LIMIT_DECAY_SECONDS', 60),
+                    'terminate_on_limit' => env('REVERB_APP_RATE_LIMIT_TERMINATE', false),
+                ],
+            ],
+        ],
+
+    ],
+
+];

--- a/config/scramble.php
+++ b/config/scramble.php
@@ -59,6 +59,18 @@ return [
         connector and manage meetups, events and courses straight from a chat. The illustrated
         step-by-step guide (in German) is at [/ki-assistent](/ki-assistent).
 
+        ## Realtime updates
+
+        You do not have to poll a full export and diff it against your cache. `GET /api/changes`
+        is a cursor-paginated change log of every create, update and delete — deletions included,
+        which are invisible anywhere else because nothing here is soft-deleted. Two public
+        WebSocket channels (`portal` and `meetup-events`) carry the same envelope within
+        milliseconds, without authentication.
+
+        The channels are not HTTP routes and therefore cannot appear in this reference. Their
+        names, the payload contract, a working TypeScript client and the gaps you have to plan
+        around are documented at [/docs/websockets](/docs/websockets).
+
         ## Authentication
 
         Most **read endpoints** are public and require no token.

--- a/database/factories/ApiChangeFactory.php
+++ b/database/factories/ApiChangeFactory.php
@@ -1,0 +1,92 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\ApiChange;
+use App\Support\Broadcasting\ChangeRecorder;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<ApiChange>
+ */
+class ApiChangeFactory extends Factory
+{
+    protected $model = ApiChange::class;
+
+    public function definition(): array
+    {
+        $resource = fake()->randomElement([
+            'meetup', 'meetup-event', 'city', 'course', 'course-event', 'lecturer',
+        ]);
+        $action = fake()->randomElement(['created', 'updated', 'deleted']);
+        $resourceId = fake()->numberBetween(1, 9999);
+        $occurredAt = fake()->dateTimeBetween('-60 days', 'now');
+
+        return [
+            'resource' => $resource,
+            'resource_id' => $resourceId,
+            'action' => $action,
+            'country_code' => null,
+            'city_id' => null,
+            'payload' => [
+                'action' => $action,
+                'resource' => $resource,
+                'id' => $resourceId,
+                'sequence' => null,
+                'occurred_at' => $occurredAt->format(DATE_ATOM),
+                'api_version' => (string) config('scramble.info.version'),
+                'data' => $action === 'deleted' ? null : ['id' => $resourceId],
+                'links' => ['self' => null],
+            ],
+            'occurred_at' => $occurredAt,
+        ];
+    }
+
+    /**
+     * Eine Zeile zu einer bestimmten Ressource — Spalte UND Payload.
+     *
+     * Nur die Spalte zu ueberschreiben reichte nicht: der Filter von
+     * `GET /api/changes` liest die Spalte, der Konsument liest das Payload. Fielen die
+     * beiden auseinander, waere ein Test ueber den Filter gruen, waehrend die Antwort
+     * Eintraege einer anderen Ressource ausweist.
+     */
+    public function forResource(string $resource): static
+    {
+        return $this->state(fn (array $attributes): array => [
+            'resource' => $resource,
+            'payload' => [...$attributes['payload'], 'resource' => $resource],
+        ]);
+    }
+
+    /**
+     * Traegt `sequence` nach, so wie es der Recorder tut.
+     *
+     * Die Sequenz IST die Zeilen-ID und steht erst nach dem Insert fest
+     * ({@see ChangeRecorder::record()}). Ohne diesen Schritt
+     * erzeugte die Factory Zeilen, die es in Wirklichkeit nicht gibt: mit
+     * `payload['sequence'] === null` — und jeder Test, der den Resync-Cursor aus dem
+     * ausgelieferten Payload liest, liefe gegen genau dieses Loch.
+     */
+    public function configure(): static
+    {
+        return $this->afterCreating(function (ApiChange $change): void {
+            if (($change->payload['sequence'] ?? null) !== null) {
+                return;
+            }
+
+            $change->forceFill([
+                'payload' => [...$change->payload, 'sequence' => $change->id],
+            ])->save();
+        });
+    }
+
+    /**
+     * Eine Zeile, die der Prune-Lauf abraeumen soll.
+     */
+    public function olderThan(int $days): static
+    {
+        return $this->state(fn (array $attributes): array => [
+            'occurred_at' => now()->subDays($days)->subHour(),
+        ]);
+    }
+}

--- a/database/migrations/2026_08_23_171259_create_api_changes_table.php
+++ b/database/migrations/2026_08_23_171259_create_api_changes_table.php
@@ -1,0 +1,59 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Issue #29: das Aenderungs-Log der oeffentlichen API.
+ *
+ * Jede Zeile ist genau eine Aenderung an einer der sechs API-Ressourcen — angelegt,
+ * geaendert oder geloescht. Die Tabelle ist der Unterbau fuer /api/changes (P2) und
+ * fuer den spaeteren Broadcast (P4); sie steht aber allein fuer sich und funktioniert
+ * auch dann, wenn nie ein WebSocket dazukommt.
+ *
+ * `id` ist zugleich der `sequence`-Cursor: monoton, luekenlos vergeben, und damit das
+ * einzige, was ein Konsument nach einem Verbindungsabriss mitschicken muss. Ein
+ * Zeitstempel taugt dafuer nicht — zwei Aenderungen in derselben Millisekunde sind der
+ * Normalfall, und `occurred_at` ist damit ein Filter, kein Cursor.
+ *
+ * `payload` traegt IMMER das vollstaendige Objekt. Die 10-KB-Grenze von Reverb kuerzt
+ * nur, was gesendet wird, niemals das, was hier steht — sonst waere der Resync-Weg
+ * genauso luekenhaft wie der Push.
+ *
+ * `country_code` und `city_id` sind Vorbereitung fuer die Geo-Kanaele aus P7. Sie
+ * werden nur gefuellt, soweit sie ohne eine zusaetzliche Query aus dem geschriebenen
+ * Datensatz ableitbar sind; sonst bleiben sie null. Ein Schreibvorgang soll nicht
+ * teurer werden, um eine Spalte zu fuellen, die heute niemand liest.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('api_changes', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            // Der Ressourcen-Name der API in Bindestrich-Schreibweise: `meetup`,
+            // `meetup-event`, `city`, `course`, `course-event`, `lecturer`.
+            $table->string('resource');
+            $table->unsignedBigInteger('resource_id');
+            // created | updated | deleted. Bewusst ein String und kein Enum: die Werte
+            // gehen so, wie sie hier stehen, ueber die API nach draussen.
+            $table->string('action');
+            // ISO-3166-1 alpha-2, gross geschrieben wie in countries.code.
+            $table->string('country_code', 2)->nullable();
+            $table->unsignedBigInteger('city_id')->nullable();
+            $table->json('payload');
+            $table->timestamp('occurred_at');
+
+            // Der Resync-Weg: "alles nach Cursor X, optional nur Ressource Y".
+            $table->index(['resource', 'id']);
+            // Der Prune-Lauf und der Zeitfilter des Endpunkts.
+            $table->index('occurred_at');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('api_changes');
+    }
+};

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -36,6 +36,13 @@
              aus — bei ueber 250 Datensaetzen allein aus dem DatabaseSeeder. Die Tests,
              die das Log pruefen, schalten es selbst per config()->set() an. -->
         <env name="CHANGE_LOG_ENABLED" value="false"/>
+        <!-- Ohne diese Zeile faellt der Broadcast-Treiber auf das .env des Entwicklers
+             zurueck. Steht dort seit P4 BROADCAST_CONNECTION=reverb, versucht jeder
+             Test, der eine Ressource anlegt, einen echten HTTP-Call an
+             localhost:8080 — und die halbe Suite wird rot, sobald der Daemon nicht
+             laeuft. Ein Test darf nie von einem Dienst abhaengen, den er nicht
+             gestartet hat. Die Broadcast-Tests setzen sich ihren eigenen Treiber. -->
+        <env name="BROADCAST_CONNECTION" value="null"/>
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_STORE" value="array"/>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -31,6 +31,11 @@
              nicht vollstaendig freigegeben; 1G ist die Grenze, nicht der Bedarf. -->
         <ini name="memory_limit" value="1G"/>
         <env name="APP_ENV" value="testing"/>
+        <!-- Das Aenderungs-Log (Issue #29) ist im Test per Default AUS. Sonst loeste
+             jeder Fixture-Aufbau eine JsonResource-Aufloesung plus zwei Schreibvorgaenge
+             aus — bei ueber 250 Datensaetzen allein aus dem DatabaseSeeder. Die Tests,
+             die das Log pruefen, schalten es selbst per config()->set() an. -->
+        <env name="CHANGE_LOG_ENABLED" value="false"/>
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="CACHE_STORE" value="array"/>

--- a/resources/views/livewire/docs/websockets.blade.php
+++ b/resources/views/livewire/docs/websockets.blade.php
@@ -1,0 +1,1063 @@
+<?php
+
+use App\Attributes\SeoDataAttribute;
+use App\Support\Broadcasting\ChangeRecorder;
+use App\Traits\SeoTrait;
+use Illuminate\Support\HtmlString;
+use Livewire\Attributes\Computed;
+use Livewire\Attributes\Layout;
+use Livewire\Component;
+
+/**
+ * Consumer documentation for the realtime change feed (Issue #29, plan phase P6).
+ *
+ * DIESE SEITE IST AUF ENGLISCH UND WIRD NICHT UEBERSETZT — anders als /ki-assistent,
+ * das dieselbe Kopfleiste traegt. Der Grund ist das Publikum, nicht die Bequemlichkeit:
+ * die Nachbarseite dieser hier ist /docs/api, die Scramble-Referenz. Deren
+ * `info.description` ist englisch, und Scalar ist in `config/scramble.php` fest auf
+ * `locale => 'en'` genagelt, mit der dort notierten Begruendung, dass eine zweite
+ * Sprache ein zweites OpenAPI-Dokument bedeutete. Beide Seiten beschreiben denselben
+ * Vertrag mit denselben Feldnamen; stuenden die Feldnamen hier in neun Sprachen
+ * gerahmt, waere der Vergleich schwerer, nicht leichter. /ki-assistent richtet sich an
+ * Meetup-Organisatoren ohne Technikwissen — ein anderes Publikum, deshalb dort
+ * neun Sprachen und hier eine.
+ */
+new
+#[Layout('components.layouts.auth')]
+#[SeoDataAttribute(key: 'docs_websockets')]
+class extends Component {
+    use SeoTrait;
+
+    /**
+     * Platzhalter fuer Verbindungsangaben, die es noch nicht gibt.
+     *
+     * Reverb ist zum Zeitpunkt dieser Phase nicht deployt (das ist P5). Eine Seite, die
+     * dann einen erfundenen App-Key zeigt, ist schlimmer als eine, die zugibt, dass der
+     * Wert fehlt: ein falscher Key verbindet nicht, und der Konsument sucht den Fehler
+     * bei sich. Die Platzhalter tragen den Namen der Env-Variablen, aus der der Wert
+     * kommt, damit erkennbar ist, worauf gewartet wird.
+     */
+    private const PATH_PLACEHOLDER = '{REVERB_SERVER_PATH}';
+
+    private const KEY_PLACEHOLDER = '{REVERB_APP_KEY}';
+
+    /**
+     * Fliesstext mit `Backticks` in Fliesstext mit <code>-Auszeichnung.
+     *
+     * Erst escapen, dann ersetzen — in dieser Reihenfolge, sonst waere die Methode ein
+     * Weg, beliebiges HTML in die Seite zu schreiben. Die Texte stammen zwar
+     * ausschliesslich aus dieser Datei, aber eine Funktion, die nur sicher ist, solange
+     * niemand sie woanders benutzt, ist keine sichere Funktion.
+     */
+    private function formatted(string $text): HtmlString
+    {
+        return new HtmlString(preg_replace(
+            '/`([^`]+)`/',
+            '<code class="rounded bg-zinc-900/5 px-1 py-0.5 font-mono text-[0.9em] dark:bg-white/10">$1</code>',
+            e($text),
+        ));
+    }
+
+    /**
+     * Die Verbindungsangaben, vollstaendig aus der Konfiguration gelesen.
+     *
+     * Nichts davon ist hier fest verdrahtet — sobald P5 die Produktionswerte setzt,
+     * zeigt die Seite sie, ohne dass jemand sie nachtraegt.
+     *
+     * EINE ABWEICHUNG, MIT ABSICHT: Host, Schema und Port kommen aus `app.url` und
+     * NICHT aus `broadcasting.connections.reverb.options.*`. Die dortigen Werte sagen,
+     * wohin die ANWENDUNG publiziert; auf Produktion steht da laut Plan
+     * `127.0.0.1:8080/http`, damit ein Broadcast nicht als TLS-Roundtrip durch nginx
+     * auf denselben Server zurueckläuft. Ein Konsument, der sich zu 127.0.0.1
+     * verbindet, verbindet sich zu seiner eigenen Maschine. Der Weg nach aussen ist der
+     * Pfad-Proxy auf demselben Hostnamen wie das Portal — also `app.url`.
+     *
+     * Der Pfad kommt aus `reverb.servers.reverb.path` (das ist das `--path` des
+     * Daemons und damit genau das Praefix, das nginx nach aussen reicht), mit
+     * `broadcasting.connections.reverb.options.path` als zweiter Quelle, weil beide
+     * dieselbe Env-Variable lesen.
+     *
+     * @return array{scheme:string, host:string, port:int, ws_path:string, key:string, url:string, published:bool}
+     */
+    #[Computed]
+    public function connection(): array
+    {
+        $appUrl = (string) config('app.url');
+        $host = parse_url($appUrl, PHP_URL_HOST) ?: request()->getHost();
+        $port = parse_url($appUrl, PHP_URL_PORT);
+        $scheme = parse_url($appUrl, PHP_URL_SCHEME) === 'http' ? 'ws' : 'wss';
+
+        $path = trim((string) (
+            config('reverb.servers.reverb.path')
+            ?: config('broadcasting.connections.reverb.options.path')
+        ), '/');
+
+        $key = trim((string) config('broadcasting.connections.reverb.key'));
+
+        $authority = $host.($port ? ':'.$port : '');
+
+        return [
+            'scheme' => $scheme,
+            'host' => $host,
+            'port' => (int) ($port ?: ($scheme === 'wss' ? 443 : 80)),
+            'ws_path' => $path === '' ? self::PATH_PLACEHOLDER : '/'.$path,
+            'key' => $key === '' ? self::KEY_PLACEHOLDER : $key,
+            'url' => sprintf(
+                '%s://%s/%s/app/%s',
+                $scheme,
+                $authority,
+                $path === '' ? self::PATH_PLACEHOLDER : $path,
+                $key === '' ? self::KEY_PLACEHOLDER : $key,
+            ),
+            'published' => $path !== '' && $key !== '',
+        ];
+    }
+
+    /**
+     * Die absolute URL des Resync-Endpunkts.
+     */
+    #[Computed]
+    public function changesUrl(): string
+    {
+        return route('api.changes.index');
+    }
+
+    /**
+     * Die Grenze, ab der `data` nicht mehr mitfaehrt.
+     */
+    #[Computed]
+    public function maxBroadcastBytes(): int
+    {
+        return ChangeRecorder::MAX_BROADCAST_BYTES;
+    }
+
+    /**
+     * Die Aufbewahrungsfrist des Aenderungs-Logs — und damit die Verfallsfrist jedes
+     * Cursors. Aus der Konfiguration, nicht abgeschrieben: wer sie dort hochsetzt,
+     * moechte nicht, dass die Doku weiter die alte Zahl nennt.
+     */
+    #[Computed]
+    public function pruneDays(): int
+    {
+        return (int) config('einundzwanzig.change_log.prune_days', 30);
+    }
+
+    /**
+     * Die Ressourcen-Namen, die im Feed ueberhaupt vorkommen — aus dem Recorder
+     * gelesen, nicht abgeschrieben. Kommt eine siebte dazu, steht sie hier.
+     *
+     * @return array<int, string>
+     */
+    #[Computed]
+    public function resourceNames(): array
+    {
+        return ChangeRecorder::resourceNames();
+    }
+
+    /**
+     * Die zwei Kanaele, die es gibt. Es sind zwei, und die Liste ist vollstaendig.
+     *
+     * @return list<array{name:string, events:string, purpose:string}>
+     */
+    #[Computed]
+    public function channels(): array
+    {
+        return [
+            [
+                'name' => 'portal',
+                'events' => 'every event of every resource',
+                'purpose' => 'The firehose: one subscription, one handler, all six resources. This is the "clear caches instantly" case.',
+            ],
+            [
+                'name' => 'meetup-events',
+                'events' => 'meetup-event.created · meetup-event.updated · meetup-event.deleted',
+                'purpose' => 'Meetup dates only. Nothing else is ever published here — no cities, no courses, not even the meetup that owns the date.',
+            ],
+        ];
+    }
+
+    /**
+     * Ein echtes Beispiel je Aktion.
+     *
+     * Die drei Objekte sind aus einem Testlauf gegen diese Anwendung entnommen und
+     * dann nur in den Werten (Ids, Namen, Zeiten) auf etwas Lesbares gesetzt — die
+     * Feldmenge ist die, die der Recorder wirklich erzeugt.
+     *
+     * @return list<array{title:string, note:HtmlString, json:string}>
+     */
+    #[Computed]
+    public function payloadExamples(): array
+    {
+        $examples = [
+            [
+                'title' => 'meetup-event.created',
+                'note' => 'A new meetup date. `data` is the complete object, in the same shape `GET /api/meetup-events` returns it — no `data` wrapper inside, because the REST API does not use one either.',
+                'json' => <<<'JSON'
+                {
+                  "action": "created",
+                  "resource": "meetup-event",
+                  "id": 1234,
+                  "sequence": 90412,
+                  "occurred_at": "2026-08-23T16:23:11+00:00",
+                  "api_version": "2.0.0",
+                  "data": {
+                    "id": 1234,
+                    "meetup_id": 77,
+                    "title": "Bitcoin-Stammtisch #42",
+                    "start": "2026-09-18T18:00:00.000000Z",
+                    "end": null,
+                    "location": "Bürgerhaus, Seiteneingang",
+                    "osm_type": null,
+                    "osm_id": null,
+                    "osm_name": null,
+                    "osm_address": null,
+                    "osm_lat": null,
+                    "osm_lon": null,
+                    "description": "Offener Abend, jeder ist willkommen.",
+                    "link": "https://example.org/stammtisch",
+                    "tags": [],
+                    "recurrence_type": null,
+                    "recurrence_day_of_week": null,
+                    "recurrence_day_position": null,
+                    "recurrence_interval": 1,
+                    "recurrence_end_date": null,
+                    "created_by": 3,
+                    "created_at": "2026-08-23T16:23:11.000000Z",
+                    "updated_at": "2026-08-23T16:23:11.000000Z"
+                  },
+                  "links": {
+                    "self": null
+                  }
+                }
+                JSON,
+            ],
+            [
+                'title' => 'meetup.updated — the second event of the same write',
+                'note' => 'Immediately after the date above, sequence 90413 carries the meetup itself: creating a date flipped `is_active` and `last_event_at`. Two records changed, so two entries. Look at `sequence` — it is one higher, not a repeat.',
+                'json' => <<<'JSON'
+                {
+                  "action": "updated",
+                  "resource": "meetup",
+                  "id": 77,
+                  "sequence": 90413,
+                  "occurred_at": "2026-08-23T16:23:11+00:00",
+                  "api_version": "2.0.0",
+                  "data": {
+                    "id": 77,
+                    "name": "Bitcoin Meetup Dortmund",
+                    "slug": "bitcoin-meetup-dortmund",
+                    "city_id": 12,
+                    "intro": "Jeden dritten Donnerstag.",
+                    "telegram_link": "https://t.me/dortmund_btc",
+                    "webpage": "https://dortmund.einundzwanzig.space",
+                    "twitter_username": null,
+                    "matrix_group": null,
+                    "nostr": null,
+                    "simplex": null,
+                    "signal": null,
+                    "community": "einundzwanzig",
+                    "visible_on_map": 1,
+                    "is_active": true,
+                    "rsvp_enabled": true,
+                    "attendees_public": true,
+                    "logo": "https://portal.einundzwanzig.space/img/domains/de-DE.jpg",
+                    "last_event_at": "2026-09-18T18:00:00.000000Z",
+                    "created_by": 3,
+                    "created_at": "2024-02-01T09:12:00.000000Z",
+                    "updated_at": "2026-08-23T16:23:11.000000Z"
+                  },
+                  "links": {
+                    "self": null
+                  }
+                }
+                JSON,
+            ],
+            [
+                'title' => 'meetup-event.deleted',
+                'note' => '`data` is null — the record is gone, and no model in this application uses soft deletes. What you get instead is `previous`: the last known identifiers, enough to invalidate a cache entry by hand. This is the one event you cannot reconstruct from anywhere else.',
+                'json' => <<<'JSON'
+                {
+                  "action": "deleted",
+                  "resource": "meetup-event",
+                  "id": 1234,
+                  "sequence": 90598,
+                  "occurred_at": "2026-08-24T08:02:44+00:00",
+                  "api_version": "2.0.0",
+                  "data": null,
+                  "links": {
+                    "self": null
+                  },
+                  "previous": {
+                    "meetup_id": 77
+                  }
+                }
+                JSON,
+            ],
+        ];
+
+        return array_map(
+            fn (array $example): array => [...$example, 'note' => $this->formatted($example['note'])],
+            $examples,
+        );
+    }
+
+    /**
+     * Der Antwortumschlag von /api/changes.
+     */
+    #[Computed]
+    public function envelopeExample(): string
+    {
+        return <<<'JSON'
+        {
+          "changes": [
+            {
+              "action": "created",
+              "resource": "meetup-event",
+              "id": 1234,
+              "sequence": 90412,
+              "occurred_at": "2026-08-23T16:23:11+00:00",
+              "api_version": "2.0.0",
+              "data": { "id": 1234, "meetup_id": 77, "title": "Bitcoin-Stammtisch #42" },
+              "links": { "self": null }
+            },
+            {
+              "action": "updated",
+              "resource": "meetup",
+              "id": 77,
+              "sequence": 90413,
+              "occurred_at": "2026-08-23T16:23:11+00:00",
+              "api_version": "2.0.0",
+              "data": { "id": 77, "name": "Bitcoin Meetup Dortmund", "is_active": true },
+              "links": { "self": null }
+            }
+          ],
+          "next_since": 90413,
+          "has_more": false,
+          "cursor_expired": false
+        }
+        JSON;
+    }
+
+    /**
+     * Das TypeScript-Beispiel — copy-paste-faehig, mit den echten Werten dieser
+     * Installation (oder den Platzhaltern, solange es keine gibt).
+     */
+    #[Computed]
+    public function typescriptExample(): string
+    {
+        $connection = $this->connection();
+        $changesUrl = $this->changesUrl();
+        $forceTls = $connection['scheme'] === 'wss' ? 'true' : 'false';
+        $maxBytes = ChangeRecorder::MAX_BROADCAST_BYTES;
+        $pruneDays = $this->pruneDays();
+
+        return <<<TS
+        // npm i pusher-js
+        //
+        // One file, both halves: the socket delivers changes while you are connected,
+        // and /api/changes closes the gap of everything you missed while you were not.
+        // Neither half is optional. The socket has no delivery guarantee.
+
+        import Pusher from 'pusher-js';
+
+        const WS_HOST = '{$connection['host']}';
+        const WS_PATH = '{$connection['ws_path']}';        // nginx proxies only this prefix
+        const APP_KEY = '{$connection['key']}';
+        const CHANGES = '{$changesUrl}';
+
+        type Change = {
+          action: 'created' | 'updated' | 'deleted';
+          resource: 'meetup' | 'meetup-event' | 'city' | 'course' | 'course-event' | 'lecturer';
+          id: number;
+          sequence: number;
+          occurred_at: string;
+          api_version: string;
+          data: Record<string, unknown> | null;
+          links: { self: string | null };
+          previous?: Record<string, unknown>;
+          truncated?: boolean;
+        };
+
+        type ChangesResponse = {
+          changes: Change[];
+          next_since: number | null;
+          has_more: boolean;
+          cursor_expired: boolean;
+        };
+
+        // Persist this. A cursor that only lives in memory is no cursor at all:
+        // after a restart you cannot tell "nothing happened" from "I missed a deletion".
+        let cursor: number | null = loadCursor();
+
+        function loadCursor(): number | null {
+          // Replace with your own storage (file, Redis, a column — anything that survives).
+          return null;
+        }
+
+        function saveCursor(value: number | null): void {
+          cursor = value;
+        }
+
+        function apply(change: Change): void {
+          // Idempotent, please: the same sequence may arrive twice — once over the
+          // socket, once again through the catch-up below. Deduplicate on `sequence`.
+          console.log(change.sequence, change.action, change.resource, change.id);
+        }
+
+        /** Drain /api/changes from the stored cursor until there is nothing left. */
+        async function catchUp(): Promise<void> {
+          for (;;) {
+            const url = new URL(CHANGES);
+            if (cursor !== null) {
+              url.searchParams.set('since', String(cursor));
+            }
+            url.searchParams.set('limit', '1000');
+
+            const response = await fetch(url, { headers: { Accept: 'application/json' } });
+            if (!response.ok) {
+              throw new Error(`/api/changes returned \${response.status}`);
+            }
+
+            const page = (await response.json()) as ChangesResponse;
+
+            if (page.cursor_expired) {
+              // Your cursor is older than the oldest row still on file ({$pruneDays}-day prune).
+              // Changes happened that this endpoint can no longer hand out — deletions
+              // above all. Re-read the regular endpoints in full, then continue from the
+              // next_since OF THIS VERY ANSWER, not from the old cursor.
+              await fullResync();
+              saveCursor(page.next_since);
+              return;
+            }
+
+            page.changes.forEach(apply);
+            saveCursor(page.next_since);
+
+            if (!page.has_more) {
+              return;
+            }
+          }
+        }
+
+        async function fullResync(): Promise<void> {
+          // GET /api/meetups, /api/meetup-events, /api/cities, /api/courses,
+          // /api/course-events, /api/lecturers — and drop whatever is no longer in them.
+        }
+
+        const pusher = new Pusher(APP_KEY, {
+          wsHost: WS_HOST,
+          wsPath: WS_PATH,
+          wsPort: {$connection['port']},
+          wssPort: {$connection['port']},
+          forceTLS: {$forceTls},
+          enabledTransports: ['ws', 'wss'],
+          disableStats: true,
+          // No `cluster`: pusher-js only needs one when it has to resolve the host itself.
+        });
+
+        // A rejected origin still completes the handshake with HTTP 101. The refusal
+        // arrives afterwards, as a frame with code 4009. Bind this, or you will sit on a
+        // socket you believe is connected and stay silent forever.
+        pusher.connection.bind('error', (error: any) => {
+          const code = error?.error?.data?.code ?? error?.data?.code;
+          console.error('reverb connection error', code, error);
+        });
+
+        pusher.connection.bind('state_change', (states: { previous: string; current: string }) => {
+          console.log('reverb', states.previous, '->', states.current);
+        });
+
+        // Every reconnect — not just the first connect — has to be followed by a
+        // catch-up. Whatever happened while the socket was down was never queued.
+        pusher.connection.bind('connected', () => {
+          catchUp().catch((error) => console.error('catch-up failed', error));
+        });
+
+        // The firehose. Subscribe to `meetup-events` instead if you only care about dates.
+        const portal = pusher.subscribe('portal');
+
+        // With raw pusher-js you bind the name that is actually on the wire — no leading
+        // dot. (With laravel-echo you would write .listen('.meetup-event.created'): that
+        // dot is Echo's "no namespace" marker, Echo strips it and subscribes to the very
+        // same name.) A name that never matches is silent, exactly like a channel that
+        // does not exist.
+        for (const resource of ['meetup', 'meetup-event', 'city', 'course', 'course-event', 'lecturer']) {
+          for (const action of ['created', 'updated', 'deleted']) {
+            portal.bind(`\${resource}.\${action}`, (change: Change) => {
+              if (change.truncated) {
+                // Over {$maxBytes} bytes: `data` was dropped for this hop.
+                // The complete object is in /api/changes under the same sequence.
+                catchUp().catch((error) => console.error('catch-up failed', error));
+                return;
+              }
+              apply(change);
+            });
+          }
+        }
+        TS;
+    }
+
+    /**
+     * Die vier Dinge, die ein Konsument sonst falsch macht.
+     *
+     * @return list<array{icon:string, title:HtmlString, body:HtmlString}>
+     */
+    #[Computed]
+    public function pitfalls(): array
+    {
+        $pitfalls = [
+            [
+                'icon' => 'square-2-stack',
+                'title' => 'One write can produce two events. That is not a double send.',
+                'body' => 'Saving a meetup date recalculates the activity state of the meetup that owns it. If `is_active` or `last_event_at` change with it, a second entry goes out for the `meetup` resource — right after the `meetup-event` one, with the next sequence number. Both are real changes to two different records, and both are what keeps a cached meetup list from quietly going stale on exactly those two fields. This happens on the channel and in `/api/changes` alike, because both read the same row. The rule is "one entry per changed record", never "one entry per request".',
+            ],
+            [
+                'icon' => 'clock',
+                'title' => '`cursor_expired: true` means your cache is wrong, not that nothing happened.',
+                'body' => 'The change log is pruned after '.$this->pruneDays().' days, which makes '.$this->pruneDays().' days a cursor expiry date. If you send a cursor older than the oldest row still on file, the endpoint cannot hand out what happened in between — deletions above all, because no model uses soft deletes and there is nowhere else to learn about them. The field is `true` exactly then, and present as `false` in every other answer, so you can read it without checking whether it exists. On `true`: read the regular endpoints in full, drop whatever is no longer in them, and then continue with the `next_since` of that same answer — not with your old cursor, and not with the `next_since` of a later call.',
+            ],
+            [
+                'icon' => 'link-slash',
+                'title' => '`links.self` is null for four of the six resources. Nothing is broken.',
+                'body' => 'Only `course` and `lecturer` have a public show endpoint today, so only they get a link. For `meetup`, `meetup-event`, `city` and `course-event` the field is `null` on purpose — a URL that answers 404 would be worse than an honest null. You do not need it: `data` already carries the complete object, which is the whole point of the payload. If you do need to re-fetch, `/api/changes` is the way.',
+            ],
+            [
+                'icon' => 'exclamation-triangle',
+                'title' => 'A rejected origin looks exactly like success.',
+                'body' => 'The WebSocket handshake completes with HTTP 101 and only then does the server send a frame with `code 4009, "Origin not allowed"`. A client that checks the status code and nothing else believes it is connected and stays silent forever — the same failure class as subscribing to a channel that does not exist. Bind the connection `error` event and log the code. (Today `allowed_origins` is `*`, measured and decided: a concrete list rejects every client that sends no `Origin` header at all, which is precisely what a server-side consumer does.)',
+            ],
+        ];
+
+        return array_map(
+            fn (array $pitfall): array => [
+                ...$pitfall,
+                'title' => $this->formatted($pitfall['title']),
+                'body' => $this->formatted($pitfall['body']),
+            ],
+            $pitfalls,
+        );
+    }
+
+    /**
+     * Die sechs bewusst akzeptierten Luecken, ohne Beschoenigung.
+     *
+     * @return list<array{title:HtmlString, body:HtmlString}>
+     */
+    #[Computed]
+    public function gaps(): array
+    {
+        $gaps = [
+            [
+                'title' => 'No delivery guarantee',
+                'body' => 'Anything that happens while you are not connected is not kept for you. There is no offline queue and no per-consumer state — the server does not know you exist. `/api/changes` is the replacement, and it is the reason the socket is allowed to be this simple.',
+            ],
+            [
+                'title' => 'No retry — a single failed broadcast loses the event on the channel for good',
+                'body' => 'The queue that carries a broadcast from the application to Reverb runs with `tries = 1`. One failed attempt and the event is gone from the channel — no second attempt, no dead-letter entry you could replay. The row in the change log is written before the broadcast is even attempted and survives it, so `/api/changes` still has the change. That is not a nice-to-have fallback: for this class of failure it is the only copy.',
+            ],
+            [
+                'title' => 'No replay in the protocol',
+                'body' => 'Pusher-protocol channels have no "give me what I missed". You cannot ask the socket for sequence 90412. `/api/changes?since=90411` can.',
+            ],
+            [
+                'title' => 'No per-message signature',
+                'body' => 'Messages are not signed. Authenticity rests on TLS and the hostname you connected to, nothing else. `REVERB_APP_SECRET` protects the path from the application to Reverb — it says nothing about the message you receive.',
+            ],
+            [
+                'title' => 'No guaranteed ordering across reconnects',
+                'body' => 'Within one connection events arrive in the order they were sent. Across a reconnect nothing is promised. `sequence` is strictly increasing and gap-free at the source, so a gap you can see is a gap you can fix — sort by it, deduplicate by it, and use it as the cursor.',
+            ],
+            [
+                'title' => 'No Pusher webhooks, and no HTTP webhooks either',
+                'body' => 'Reverb does not implement the Pusher webhook API (laravel/reverb#64 was closed without an implementation), and this portal does not POST to registered URLs with an HMAC and a retry schedule. If that is what you need, say so on the issue — the change log is the substrate a webhook fan-out would read, so it is buildable, it is just not built.',
+            ],
+        ];
+
+        return array_map(
+            fn (array $gap): array => [
+                'title' => $this->formatted($gap['title']),
+                'body' => $this->formatted($gap['body']),
+            ],
+            $gaps,
+        );
+    }
+}; ?>
+
+<div class="relative min-h-screen overflow-hidden text-zinc-900 dark:text-white">
+    {{-- Dekorativer Hintergrund-Glow, wie auf /ki-assistent --}}
+    <div aria-hidden="true"
+         class="pointer-events-none absolute inset-x-0 top-0 -z-10 h-[40rem] bg-[radial-gradient(60rem_30rem_at_50%_-10%,rgba(249,115,22,0.18),transparent)]"></div>
+
+    {{-- Kopfleiste --}}
+    <header class="mx-auto flex max-w-6xl items-center justify-between gap-4 px-6 py-6">
+        <a href="{{ route('welcome') }}" wire:navigate class="flex items-center gap-3" aria-label="EINUNDZWANZIG">
+            <div class="size-10">
+                <x-app-logo-icon/>
+            </div>
+            <span class="hidden text-sm font-semibold tracking-tight sm:block">EINUNDZWANZIG</span>
+        </a>
+
+        <flux:button :href="route('scramble.docs.ui')" variant="ghost" icon="book-open-text" size="sm">
+            API reference
+        </flux:button>
+    </header>
+
+    {{-- Hero --}}
+    <section class="mx-auto max-w-4xl px-6 pt-6 pb-12 text-center sm:pt-12">
+        <flux:badge color="orange" size="sm" icon="bolt" class="mb-6">Realtime</flux:badge>
+
+        <h1 class="mx-auto max-w-3xl text-balance text-4xl font-bold tracking-tight sm:text-5xl">
+            Realtime change feed
+        </h1>
+
+        <p class="mx-auto mt-6 max-w-2xl text-pretty text-lg text-zinc-600 dark:text-zinc-300">
+            Learn that a meetup, a date, a city, a course, a course event or a lecturer was created,
+            changed or deleted — instead of diffing a fresh export against an old cache.
+        </p>
+    </section>
+
+    {{-- Zwei Wege --}}
+    <section class="mx-auto max-w-5xl px-6 pb-16">
+        <div class="grid gap-4 lg:grid-cols-2">
+            <div class="rounded-2xl border border-emerald-500/30 bg-emerald-500/[0.06] p-6 sm:p-8">
+                <div class="flex items-center gap-3">
+                    <flux:icon name="shield-check" class="size-5 text-emerald-500"/>
+                    <flux:heading size="lg">
+                        <a href="{{ $this->changesUrl }}" class="underline decoration-emerald-500/40 underline-offset-4">GET /api/changes</a>
+                        — the reliable way
+                    </flux:heading>
+                </div>
+                <p class="mt-3 text-pretty leading-relaxed text-zinc-600 dark:text-zinc-300">
+                    A cursor-paginated change log. It replays, it survives your downtime, and it is the
+                    only place a deletion can ever be learned about after the fact. Public, no token,
+                    same 60 requests/minute as the rest of the read API. If you build only one half,
+                    build this one.
+                </p>
+            </div>
+
+            <div class="rounded-2xl border border-orange-500/30 bg-orange-500/[0.06] p-6 sm:p-8">
+                <div class="flex items-center gap-3">
+                    <flux:icon name="bolt" class="size-5 text-orange-500"/>
+                    <flux:heading size="lg">The WebSocket — the fast way</flux:heading>
+                </div>
+                <p class="mt-3 text-pretty leading-relaxed text-zinc-600 dark:text-zinc-300">
+                    Two public channels on a Laravel Reverb server (Pusher protocol), no authentication.
+                    You hear about a change within milliseconds instead of within a poll interval.
+                    It carries no guarantee of any kind: not delivery, not retry, not replay, not
+                    ordering across a reconnect.
+                </p>
+            </div>
+        </div>
+
+        <div class="mt-4 flex items-start gap-4 rounded-2xl border border-zinc-200 bg-white/60 p-6 dark:border-white/10 dark:bg-white/[0.03]">
+            <flux:icon name="arrow-path" class="mt-0.5 size-5 shrink-0 text-orange-500"/>
+            <p class="text-pretty leading-relaxed text-zinc-700 dark:text-zinc-200">
+                <strong>After every reconnect, catch up over <code class="rounded bg-zinc-900/5 px-1 py-0.5 font-mono text-sm dark:bg-white/10">/api/changes</code>.</strong>
+                Not only after the first connect — after every single one. Nothing that happened while
+                your socket was down was queued for you, and no error will tell you that you missed it.
+                The two halves are one design: the socket says <em>now</em>, the endpoint says <em>completely</em>.
+            </p>
+        </div>
+    </section>
+
+    {{-- Verbindung --}}
+    <section class="mx-auto max-w-5xl px-6 pb-16">
+        <flux:heading size="xl" class="mb-6">Connecting</flux:heading>
+
+        @unless ($this->connection['published'])
+            <div class="mb-6 flex items-start gap-4 rounded-2xl border border-amber-500/40 bg-amber-500/[0.08] p-6">
+                <flux:icon name="wrench-screwdriver" class="mt-0.5 size-5 shrink-0 text-amber-500"/>
+                <p class="text-pretty leading-relaxed text-zinc-700 dark:text-zinc-200">
+                    <strong>The socket is not published in this environment yet.</strong>
+                    Everything in curly braces below is a placeholder named after the environment
+                    variable it will come from. The values on this page are read from the running
+                    configuration, so the moment the server is deployed they appear here by themselves
+                    — there is nothing on this page to keep up to date by hand.
+                </p>
+            </div>
+        @endunless
+
+        <div class="overflow-hidden rounded-2xl border border-zinc-200 dark:border-white/10">
+            <table class="w-full text-left text-sm">
+                <tbody class="divide-y divide-zinc-200 dark:divide-white/10">
+                    <tr class="bg-white/60 dark:bg-white/[0.03]">
+                        <th scope="row" class="w-56 px-5 py-4 align-top font-semibold">WebSocket URL</th>
+                        <td class="px-5 py-4 font-mono break-all">{{ $this->connection['url'] }}</td>
+                    </tr>
+                    <tr class="bg-white/60 dark:bg-white/[0.03]">
+                        <th scope="row" class="px-5 py-4 align-top font-semibold">Host</th>
+                        <td class="px-5 py-4 font-mono break-all">{{ $this->connection['host'] }}</td>
+                    </tr>
+                    <tr class="bg-white/60 dark:bg-white/[0.03]">
+                        <th scope="row" class="px-5 py-4 align-top font-semibold">Scheme / port</th>
+                        <td class="px-5 py-4 font-mono">{{ $this->connection['scheme'] }} / {{ $this->connection['port'] }}</td>
+                    </tr>
+                    <tr class="bg-white/60 dark:bg-white/[0.03]">
+                        <th scope="row" class="px-5 py-4 align-top font-semibold"><code>wsPath</code></th>
+                        <td class="px-5 py-4">
+                            <span class="font-mono">{{ $this->connection['ws_path'] }}</span>
+                            <span class="mt-1 block text-zinc-500 dark:text-zinc-400">
+                                Not the Pusher default <code>/app</code>: that prefix is already taken by the
+                                portal's mobile login handoff, so only this path is proxied through to Reverb.
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="bg-white/60 dark:bg-white/[0.03]">
+                        <th scope="row" class="px-5 py-4 align-top font-semibold">App key</th>
+                        <td class="px-5 py-4">
+                            <span class="font-mono break-all">{{ $this->connection['key'] }}</span>
+                            <span class="mt-1 block text-zinc-500 dark:text-zinc-400">
+                                Public by design. There is no secret to hand out, because there is nothing to
+                                authenticate: both channels are public and carry only data the REST API serves
+                                without a token.
+                            </span>
+                        </td>
+                    </tr>
+                    <tr class="bg-white/60 dark:bg-white/[0.03]">
+                        <th scope="row" class="px-5 py-4 align-top font-semibold">Authentication</th>
+                        <td class="px-5 py-4">None. No <code>/broadcasting/auth</code> round trip — there are no
+                            private or presence channels.</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </section>
+
+    {{-- Kanaele --}}
+    <section class="mx-auto max-w-5xl px-6 pb-16">
+        <flux:heading size="xl" class="mb-2">Channels</flux:heading>
+        <p class="mb-6 text-pretty text-zinc-600 dark:text-zinc-300">
+            There are two. This table is the complete list — if a channel name is not in it, it does not
+            exist, and subscribing to it will succeed and stay silent forever. Country, city, entity and
+            RSVP channels have been discussed and are deliberately not built.
+        </p>
+
+        <div class="overflow-x-auto rounded-2xl border border-zinc-200 dark:border-white/10">
+            <table class="w-full min-w-[40rem] text-left text-sm">
+                <thead class="bg-zinc-50 text-xs uppercase tracking-wide text-zinc-500 dark:bg-white/[0.06] dark:text-zinc-400">
+                    <tr>
+                        <th scope="col" class="px-5 py-3">Channel</th>
+                        <th scope="col" class="px-5 py-3">Carries</th>
+                        <th scope="col" class="px-5 py-3">What for</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-zinc-200 bg-white/60 dark:divide-white/10 dark:bg-white/[0.03]">
+                    @foreach ($this->channels as $channel)
+                        <tr wire:key="channel-{{ $channel['name'] }}">
+                            <td class="px-5 py-4 align-top font-mono font-semibold text-orange-500">{{ $channel['name'] }}</td>
+                            <td class="px-5 py-4 align-top font-mono text-xs">{{ $channel['events'] }}</td>
+                            <td class="px-5 py-4 align-top text-zinc-600 dark:text-zinc-300">{{ $channel['purpose'] }}</td>
+                        </tr>
+                    @endforeach
+                </tbody>
+            </table>
+        </div>
+    </section>
+
+    {{-- Event-Namen --}}
+    <section class="mx-auto max-w-5xl px-6 pb-16">
+        <flux:heading size="xl" class="mb-2">Event names</flux:heading>
+        <p class="mb-6 text-pretty text-zinc-600 dark:text-zinc-300">
+            An event name is <code>&lt;resource&gt;.&lt;action&gt;</code> — six resources, three actions,
+            eighteen names in total. All eighteen appear on <code>portal</code>; the three
+            <code>meetup-event</code> ones also on <code>meetup-events</code>.
+        </p>
+
+        <div class="mb-8 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            @foreach ($this->resourceNames as $resource)
+                <div wire:key="resource-{{ $resource }}"
+                     class="rounded-xl border border-zinc-200 bg-white/60 p-5 dark:border-white/10 dark:bg-white/[0.03]">
+                    <div class="font-mono text-sm font-semibold text-orange-500">{{ $resource }}</div>
+                    <ul class="mt-2 space-y-1 font-mono text-xs text-zinc-600 dark:text-zinc-300">
+                        <li>{{ $resource }}.created</li>
+                        <li>{{ $resource }}.updated</li>
+                        <li>{{ $resource }}.deleted</li>
+                    </ul>
+                </div>
+            @endforeach
+        </div>
+
+        <div class="flex items-start gap-4 rounded-2xl border border-orange-500/30 bg-orange-500/[0.06] p-6">
+            <flux:icon name="ellipsis-horizontal-circle" class="mt-0.5 size-5 shrink-0 text-orange-500"/>
+            <div>
+                <flux:heading size="lg" class="mb-2">The leading dot: where it belongs, and where it does not</flux:heading>
+                <p class="text-pretty leading-relaxed text-zinc-600 dark:text-zinc-300">
+                    Laravel examples show event names written with a leading dot, and that trips people
+                    up. The dot is <strong>client syntax, not part of the name</strong>: it tells
+                    <code>laravel-echo</code> not to prepend an application namespace, and Echo removes
+                    it before subscribing. On the wire the event is called
+                    <code>meetup-event.created</code>, full stop.
+                </p>
+                <div class="mt-4 grid gap-3 sm:grid-cols-2">
+                    <div class="rounded-xl border border-zinc-200 bg-white p-4 dark:border-white/10 dark:bg-zinc-900">
+                        <div class="mb-2 text-xs font-semibold uppercase tracking-wide text-zinc-500 dark:text-zinc-400">Raw pusher-js — no dot</div>
+                        <pre class="overflow-x-auto text-xs leading-relaxed"><code>pusher
+  .subscribe('meetup-events')
+  .bind('meetup-event.created', handler);</code></pre>
+                    </div>
+                    <div class="rounded-xl border border-zinc-200 bg-white p-4 dark:border-white/10 dark:bg-zinc-900">
+                        <div class="mb-2 text-xs font-semibold uppercase tracking-wide text-zinc-500 dark:text-zinc-400">laravel-echo — with the dot</div>
+                        <pre class="overflow-x-auto text-xs leading-relaxed"><code>Echo
+  .channel('meetup-events')
+  .listen('.meetup-event.created', handler);</code></pre>
+                    </div>
+                </div>
+                <p class="mt-4 text-pretty leading-relaxed text-zinc-600 dark:text-zinc-300">
+                    Both subscribe to the same event. Get it wrong in either direction — a dot passed to
+                    <code>bind()</code>, or none passed to <code>listen()</code> — and you subscribe to a
+                    name nobody sends. That succeeds, and then stays silent forever.
+                </p>
+            </div>
+        </div>
+    </section>
+
+    {{-- Payload-Vertrag --}}
+    <section class="mx-auto max-w-5xl px-6 pb-16">
+        <flux:heading size="xl" class="mb-2">The payload contract</flux:heading>
+        <p class="mb-6 text-pretty text-zinc-600 dark:text-zinc-300">
+            Every event, on either channel, is one envelope. The exact same envelope comes back out of
+            <code>/api/changes</code> — byte for byte, because it is built once and stored, not rebuilt
+            per transport. <code>data</code> follows the shape of the matching REST resource, so you do
+            not need a second set of types.
+        </p>
+
+        <div class="mb-8 overflow-x-auto rounded-2xl border border-zinc-200 dark:border-white/10">
+            <table class="w-full min-w-[40rem] text-left text-sm">
+                <thead class="bg-zinc-50 text-xs uppercase tracking-wide text-zinc-500 dark:bg-white/[0.06] dark:text-zinc-400">
+                    <tr>
+                        <th scope="col" class="px-5 py-3">Field</th>
+                        <th scope="col" class="px-5 py-3">Meaning</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-zinc-200 bg-white/60 dark:divide-white/10 dark:bg-white/[0.03]">
+                    <tr>
+                        <td class="px-5 py-3 font-mono">action</td>
+                        <td class="px-5 py-3 text-zinc-600 dark:text-zinc-300"><code>created</code>, <code>updated</code> or <code>deleted</code>.</td>
+                    </tr>
+                    <tr>
+                        <td class="px-5 py-3 font-mono">resource</td>
+                        <td class="px-5 py-3 text-zinc-600 dark:text-zinc-300">One of {{ implode(', ', $this->resourceNames) }}.</td>
+                    </tr>
+                    <tr>
+                        <td class="px-5 py-3 font-mono">id</td>
+                        <td class="px-5 py-3 text-zinc-600 dark:text-zinc-300">Primary key of the record that changed.</td>
+                    </tr>
+                    <tr>
+                        <td class="px-5 py-3 font-mono">sequence</td>
+                        <td class="px-5 py-3 text-zinc-600 dark:text-zinc-300">Strictly increasing, and the cursor you send back as <code>since</code>. Deduplicate on it.</td>
+                    </tr>
+                    <tr>
+                        <td class="px-5 py-3 font-mono">occurred_at</td>
+                        <td class="px-5 py-3 text-zinc-600 dark:text-zinc-300">ISO 8601, the moment of the change — not the moment of delivery.</td>
+                    </tr>
+                    <tr>
+                        <td class="px-5 py-3 font-mono">api_version</td>
+                        <td class="px-5 py-3 text-zinc-600 dark:text-zinc-300">The REST API version whose resource shape <code>data</code> follows.</td>
+                    </tr>
+                    <tr>
+                        <td class="px-5 py-3 font-mono">data</td>
+                        <td class="px-5 py-3 text-zinc-600 dark:text-zinc-300">The complete object, bare — no <code>data</code> wrapper inside. <code>null</code> on <code>deleted</code>, and <code>null</code> when the envelope was too large (see below).</td>
+                    </tr>
+                    <tr>
+                        <td class="px-5 py-3 font-mono">links.self</td>
+                        <td class="px-5 py-3 text-zinc-600 dark:text-zinc-300"><code>null</code> for four of the six resources. Normal — see the pitfalls below.</td>
+                    </tr>
+                    <tr>
+                        <td class="px-5 py-3 font-mono">previous</td>
+                        <td class="px-5 py-3 text-zinc-600 dark:text-zinc-300">Only on <code>deleted</code>: the last known identifiers of the record that is gone.</td>
+                    </tr>
+                    <tr>
+                        <td class="px-5 py-3 font-mono">truncated</td>
+                        <td class="px-5 py-3 text-zinc-600 dark:text-zinc-300">Only present, and only <code>true</code>, when <code>data</code> was dropped for size.</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+
+        @foreach ($this->payloadExamples as $example)
+            <div wire:key="payload-{{ $loop->index }}" class="mb-6">
+                <flux:heading size="lg" class="mb-2 font-mono">{{ $example['title'] }}</flux:heading>
+                <p class="mb-3 text-pretty text-sm text-zinc-600 dark:text-zinc-300">{!! $example['note'] !!}</p>
+                <pre class="overflow-x-auto rounded-xl border border-zinc-200 bg-white p-5 text-xs leading-relaxed dark:border-white/10 dark:bg-zinc-900"><code>{{ $example['json'] }}</code></pre>
+            </div>
+        @endforeach
+
+        <div class="mt-8 flex items-start gap-4 rounded-2xl border border-zinc-200 bg-white/60 p-6 dark:border-white/10 dark:bg-white/[0.03]">
+            <flux:icon name="scissors" class="mt-0.5 size-5 shrink-0 text-orange-500"/>
+            <div>
+                <flux:heading size="lg" class="mb-2">The {{ number_format($this->maxBroadcastBytes, 0, '.', ' ') }} byte limit</flux:heading>
+                <p class="text-pretty leading-relaxed text-zinc-600 dark:text-zinc-300">
+                    Reverb rejects anything above <code>max_request_size</code> ({{ number_format($this->maxBroadcastBytes, 0, '.', ' ') }} bytes)
+                    with HTTP 413, so an envelope that would exceed it goes out over the socket as
+                    <code>"data": null, "truncated": true</code> instead of not going out at all. The stored
+                    row keeps the complete object: fetch it from
+                    <a href="{{ $this->changesUrl }}" class="underline underline-offset-4">/api/changes</a>
+                    under the same <code>sequence</code>. Measured against the whole envelope, not just
+                    <code>data</code> — a long event description is the usual cause.
+                </p>
+            </div>
+        </div>
+    </section>
+
+    {{-- /api/changes --}}
+    <section class="mx-auto max-w-5xl px-6 pb-16">
+        <flux:heading size="xl" class="mb-2">The <code>/api/changes</code> envelope</flux:heading>
+        <p class="mb-6 text-pretty text-zinc-600 dark:text-zinc-300">
+            This is the one endpoint in the API that wraps its list in an object instead of returning a
+            bare array — the cursor has to travel with the answer. The list is called
+            <code>changes</code>, not <code>data</code>, because every entry already carries a
+            <code>data</code> field of its own.
+        </p>
+
+        <pre class="mb-6 overflow-x-auto rounded-xl border border-zinc-200 bg-white p-5 text-xs leading-relaxed dark:border-white/10 dark:bg-zinc-900"><code>{{ $this->envelopeExample }}</code></pre>
+        <p class="mb-8 text-sm text-zinc-500 dark:text-zinc-400">
+            (<code>data</code> shortened here for readability — in the real answer it is the complete
+            object, exactly as in the examples above.)
+        </p>
+
+        <div class="mb-8 overflow-x-auto rounded-2xl border border-zinc-200 dark:border-white/10">
+            <table class="w-full min-w-[40rem] text-left text-sm">
+                <thead class="bg-zinc-50 text-xs uppercase tracking-wide text-zinc-500 dark:bg-white/[0.06] dark:text-zinc-400">
+                    <tr>
+                        <th scope="col" class="px-5 py-3">Field</th>
+                        <th scope="col" class="px-5 py-3">Meaning</th>
+                    </tr>
+                </thead>
+                <tbody class="divide-y divide-zinc-200 bg-white/60 dark:divide-white/10 dark:bg-white/[0.03]">
+                    <tr>
+                        <td class="px-5 py-3 font-mono">changes</td>
+                        <td class="px-5 py-3 text-zinc-600 dark:text-zinc-300">The entries, ascending by <code>sequence</code>. Same envelope as on the channel.</td>
+                    </tr>
+                    <tr>
+                        <td class="px-5 py-3 font-mono">next_since</td>
+                        <td class="px-5 py-3 text-zinc-600 dark:text-zinc-300">The cursor for your next call. On an empty page it is the cursor you sent, not <code>null</code> — so a quiet minute does not rewind you to the beginning.</td>
+                    </tr>
+                    <tr>
+                        <td class="px-5 py-3 font-mono">has_more</td>
+                        <td class="px-5 py-3 text-zinc-600 dark:text-zinc-300"><code>true</code> when <code>limit</code> cut the page off. Keep calling until it is <code>false</code>.</td>
+                    </tr>
+                    <tr>
+                        <td class="px-5 py-3 font-mono">cursor_expired</td>
+                        <td class="px-5 py-3 text-zinc-600 dark:text-zinc-300">Present in every answer, including as <code>false</code>. On <code>true</code>, your cache is incomplete — see the pitfalls below.</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+
+        <flux:heading size="lg" class="mb-3">The cursor loop</flux:heading>
+        <p class="mb-4 text-pretty text-zinc-600 dark:text-zinc-300">
+            <code>since</code> → read <code>next_since</code> → send it back as <code>since</code>. That is
+            the whole protocol. The cursor is exclusive: you never receive the entry you named again.
+        </p>
+        <pre class="overflow-x-auto rounded-xl border border-zinc-200 bg-white p-5 text-xs leading-relaxed dark:border-white/10 dark:bg-zinc-900"><code># First call ever — no cursor. You get the newest 100 entries (limit, max 1000)
+# just to pick up a starting point, and has_more is false.
+curl '{{ $this->changesUrl }}?limit=1'
+
+# → { "changes": [ … ], "next_since": 90413, "has_more": false, "cursor_expired": false }
+
+# Every call after that: send back what you were given.
+curl '{{ $this->changesUrl }}?since=90413'
+
+# Only interested in dates? Filter — repeatable or comma separated.
+curl '{{ $this->changesUrl }}?since=90413&resource=meetup-event,meetup'
+
+# A timestamp works as a cursor too, for a consumer that only knows when it last synced.
+curl '{{ $this->changesUrl }}?since=2026-08-23T16:00:00%2B00:00'</code></pre>
+    </section>
+
+    {{-- TypeScript --}}
+    <section class="mx-auto max-w-5xl px-6 pb-16">
+        <flux:heading size="xl" class="mb-2">A working TypeScript client</flux:heading>
+        <p class="mb-6 text-pretty text-zinc-600 dark:text-zinc-300">
+            Both halves in one file: subscribe to the channel, and catch up over
+            <code>/api/changes</code> on every <code>connected</code>. The only dependency is
+            <code>pusher-js</code> — Reverb speaks the Pusher protocol, so no Laravel-specific client is
+            needed.
+        </p>
+        <pre class="overflow-x-auto rounded-xl border border-zinc-200 bg-white p-5 text-xs leading-relaxed dark:border-white/10 dark:bg-zinc-900"><code>{{ $this->typescriptExample }}</code></pre>
+    </section>
+
+    {{-- Stolperfallen --}}
+    <section class="mx-auto max-w-5xl px-6 pb-16">
+        <flux:heading size="xl" class="mb-2">Four things that go wrong</flux:heading>
+        <p class="mb-6 text-pretty text-zinc-600 dark:text-zinc-300">
+            None of these produce an error message. That is what they have in common, and why they are
+            listed here rather than left to be discovered.
+        </p>
+
+        <div class="space-y-4">
+            @foreach ($this->pitfalls as $pitfall)
+                <div wire:key="pitfall-{{ $loop->index }}"
+                     class="flex items-start gap-4 rounded-2xl border border-zinc-200 bg-white/60 p-6 dark:border-white/10 dark:bg-white/[0.03]">
+                    <div class="shrink-0 rounded-lg bg-orange-500/10 p-2.5 text-orange-500">
+                        <flux:icon name="{{ $pitfall['icon'] }}" class="size-6"/>
+                    </div>
+                    <div>
+                        <flux:heading size="lg" class="mb-2">{!! $pitfall['title'] !!}</flux:heading>
+                        <p class="text-pretty leading-relaxed text-zinc-600 dark:text-zinc-300">{!! $pitfall['body'] !!}</p>
+                    </div>
+                </div>
+            @endforeach
+        </div>
+    </section>
+
+    {{-- Luecken --}}
+    <section class="mx-auto max-w-5xl px-6 pb-16">
+        <flux:heading size="xl" class="mb-2">Six gaps, accepted on purpose</flux:heading>
+        <p class="mb-6 text-pretty text-zinc-600 dark:text-zinc-300">
+            None of these are oversights and none are on a roadmap. They are the price of a transport
+            that is this simple, and they are listed so you can decide whether it is a price you can pay.
+            Every one of them is survivable in the same way: <code>/api/changes</code>.
+        </p>
+
+        <div class="grid gap-4 lg:grid-cols-2">
+            @foreach ($this->gaps as $gap)
+                <div wire:key="gap-{{ $loop->index }}"
+                     class="rounded-2xl border border-zinc-200 bg-white/60 p-6 dark:border-white/10 dark:bg-white/[0.03]">
+                    <div class="flex items-start gap-3">
+                        <flux:icon name="minus-circle" class="mt-0.5 size-5 shrink-0 text-zinc-400"/>
+                        <div>
+                            <flux:heading size="lg" class="mb-2">{!! $gap['title'] !!}</flux:heading>
+                            <p class="text-pretty leading-relaxed text-zinc-600 dark:text-zinc-300">{!! $gap['body'] !!}</p>
+                        </div>
+                    </div>
+                </div>
+            @endforeach
+        </div>
+    </section>
+
+    {{-- Betrieb --}}
+    <section class="mx-auto max-w-5xl px-6 pb-24">
+        <flux:heading size="xl" class="mb-6">Operations</flux:heading>
+
+        <div class="space-y-4">
+            <div class="flex items-start gap-4 rounded-2xl border border-zinc-200 bg-white/60 p-6 dark:border-white/10 dark:bg-white/[0.03]">
+                <flux:icon name="arrow-path-rounded-square" class="mt-0.5 size-5 shrink-0 text-orange-500"/>
+                <div>
+                    <flux:heading size="lg" class="mb-2">Every deploy drops every connection</flux:heading>
+                    <p class="text-pretty leading-relaxed text-zinc-600 dark:text-zinc-300">
+                        The server is restarted as part of the deploy, and the restart has no graceful
+                        drain: all sockets close at once, without a goodbye frame. That is normal and it
+                        happens whenever the portal ships. Plan for reconnect with backoff — and for the
+                        catch-up over <code>/api/changes</code> that follows it, because the changes made
+                        during the restart window were not kept for you.
+                    </p>
+                </div>
+            </div>
+
+            <div class="flex items-start gap-4 rounded-2xl border border-zinc-200 bg-white/60 p-6 dark:border-white/10 dark:bg-white/[0.03]">
+                <flux:icon name="chat-bubble-left-right" class="mt-0.5 size-5 shrink-0 text-orange-500"/>
+                <div>
+                    <flux:heading size="lg" class="mb-2">Missing a channel you need?</flux:heading>
+                    <p class="text-pretty leading-relaxed text-zinc-600 dark:text-zinc-300">
+                        Country-scoped, city-scoped and per-entity channels are designed but not built,
+                        because a published channel name is a contract whose breach is silent at the
+                        subscriber. They get built when a consumer asks for them by name — say so on
+                        <a href="https://github.com/HolgerHatGarKeineNode/einundzwanzig-app/issues/29"
+                           class="underline underline-offset-4" target="_blank" rel="noopener">issue #29</a>.
+                    </p>
+                </div>
+            </div>
+        </div>
+    </section>
+</div>

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\Api\BtcMapCommunityController;
+use App\Http\Controllers\Api\ChangeController;
 use App\Http\Controllers\Api\CityController;
 use App\Http\Controllers\Api\CountryController;
 use App\Http\Controllers\Api\CourseController;
@@ -37,6 +38,9 @@ Route::middleware([SetApiLocale::class, 'throttle:60,1'])
         Route::get('mobile/meetups', MobileMeetupListController::class);
         Route::get('meetup-events/{date?}', MeetupEventController::class);
         Route::get('btc-map-communities', BtcMapCommunityController::class);
+        // Der Resync-Weg fuer Konsumenten (Issue #29): alle Aenderungen ab einem
+        // Cursor, inklusive der Loeschungen, die sonst nirgends sichtbar sind.
+        Route::get('changes', [ChangeController::class, 'index'])->name('changes.index');
     });
 
 /*

--- a/routes/channels.php
+++ b/routes/channels.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| Broadcast Channels
+|--------------------------------------------------------------------------
+|
+| Bewusst leer (Issue #29, Plan-Phase P4).
+|
+| Das Portal broadcastet ausschliesslich auf OEFFENTLICHEN Kanaelen — `portal` und
+| `meetup-events`. Ein oeffentlicher Kanal wird von Reverb ohne Rueckfrage bei der
+| Anwendung abonniert; `Broadcast::channel()` wird fuer ihn nie aufgerufen. Eine
+| Autorisierungsregel hier haette also keine Wirkung, aber sie waere ein Versprechen:
+| wer sie liest, haelt den Kanal fuer geschuetzt.
+|
+| Private und Presence-Kanaele sind laut Plan ausdruecklich out of scope; sie brauchen
+| `/broadcasting/auth` und eine Autorisierungsschicht, die es hier nicht gibt.
+|
+| Die Datei existiert trotzdem, und sie existierte VOR `reverb:install`: der Installer
+| ruft sonst `install:broadcasting` auf, das `resources/js/echo.js` anlegt und einen
+| Import in `app.js` haengt. Das Portal konsumiert seine eigenen Kanaele nicht.
+|
+*/

--- a/routes/console.php
+++ b/routes/console.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Console\Commands\Database\CleanupLoginKeys;
+use App\Console\Commands\Database\PruneApiChanges;
 use App\Console\Commands\Database\UpdateMeetupActivity;
 use App\Console\Commands\Nostr\PublishUnpublishedItems;
 
@@ -15,3 +16,11 @@ Schedule::command(PublishUnpublishedItems::class, [
 ])->dailyAt('18:00');
 
 Schedule::command(UpdateMeetupActivity::class)->dailyAt('03:30');
+
+/*
+ * Bewusst NACH dem Aktivitaets-Lauf um 03:30: der schreibt selbst in `api_changes`
+ * (siehe Meetup::recalculateActivity), und die beiden sollen nicht gleichzeitig auf
+ * derselben Tabelle arbeiten. Die Frist steht in config/einundzwanzig.php und ist
+ * zugleich die Reichweite, ueber die ein Konsument per /api/changes nachziehen kann.
+ */
+Schedule::command(PruneApiChanges::class)->dailyAt('04:00');

--- a/routes/web.php
+++ b/routes/web.php
@@ -36,6 +36,13 @@ Route::livewire('/welcome', 'welcome')->name('welcome');
 // Public guide explaining the MCP/AI connector and the claude.ai setup
 Route::livewire('/ki-assistent', 'ki-assistent')->name('ki-assistent');
 
+/*
+ * Consumer documentation for the realtime change feed (WebSocket channels plus
+ * /api/changes). Sits next to Scramble's /docs/api, which links here from its
+ * description — the channels are not Laravel routes, so Scramble cannot generate them.
+ */
+Route::livewire('/docs/websockets', 'docs.websockets')->name('docs.websockets');
+
 // Stream calendar route to download meetup calendar as ICS file
 Route::get('stream-calendar', DownloadMeetupCalendar::class)
     ->name('ics')

--- a/tests/Feature/Api/ChangeEndpointTest.php
+++ b/tests/Feature/Api/ChangeEndpointTest.php
@@ -1,0 +1,400 @@
+<?php
+
+use App\Http\Middleware\SetApiLocale;
+use App\Http\Resources\MeetupEventResource;
+use App\Models\ApiChange;
+use App\Models\Meetup;
+use App\Models\MeetupEvent;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Route;
+use Psr\Log\LoggerInterface;
+
+/*
+|--------------------------------------------------------------------------
+| GET /api/changes — der Resync-Weg (Issue #29, Plan-Phase P2)
+|--------------------------------------------------------------------------
+|
+| Der Endpunkt ist das einzige Netz unter einem verpassten Broadcast, und der
+| einzige Ort, an dem ein LOESCHEN ueberhaupt noch sichtbar ist: kein Model in
+| diesem Projekt nutzt SoftDeletes, der Datensatz ist danach wirklich weg. Wer
+| offline war, erfaehrt es hier oder nie — deshalb steht dieser Fall unten als
+| eigener Test und nicht als Randnotiz.
+|
+*/
+
+/**
+ * Aufsteigend geschriebene Log-Zeilen, deren `occurred_at` in derselben Reihenfolge
+ * laeuft wie ihre `id`. Die Factory streut ihren Zeitstempel sonst ueber 60 Tage —
+ * fuer einen Cursor-Test waere das Rauschen.
+ *
+ * @return Collection<int, ApiChange>
+ */
+function apiChangeRows(int $count, ?string $resource = null): Collection
+{
+    $factory = $resource === null
+        ? ApiChange::factory()
+        : ApiChange::factory()->forResource($resource);
+
+    return collect(range(1, $count))->map(fn (int $index): ApiChange => $factory->create([
+        'occurred_at' => now()->subMinutes($count - $index),
+    ]));
+}
+
+it('is throttled and localised like the other public read endpoints', function (): void {
+    $route = Route::getRoutes()->getByName('api.changes.index');
+
+    expect($route)->not->toBeNull()
+        ->and($route->gatherMiddleware())
+        ->toContain('throttle:60,1')
+        ->toContain(SetApiLocale::class);
+});
+
+it('is readable without authentication', function (): void {
+    apiChangeRows(3);
+
+    $this->getJson('/api/changes')
+        ->assertOk()
+        ->assertJsonStructure(['changes', 'next_since', 'has_more', 'cursor_expired']);
+});
+
+it('returns the changes after a sequence cursor, exclusively', function (): void {
+    $rows = apiChangeRows(5);
+    $cursor = $rows[2]->id;
+
+    $response = $this->getJson("/api/changes?since={$cursor}")->assertOk();
+
+    expect(collect($response->json('changes'))->pluck('sequence')->all())
+        ->toBe([$rows[3]->id, $rows[4]->id])
+        // Exklusiv: die Zeile, deren Sequenz der Konsument mitschickt, hat er schon.
+        ->not->toContain($cursor)
+        ->and($response->json('next_since'))->toBe($rows[4]->id)
+        ->and($response->json('has_more'))->toBeFalse();
+});
+
+it('walks the cursor forward without duplicates and without gaps', function (): void {
+    $rows = apiChangeRows(5);
+
+    $seen = [];
+    $cursor = 0;
+    $pages = 0;
+
+    do {
+        $response = $this->getJson("/api/changes?since={$cursor}&limit=2")->assertOk();
+
+        foreach ($response->json('changes') as $change) {
+            $seen[] = $change['sequence'];
+        }
+
+        $cursor = $response->json('next_since');
+        $pages++;
+    } while ($response->json('has_more') && $pages < 10);
+
+    // Weder eine Zeile doppelt noch eine ausgelassen — genau die beiden Fehler, die
+    // ein Konsument nicht bemerkt: die Dopplung kostet nur Arbeit, die Luecke ist ein
+    // Datensatz, von dem er nie erfaehrt.
+    expect($seen)->toBe($rows->pluck('id')->all())
+        ->and($seen)->toHaveCount(count(array_unique($seen)))
+        ->and($pages)->toBe(3);
+
+    // Und der naechste Aufruf mit dem letzten Cursor liefert nichts Neues, ohne den
+    // Cursor zurueckzuspulen.
+    $empty = $this->getJson("/api/changes?since={$cursor}")->assertOk();
+
+    expect($empty->json('changes'))->toBe([])
+        ->and($empty->json('next_since'))->toBe($rows->last()->id)
+        ->and($empty->json('has_more'))->toBeFalse();
+});
+
+it('accepts an ISO-8601 timestamp as the cursor', function (): void {
+    $older = ApiChange::factory()->create(['occurred_at' => now()->subHours(3)]);
+    $newer = ApiChange::factory()->create(['occurred_at' => now()->subHour()]);
+
+    $since = now()->subHours(2)->toIso8601String();
+
+    $response = $this->getJson('/api/changes?since='.urlencode($since))->assertOk();
+
+    expect(collect($response->json('changes'))->pluck('sequence')->all())
+        ->toBe([$newer->id])
+        ->and($response->json('changes')[0]['id'])->toBe($newer->resource_id)
+        ->and($response->json('next_since'))->toBe($newer->id);
+
+    unset($older);
+});
+
+it('reports a deletion to a consumer that was offline while it happened', function (): void {
+    // Das Log ist im Test per Default aus (phpunit.xml) — hier geht es um echte
+    // Model-Events, also muss es scharf sein.
+    config()->set('einundzwanzig.change_log.enabled', true);
+
+    $meetup = Meetup::factory()->create();
+    $event = MeetupEvent::factory()->create(['meetup_id' => $meetup->id]);
+
+    // Der Stand, den der Konsument kennt, bevor die Verbindung abreisst.
+    $cursor = ApiChange::query()->max('id');
+
+    $meetupId = $event->meetup_id;
+    $eventId = $event->id;
+    $event->delete();
+
+    expect(MeetupEvent::query()->find($eventId))->toBeNull();
+
+    $response = $this->getJson("/api/changes?since={$cursor}&resource=meetup-event")->assertOk();
+
+    $deletion = collect($response->json('changes'))
+        ->firstWhere(fn (array $change): bool => $change['action'] === 'deleted');
+
+    expect($deletion)->not->toBeNull()
+        ->and($deletion['resource'])->toBe('meetup-event')
+        ->and($deletion['id'])->toBe($eventId)
+        // Kein SoftDelete: `data` waere eine Erfindung, `previous` ist der Schluessel
+        // zum gezielten Cache-Invalidieren.
+        ->and($deletion['data'])->toBeNull()
+        ->and($deletion['previous'])->toBe(['meetup_id' => $meetupId]);
+});
+
+it('filters by a single resource and by several at once', function (): void {
+    apiChangeRows(2, 'city');
+    apiChangeRows(2, 'meetup');
+    apiChangeRows(2, 'lecturer');
+
+    $single = $this->getJson('/api/changes?since=0&resource=city')->assertOk();
+
+    expect(collect($single->json('changes'))->pluck('resource')->unique()->all())
+        ->toBe(['city'])
+        ->and($single->json('changes'))->toHaveCount(2);
+
+    $commaSeparated = $this->getJson('/api/changes?since=0&resource=city,meetup')->assertOk();
+
+    expect(collect($commaSeparated->json('changes'))->pluck('resource')->unique()->sort()->values()->all())
+        ->toBe(['city', 'meetup'])
+        ->and($commaSeparated->json('changes'))->toHaveCount(4);
+
+    $repeated = $this->getJson('/api/changes?since=0&resource[]=city&resource[]=lecturer')->assertOk();
+
+    expect($repeated->json('changes'))->toHaveCount(4);
+});
+
+it('rejects an unknown resource instead of answering with an empty list', function (): void {
+    apiChangeRows(2, 'city');
+
+    // Eine leere Liste waere hier die schlechtere Antwort: ein Tippfehler im
+    // Filternamen saehe genauso aus wie "es hat sich nichts geaendert", und der
+    // Konsument wartete still auf Ereignisse, die er nie bekommt.
+    $this->getJson('/api/changes?resource=citys')
+        ->assertStatus(422)
+        ->assertJsonValidationErrors('resource.0');
+
+    $this->getJson('/api/changes?resource=city,podcast')
+        ->assertStatus(422)
+        ->assertJsonValidationErrors('resource.1');
+});
+
+it('rejects a cursor that is neither a sequence nor a timestamp', function (): void {
+    $this->getJson('/api/changes?since=irgendwann')
+        ->assertStatus(422)
+        ->assertJsonValidationErrors('since');
+
+    $this->getJson('/api/changes?since=-5')
+        ->assertStatus(422)
+        ->assertJsonValidationErrors('since');
+});
+
+it('caps the page at 100 entries by default and at 1000 on request', function (): void {
+    $rows = apiChangeRows(150);
+
+    $default = $this->getJson('/api/changes?since=0')->assertOk();
+
+    expect($default->json('changes'))->toHaveCount(100)
+        ->and($default->json('has_more'))->toBeTrue()
+        ->and($default->json('next_since'))->toBe($rows[99]->id);
+
+    expect($this->getJson('/api/changes?since=0&limit=1000')->assertOk()->json('changes'))
+        ->toHaveCount(150);
+
+    $this->getJson('/api/changes?since=0&limit=1001')
+        ->assertStatus(422)
+        ->assertJsonValidationErrors('limit');
+
+    $this->getJson('/api/changes?since=0&limit=0')
+        ->assertStatus(422)
+        ->assertJsonValidationErrors('limit');
+});
+
+it('returns the newest entries when no cursor is given, so a newcomer finds a start', function (): void {
+    $rows = apiChangeRows(150);
+
+    $response = $this->getJson('/api/changes?limit=10')->assertOk();
+
+    // Die JUENGSTEN zehn, nicht die aeltesten — und nicht die ganze Tabelle. Wer ohne
+    // Cursor kommt, will einen Startpunkt, keine 30 Tage Historie.
+    expect(collect($response->json('changes'))->pluck('sequence')->all())
+        ->toBe($rows->slice(140)->pluck('id')->values()->all())
+        ->and($response->json('next_since'))->toBe($rows->last()->id)
+        // Jenseits der juengsten Zeile gibt es nichts mehr.
+        ->and($response->json('has_more'))->toBeFalse();
+});
+
+it('sorts ascending by sequence, whatever the cursor', function (): void {
+    $rows = apiChangeRows(6);
+
+    $sequences = collect($this->getJson('/api/changes?since=0')->assertOk()->json('changes'))
+        ->pluck('sequence')
+        ->all();
+
+    expect($sequences)->toBe($rows->pluck('id')->all())
+        ->and($sequences)->toBe(collect($sequences)->sort()->values()->all());
+});
+
+it('hands out exactly the envelope the recorder wrote', function (): void {
+    config()->set('einundzwanzig.change_log.enabled', true);
+
+    $event = MeetupEvent::factory()->create();
+
+    $row = ApiChange::query()->where('resource', 'meetup-event')->sole();
+
+    /*
+     * Die Erwartung wird hier UNABHAENGIG gebaut — aus dem Payload-Vertrag des Plans
+     * und der kanonischen Relationsgestalt (`tags`), nicht aus `$row->payload`. Sonst
+     * pruefte der Test den Endpunkt gegen sich selbst und waere auch dann gruen, wenn
+     * beide Seiten dasselbe Falsche liefern.
+     */
+    $expected = [
+        'action' => 'created',
+        'resource' => 'meetup-event',
+        'id' => $event->id,
+        'sequence' => $row->id,
+        'occurred_at' => $row->occurred_at->toIso8601String(),
+        'api_version' => (string) config('scramble.info.version'),
+        'data' => json_decode(json_encode(
+            MeetupEventResource::make(MeetupEvent::query()->with('tags')->findOrFail($event->id))->resolve()
+        ) ?: '{}', true),
+        'links' => ['self' => null],
+    ];
+
+    $change = $this->getJson('/api/changes?since=0&resource=meetup-event')
+        ->assertOk()
+        ->json('changes.0');
+
+    // toBe ist hier Absicht: identische Schluesselreihenfolge und identische Typen,
+    // nicht bloss gleicher Inhalt. Ab P4 geht genau dieses Envelope ueber den Kanal,
+    // und ein Resync-Eintrag, der sich davon unterscheidet, waere ein zweites Format.
+    expect($change)->toBe($expected)
+        ->and(json_encode($change))->toBe(json_encode($row->payload));
+});
+
+it('says so when the cursor is older than everything still on file', function (): void {
+    // Zwei Zeilen jenseits der Aufbewahrungsfrist, zwei innerhalb.
+    $pruned = collect([
+        ApiChange::factory()->olderThan(40)->create(),
+        ApiChange::factory()->olderThan(35)->create(),
+    ]);
+    $kept = ApiChange::factory()->create(['occurred_at' => now()->subDay()]);
+
+    // Der Cursor, den der Konsument vor seinem Ausfall hatte.
+    $cursor = $pruned->last()->id;
+
+    // Echt geprunt, nicht von Hand geloescht: derselbe Weg, der es in Produktion tut.
+    $this->artisan('api-changes:prune')->assertSuccessful();
+
+    expect(ApiChange::query()->min('id'))->toBe($kept->id);
+
+    $response = $this->getJson("/api/changes?since={$cursor}")->assertOk();
+
+    /*
+     * Ohne dieses Feld waere die Antwort hier NICHT leer, sondern harmlos falsch: der
+     * Konsument bekaeme die eine verbliebene Zeile, haette aber die geloeschten
+     * Datensaetze dazwischen nie gesehen — und kein Model nutzt SoftDeletes, es gibt
+     * also keinen zweiten Weg, davon zu erfahren.
+     */
+    expect($response->json('cursor_expired'))->toBeTrue()
+        ->and($response->json('changes'))->toHaveCount(1)
+        // Der Weiterarbeits-Cursor steht trotzdem in derselben Antwort: erst
+        // Vollabgleich, dann ab hier weiter.
+        ->and($response->json('next_since'))->toBe($kept->id);
+});
+
+it('says so for an ISO cursor that predates the oldest entry', function (): void {
+    ApiChange::factory()->create(['occurred_at' => now()->subDay()]);
+
+    $expired = $this->getJson('/api/changes?since='.urlencode(now()->subDays(45)->toIso8601String()))
+        ->assertOk();
+
+    expect($expired->json('cursor_expired'))->toBeTrue();
+
+    $valid = $this->getJson('/api/changes?since='.urlencode(now()->subHours(2)->toIso8601String()))
+        ->assertOk();
+
+    expect($valid->json('cursor_expired'))->toBeFalse();
+});
+
+it('reports a valid cursor, a missing cursor and an empty log as not expired', function (): void {
+    // Leeres Log: nichts ist abgelaufen, es ist nur nichts da. Ohne diesen Fall
+    // meldete ein frisch aufgesetztes System jedem Konsumenten sofort Datenverlust.
+    expect(ApiChange::query()->count())->toBe(0)
+        ->and($this->getJson('/api/changes?since=999')->assertOk()->json('cursor_expired'))->toBeFalse()
+        ->and($this->getJson('/api/changes')->assertOk()->json('cursor_expired'))->toBeFalse();
+
+    $rows = apiChangeRows(3);
+
+    expect($this->getJson("/api/changes?since={$rows[1]->id}")->assertOk()->json('cursor_expired'))->toBeFalse()
+        // Auch der aelteste noch vorhandene Eintrag selbst ist ein gueltiger Cursor —
+        // die Grenze liegt darunter, nicht auf ihm.
+        ->and($this->getJson("/api/changes?since={$rows->first()->id}")->assertOk()->json('cursor_expired'))->toBeFalse()
+        // Ohne Cursor gibt es nichts, was ablaufen koennte.
+        ->and($this->getJson('/api/changes')->assertOk()->json('cursor_expired'))->toBeFalse();
+});
+
+it('counts every call in its own log channel without writing to the database', function (): void {
+    apiChangeRows(2);
+
+    $logger = Mockery::spy(LoggerInterface::class);
+    Log::partialMock()->shouldReceive('channel')->with('api-changes')->andReturn($logger);
+
+    DB::enableQueryLog();
+
+    $this->getJson('/api/changes?since=1&resource=city&limit=25')->assertOk();
+
+    $writes = collect(DB::getQueryLog())
+        ->filter(fn (array $query): bool => (bool) preg_match('/^\s*(insert|update|delete)\b/i', $query['query']));
+
+    DB::disableQueryLog();
+
+    // Der Zaehler ist ein Log-Eintrag, kein INSERT: der Endpunkt wird gepollt, und
+    // eine Zeile je Poll erzeugte genau die Schreiblast, die hier gemessen wird.
+    expect($writes)->toBeEmpty();
+
+    $logger->shouldHaveReceived('info')
+        ->withArgs(function (string $message, array $context): bool {
+            return $message === 'api-changes.request'
+                && $context['since'] === '1'
+                && $context['resource'] === ['city']
+                && $context['limit'] === 25
+                // Keine IP im Klartext, sondern ein geschluesseltes Pseudonym: stabil
+                // genug, um zwei Konsumenten zu unterscheiden, und nicht
+                // ruecktauschbar. P3 fragt "wie viele und wie oft", nicht "wer".
+                && $context['client'] === substr(hash_hmac('sha256', '127.0.0.1', (string) config('app.key')), 0, 12)
+                && ! array_key_exists('ip', $context)
+                && $context['user_agent'] !== ''
+                && array_key_exists('returned', $context);
+        })
+        ->once();
+});
+
+it('appears in the generated openapi document', function (): void {
+    $document = $this->getJson(route('scramble.docs.document'))->assertOk()->json();
+
+    expect($document['paths'])->toHaveKey('/changes');
+
+    $parameters = collect($document['paths']['/changes']['get']['parameters'] ?? [])
+        ->pluck('name')
+        ->all();
+
+    // `resource[]` und nicht `resource`: Scramble leitet den Namen aus der
+    // Array-Regel des Form Requests ab. Hier steht der Name, der wirklich im
+    // Dokument landet — nicht der, den man erwarten wuerde.
+    expect($parameters)->toContain('since')
+        ->toContain('resource[]')
+        ->toContain('limit');
+});

--- a/tests/Feature/Api/WebSocketDocsPageTest.php
+++ b/tests/Feature/Api/WebSocketDocsPageTest.php
@@ -1,0 +1,165 @@
+<?php
+
+use App\Support\Broadcasting\ChangeRecorder;
+
+/*
+ * Die Konsumenten-Doku unter /docs/websockets (Plan-Phase P6).
+ *
+ * Der Zweck dieser Tests ist nicht "die Seite rendert" — sie ist eine Blade-Datei, das
+ * tut sie fast immer. Geprueft wird, was an ihr ein Aussenvertrag ist: dass sie ohne
+ * Anmeldung erreichbar ist, dass sie genau die zwei Kanaele nennt, die es gibt, und
+ * dass die Verbindungsangaben aus der Konfiguration kommen. Der letzte Punkt ist der
+ * teuerste Fehler, den diese Seite machen koennte: ein fest verdrahteter App-Key waere
+ * ab dem Tag falsch, an dem P5 den echten setzt, und niemand saehe es.
+ */
+
+it('serves the websocket documentation to guests', function () {
+    $this->get(route('docs.websockets'))
+        ->assertSuccessful()
+        ->assertSee('Realtime change feed');
+});
+
+it('names both channels and only those two', function () {
+    $response = $this->get(route('docs.websockets'))->assertSuccessful();
+
+    $response->assertSee('portal');
+    $response->assertSee('meetup-events');
+
+    /*
+     * Die Kanalfamilien aus P7 sind entworfen, aber nicht gebaut. Stuenden sie hier,
+     * abonnierte ein Konsument einen Kanal, den es nicht gibt — erfolgreich und fuer
+     * immer still, weil ein oeffentlicher Pusher-Kanal keinen Rueckkanal hat. Genau
+     * deshalb ist eine zu grosszuegige Doku hier schlimmer als gar keine.
+     */
+    foreach (['meetups.country.', 'meetup-events.country.', 'meetups.city.', 'meetup-events.rsvp.', 'cities.country.'] as $unbuiltChannel) {
+        $response->assertDontSee($unbuiltChannel);
+    }
+});
+
+it('links to the resync endpoint and to the api reference', function () {
+    $this->get(route('docs.websockets'))
+        ->assertSuccessful()
+        ->assertSee(route('api.changes.index'))
+        ->assertSee(route('scramble.docs.ui'));
+});
+
+it('spells out the payload contract, the pitfalls and the accepted gaps', function () {
+    $response = $this->get(route('docs.websockets'))->assertSuccessful();
+
+    // Event-Namen OHNE fuehrenden Punkt, so wie sie ueber die Leitung gehen — und der
+    // Punkt, der nur Echo-Syntax ist, ausdruecklich erklaert. Steht hier der Punkt im
+    // Draht-Namen, abonniert ein Echo-Konsument mit der naheliegenden Schreibweise
+    // einen Namen, den niemand sendet: erfolgreich und fuer immer still.
+    $response->assertSee('meetup-event.created');
+    $response->assertSee('meetup-event.deleted');
+    // Die Liste selbst traegt keinen Punkt — und zwar nachweislich nicht.
+    $response->assertSee('<li>meetup-event.created</li>', false);
+    $response->assertDontSee('<li>.meetup-event.created</li>', false);
+    $response->assertSee('The leading dot: where it belongs, and where it does not');
+    $response->assertSee("bind('meetup-event.created', handler)", false);
+    $response->assertSee("listen('.meetup-event.created', handler)", false);
+
+    // Der deleted-Fall: data null plus previous — der einzige Weg, von einer Loeschung
+    // zu erfahren, weil kein Model SoftDeletes nutzt.
+    $response->assertSee('&quot;previous&quot;', false);
+
+    // Der Umschlag von /api/changes.
+    foreach (['next_since', 'has_more', 'cursor_expired'] as $field) {
+        $response->assertSee($field);
+    }
+
+    // Die vier Stolperfallen.
+    $response->assertSee('4009');
+    $response->assertSee('links.self');
+    $response->assertSee('truncated');
+
+    // Die 10-KB-Grenze, aus dem Recorder gelesen statt hingeschrieben.
+    $response->assertSee(number_format(ChangeRecorder::MAX_BROADCAST_BYTES, 0, '.', ' '));
+
+    // Der Deploy-Hinweis.
+    $response->assertSee('Every deploy drops every connection');
+});
+
+it('shows a placeholder instead of an invented value while reverb is unpublished', function () {
+    config([
+        'broadcasting.connections.reverb.key' => null,
+        'reverb.servers.reverb.path' => '',
+        'broadcasting.connections.reverb.options.path' => '',
+    ]);
+
+    $this->get(route('docs.websockets'))
+        ->assertSuccessful()
+        ->assertSee('{REVERB_APP_KEY}')
+        ->assertSee('{REVERB_SERVER_PATH}')
+        ->assertSee('The socket is not published in this environment yet.');
+});
+
+it('reads the connection details from the configuration, not from the page', function () {
+    /*
+     * Der eigentliche Beleg: Config aendern, Seite neu laden, neuer Wert steht da.
+     * Ohne diesen Test waere "kommt aus der Config" eine Behauptung ueber Code, den
+     * niemand nachfaehrt, sobald P5 die Produktionswerte setzt.
+     */
+    config([
+        'app.url' => 'https://ws.example.test',
+        'broadcasting.connections.reverb.key' => 'schluessel-aus-der-config',
+        'reverb.servers.reverb.path' => 'reverb-pfad-aus-der-config',
+    ]);
+
+    $this->get(route('docs.websockets'))
+        ->assertSuccessful()
+        ->assertSee('schluessel-aus-der-config')
+        ->assertSee('/reverb-pfad-aus-der-config')
+        ->assertSee('wss://ws.example.test/reverb-pfad-aus-der-config/app/schluessel-aus-der-config')
+        ->assertDontSee('{REVERB_APP_KEY}')
+        ->assertDontSee('{REVERB_SERVER_PATH}');
+});
+
+it('falls back to the broadcasting path when the reverb server path is unset', function () {
+    /*
+     * Beide Schluessel lesen dieselbe Env-Variable, aber nur einer von beiden ist auf
+     * einem Rechner ohne publizierte config/reverb.php gesetzt. Faellt der Fallback
+     * aus, zeigt die Seite den Platzhalter, obwohl der Wert bekannt ist.
+     */
+    config([
+        'reverb.servers.reverb.path' => '',
+        'broadcasting.connections.reverb.options.path' => 'nur-im-broadcasting',
+        'broadcasting.connections.reverb.key' => 'irgendein-key',
+    ]);
+
+    $this->get(route('docs.websockets'))
+        ->assertSuccessful()
+        ->assertSee('/nur-im-broadcasting');
+});
+
+it('exposes the websockets tag in the openapi document', function () {
+    /*
+     * Der sichtbare Reiter in der Scalar-UI. Geprueft wird das Dokument, nicht die UI:
+     * der Tag muss NACH Scrambles eigenem AddDocumentTags angehaengt werden, das
+     * `$document->tags` komplett neu setzt — ein zu frueh eingehaengter Transformer
+     * verschwaende spurlos.
+     */
+    $document = $this->get(route('scramble.docs.document'))
+        ->assertSuccessful()
+        ->json();
+
+    $tags = collect($document['tags'] ?? []);
+
+    expect($tags->pluck('name'))->toContain('WebSockets')
+        ->and($tags->firstWhere('name', 'WebSockets')['description'])->toContain('/docs/websockets');
+});
+
+it('links from the api reference to the websocket documentation', function () {
+    /*
+     * Die Pflicht aus der DoD: /docs/api zeigt sichtbar hierher. Der Tag oben ist die
+     * Kuer und kann an Scalars Darstellung scheitern; die Einleitung wird immer
+     * gerendert.
+     */
+    $document = $this->get(route('scramble.docs.document'))
+        ->assertSuccessful()
+        ->json();
+
+    expect($document['info']['description'])
+        ->toContain('## Realtime updates')
+        ->toContain('/docs/websockets');
+});

--- a/tests/Feature/Broadcasting/ChangeRecorderTest.php
+++ b/tests/Feature/Broadcasting/ChangeRecorderTest.php
@@ -1,0 +1,337 @@
+<?php
+
+use App\Http\Resources\CityResource;
+use App\Http\Resources\CourseEventResource;
+use App\Http\Resources\CourseResource;
+use App\Http\Resources\LecturerResource;
+use App\Http\Resources\MeetupEventResource;
+use App\Http\Resources\MeetupResource;
+use App\Models\ApiChange;
+use App\Models\City;
+use App\Models\Country;
+use App\Models\Course;
+use App\Models\CourseEvent;
+use App\Models\Lecturer;
+use App\Models\Meetup;
+use App\Models\MeetupEvent;
+use App\Support\Broadcasting\ChangeRecorder;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/*
+|--------------------------------------------------------------------------
+| Das Aenderungs-Log (Issue #29, Plan-Phase P1)
+|--------------------------------------------------------------------------
+|
+| Der eigentliche Vertrag steht in "records the resource payload on create":
+| `payload['data']` ist genau das, was die zugehoerige JsonResource in der
+| kanonischen Relationsgestalt liefert. Die Gestalt wird hier NICHT aus dem
+| ChangeRecorder gelesen, sondern noch einmal von Hand hingeschrieben — sonst
+| pruefte der Test den Recorder gegen sich selbst und waere immer gruen.
+|
+*/
+
+beforeEach(function (): void {
+    // In der Testumgebung ist das Log per Default aus (phpunit.xml). Die Tests, die
+    // es pruefen, schalten es selbst scharf.
+    config()->set('einundzwanzig.change_log.enabled', true);
+});
+
+dataset('api resources', [
+    'meetup',
+    'meetup-event',
+    'city',
+    'course',
+    'course-event',
+    'lecturer',
+]);
+
+/**
+ * Ein frisch angelegter Datensatz je Ressource, ohne Abhaengige — damit `delete()`
+ * nicht an einem Fremdschluessel scheitert.
+ */
+function changeLogRecord(string $resource): Model
+{
+    return match ($resource) {
+        'meetup' => Meetup::factory()->create(),
+        'meetup-event' => MeetupEvent::factory()->create(),
+        'city' => City::factory()->create(),
+        'course' => Course::factory()->create(),
+        'course-event' => CourseEvent::factory()->create(),
+        'lecturer' => Lecturer::factory()->create(),
+    };
+}
+
+/**
+ * Eine Aenderung, die im Payload sichtbar wird.
+ */
+function changeLogUpdate(string $resource, Model $model): void
+{
+    match ($resource) {
+        'meetup' => $model->update(['intro' => 'Neuer Einleitungstext.']),
+        'meetup-event' => $model->update(['description' => 'Neue Beschreibung.']),
+        'city' => $model->update(['population' => 424242]),
+        'course' => $model->update(['description' => 'Neue Kursbeschreibung.']),
+        'course-event' => $model->update(['location' => 'Neuer Ort 7']),
+        'lecturer' => $model->update(['subtitle' => 'Neuer Untertitel']),
+    };
+}
+
+/**
+ * DIE KANONISCHE RELATIONSGESTALT, unabhaengig vom Recorder noch einmal notiert.
+ * Weicht sie von {@see ChangeRecorder}::RESOURCES ab, faellt genau das hier auf.
+ *
+ * @return array{0: class-string<Model>, 1: class-string<JsonResource>, 2: array<int, string>}
+ */
+function changeLogShape(string $resource): array
+{
+    return match ($resource) {
+        'meetup' => [Meetup::class, MeetupResource::class, ['media']],
+        'meetup-event' => [MeetupEvent::class, MeetupEventResource::class, ['tags']],
+        'city' => [City::class, CityResource::class, []],
+        'course' => [Course::class, CourseResource::class, ['media']],
+        'course-event' => [CourseEvent::class, CourseEventResource::class, ['tags', 'course', 'city']],
+        'lecturer' => [Lecturer::class, LecturerResource::class, ['media']],
+    };
+}
+
+/**
+ * Was die Resource fuer diesen Datensatz liefert — nackt, ohne `data`-Wrapper, in der
+ * Gestalt, in der sie auch ueber HTTP ginge.
+ *
+ * @return array<string, mixed>
+ */
+function changeLogExpectedData(string $resource, int $id): array
+{
+    [$modelClass, $resourceClass, $relations] = changeLogShape($resource);
+
+    $model = $modelClass::query()->with($relations)->findOrFail($id);
+
+    return json_decode(json_encode($resourceClass::make($model)->resolve()) ?: '{}', true);
+}
+
+/**
+ * Die Identifikatoren, die ein `deleted` mitgeben muss.
+ *
+ * @return array<int, string>
+ */
+function changeLogPreviousKeys(string $resource): array
+{
+    return match ($resource) {
+        'meetup' => ['slug', 'city_id'],
+        'meetup-event' => ['meetup_id'],
+        'city' => ['slug', 'country_id'],
+        'course' => ['lecturer_id'],
+        'course-event' => ['course_id', 'city_id'],
+        'lecturer' => ['slug'],
+    };
+}
+
+it('records exactly one row whose data equals the resource on create', function (string $resource): void {
+    $model = changeLogRecord($resource);
+
+    $rows = ApiChange::query()->where('resource', $resource)->get();
+
+    expect($rows)->toHaveCount(1);
+
+    $row = $rows->first();
+
+    expect($row->action)->toBe('created')
+        ->and($row->resource_id)->toBe($model->getKey())
+        ->and($row->payload['action'])->toBe('created')
+        ->and($row->payload['resource'])->toBe($resource)
+        ->and($row->payload['id'])->toBe($model->getKey())
+        // Die Sequenz IST die Zeilen-ID; sie ist der Resync-Cursor aus P2.
+        ->and($row->payload['sequence'])->toBe($row->id)
+        ->and($row->payload['api_version'])->toBe((string) config('scramble.info.version'))
+        ->and($row->payload)->toHaveKey('links')
+        ->and($row->payload)->not->toHaveKey('previous')
+        ->and($row->payload['data'])->toBe(changeLogExpectedData($resource, $model->getKey()));
+})->with('api resources');
+
+it('records exactly one row whose data equals the resource on update', function (string $resource): void {
+    $model = changeLogRecord($resource);
+    ApiChange::query()->delete();
+
+    changeLogUpdate($resource, $model);
+
+    $rows = ApiChange::query()->where('resource', $resource)->get();
+
+    expect($rows)->toHaveCount(1);
+
+    $row = $rows->first();
+
+    expect($row->action)->toBe('updated')
+        ->and($row->resource_id)->toBe($model->getKey())
+        ->and($row->payload['data'])->toBe(changeLogExpectedData($resource, $model->getKey()));
+})->with('api resources');
+
+it('records a delete without data but with the previous identifiers', function (string $resource): void {
+    $model = changeLogRecord($resource);
+    $before = $model->only(changeLogPreviousKeys($resource));
+    ApiChange::query()->delete();
+
+    $model->delete();
+
+    $rows = ApiChange::query()->where('resource', $resource)->get();
+
+    expect($rows)->toHaveCount(1);
+
+    $row = $rows->first();
+
+    expect($row->action)->toBe('deleted')
+        ->and($row->resource_id)->toBe($model->getKey())
+        // Kein SoftDelete im Projekt: der Datensatz ist wirklich weg, `data` waere
+        // eine Erfindung.
+        ->and($row->payload['data'])->toBeNull()
+        ->and($row->payload['previous'])->toBe($before);
+
+    foreach (changeLogPreviousKeys($resource) as $key) {
+        expect($row->payload['previous'])->toHaveKey($key);
+    }
+})->with('api resources');
+
+it('fills city_id where it is on the record itself and leaves country_code alone', function (): void {
+    $country = Country::factory()->create(['code' => 'DE']);
+    $city = City::factory()->create(['country_id' => $country->id]);
+
+    $cityRow = ApiChange::query()->where('resource', 'city')->sole();
+
+    // Die Stadt ist ihre eigene Stadt — das ist ohne Zusatz-Query zu haben.
+    expect($cityRow->city_id)->toBe($city->id)
+        // Der Laendercode nicht: dafuer muesste die country-Relation geladen werden,
+        // und das ist eine Query pro Schreibvorgang fuer eine Spalte, die erst P7
+        // liest. Sobald P7 `city.country` eager laedt, faellt der Wert nebenbei ab.
+        ->and($cityRow->country_code)->toBeNull();
+
+    $meetup = Meetup::factory()->create(['city_id' => $city->id]);
+
+    expect(ApiChange::query()->where('resource', 'meetup')->sole()->city_id)->toBe($city->id);
+});
+
+it('links to the resource only where a show endpoint actually exists', function (): void {
+    $lecturer = Lecturer::factory()->create();
+    $meetup = Meetup::factory()->create();
+
+    $lecturerRow = ApiChange::query()->where('resource', 'lecturer')->sole();
+    $meetupRow = ApiChange::query()->where('resource', 'meetup')->sole();
+
+    expect($lecturerRow->payload['links']['self'])
+        ->toBe(route('api.lecturers.show', $lecturer->id))
+        // /api/meetup hat heute nur einen index. Eine self-URL, die 404 liefert, waere
+        // schlechter als keine — der verlaessliche Weg ist /api/changes (P2).
+        ->and($meetupRow->payload['links']['self'])->toBeNull();
+});
+
+it('records the meetup activity change that saveQuietly would swallow', function (): void {
+    $meetup = Meetup::factory()->create(['is_active' => false, 'last_event_at' => null]);
+    ApiChange::query()->delete();
+
+    // Loest ueber den MeetupEventObserver recalculateActivity() aus. Die Methode endet
+    // auf saveQuietly() und feuert deshalb kein Model-Event — ohne den ausdruecklichen
+    // Recorder-Aufruf in Meetup::recalculateActivity() bliebe der Wechsel unsichtbar.
+    MeetupEvent::factory()->create([
+        'meetup_id' => $meetup->id,
+        'start' => now()->addDays(7),
+        'recurrence_type' => null,
+    ]);
+
+    $rows = ApiChange::query()->where('resource', 'meetup')->get();
+
+    expect($meetup->fresh()->is_active)->toBeTrue()
+        ->and($rows)->toHaveCount(1)
+        ->and($rows->first()->action)->toBe('updated')
+        ->and($rows->first()->payload['data']['is_active'])->toBeTrue();
+});
+
+it('records nothing when recalculating activity changes neither field', function (): void {
+    $meetup = Meetup::factory()->create(['is_active' => false, 'last_event_at' => null]);
+    ApiChange::query()->delete();
+
+    // Kein Termin, kein Wechsel — der Normalfall des naechtlichen Laufs ueber alle
+    // Meetups. Wuerde hier eine Zeile entstehen, waere das Log jede Nacht so lang wie
+    // die Meetup-Tabelle.
+    $meetup->recalculateActivity();
+
+    expect(ApiChange::query()->count())->toBe(0);
+});
+
+it('records nothing while the kill switch is off', function (): void {
+    config()->set('einundzwanzig.change_log.enabled', false);
+
+    $city = City::factory()->create();
+    $city->update(['population' => 1234]);
+    $city->delete();
+
+    expect(ApiChange::query()->count())->toBe(0);
+});
+
+it('records nothing inside a muted block and resumes afterwards', function (): void {
+    ChangeRecorder::muted(function (): void {
+        City::factory()->count(3)->create();
+    });
+
+    expect(ApiChange::query()->count())->toBe(0);
+
+    City::factory()->create();
+
+    expect(ApiChange::query()->where('resource', 'city')->count())->toBe(1);
+});
+
+it('resumes recording even when the muted block throws', function (): void {
+    try {
+        ChangeRecorder::muted(function (): void {
+            City::factory()->create();
+
+            throw new RuntimeException('Import abgebrochen');
+        });
+    } catch (RuntimeException) {
+        // Erwartet — der Punkt des Tests ist, was danach gilt.
+    }
+
+    expect(ChangeRecorder::enabled())->toBeTrue();
+
+    City::factory()->create();
+
+    expect(ApiChange::query()->where('resource', 'city')->count())->toBe(1);
+});
+
+it('keeps the full object in the table but strips data from an oversized broadcast', function (): void {
+    $description = str_repeat('Bitcoin. ', 1500); // ~13,5 KB
+
+    $event = MeetupEvent::factory()->create(['description' => $description]);
+
+    $row = ApiChange::query()->where('resource', 'meetup-event')->sole();
+
+    // Die Tabelle behaelt das vollstaendige Objekt — sie ist der Resync-Weg, und ein
+    // gekuerzter Resync waere kein Resync.
+    expect($row->payload['data']['description'])->toBe($description)
+        ->and($row->payload['data'])->toBe(changeLogExpectedData('meetup-event', $event->id))
+        ->and(strlen((string) json_encode($row->payload)))->toBeGreaterThan(ChangeRecorder::MAX_BROADCAST_BYTES);
+
+    $broadcast = $row->broadcastPayload();
+
+    // Reverb weist alles ueber max_request_size (10 000 Bytes) mit HTTP 413 ab.
+    expect($broadcast['data'])->toBeNull()
+        ->and($broadcast['truncated'])->toBeTrue()
+        ->and($broadcast['sequence'])->toBe($row->id)
+        ->and($broadcast['resource'])->toBe('meetup-event')
+        ->and(strlen((string) json_encode($broadcast)))->toBeLessThanOrEqual(ChangeRecorder::MAX_BROADCAST_BYTES);
+});
+
+it('leaves a payload under the limit untouched', function (): void {
+    $lecturer = Lecturer::factory()->create(['description' => 'Kurz.']);
+
+    $row = ApiChange::query()->where('resource', 'lecturer')->sole();
+
+    expect(strlen((string) json_encode($row->payload)))->toBeLessThanOrEqual(ChangeRecorder::MAX_BROADCAST_BYTES)
+        ->and($row->broadcastPayload())->toBe($row->payload)
+        ->and($row->broadcastPayload())->not->toHaveKey('truncated')
+        ->and($row->broadcastPayload()['data']['id'])->toBe($lecturer->id);
+});
+
+it('ignores models that are not public API resources', function (): void {
+    Country::factory()->create();
+
+    expect(ApiChange::query()->count())->toBe(0);
+});

--- a/tests/Feature/Broadcasting/ResourceChangedTest.php
+++ b/tests/Feature/Broadcasting/ResourceChangedTest.php
@@ -211,7 +211,7 @@ it('delivers a delete through a real queue run although the model is gone', func
 
     $sent = $broadcasts[0];
 
-    expect($sent['event'])->toBe('.meetup-event.deleted')
+    expect($sent['event'])->toBe('meetup-event.deleted')
         ->and($sent['channels'])->toBe(['portal', 'meetup-events'])
         ->and($sent['payload']['action'])->toBe('deleted')
         ->and($sent['payload']['id'])->toBe($id)
@@ -255,16 +255,50 @@ it('broadcasts every other resource on portal alone', function (string $resource
     expect(array_map(strval(...), $channels))->toBe(['portal']);
 })->with(['meetup', 'city', 'course', 'course-event', 'lecturer']);
 
-it('names the event with a leading dot for every action', function (string $action): void {
+it('names the event without a leading dot for every action', function (string $action): void {
     expect((new ResourceChanged(changeEnvelope('meetup-event', $action)))->broadcastAs())
-        ->toBe(".meetup-event.{$action}");
+        ->toBe("meetup-event.{$action}");
 })->with(['created', 'updated', 'deleted']);
 
 it('names the event after the resource in the payload', function (): void {
     expect((new ResourceChanged(changeEnvelope('course-event', 'created')))->broadcastAs())
-        ->toBe('.course-event.created')
+        ->toBe('course-event.created')
         ->and((new ResourceChanged(changeEnvelope('lecturer', 'deleted')))->broadcastAs())
-        ->toBe('.lecturer.deleted');
+        ->toBe('lecturer.deleted');
+});
+
+it('never lets a leading dot back into the event name', function (string $resource): void {
+    /*
+     * Der Punkt ist CLIENT-Syntax und gehoert nicht in den Namen: was broadcastAs()
+     * liefert, geht woertlich ueber den Draht (BroadcastEvent::handle()). Stuende er
+     * hier, entfernte laravel-echo bei `.listen('.meetup-event.created')` genau einen
+     * Punkt und abonnierte einen Namen, den niemand sendet — erfolgreich und fuer
+     * immer still.
+     *
+     * Diese Zusicherung ist bewusst eine eigene und nicht bloss ein `toBe(...)`: ein
+     * Gleichheitstest faellt mit dem Namen zusammen, wenn jemand beide zugleich
+     * anfasst. Diese hier bleibt rot, egal wie der Name lautet.
+     */
+    foreach (['created', 'updated', 'deleted'] as $action) {
+        $name = (new ResourceChanged(changeEnvelope($resource, $action)))->broadcastAs();
+
+        expect($name)->not->toStartWith('.')
+            ->and($name)->toBe("{$resource}.{$action}");
+    }
+})->with(['meetup', 'meetup-event', 'city', 'course', 'course-event', 'lecturer']);
+
+it('puts the dotless name on the wire, not just in broadcastAs', function (): void {
+    /*
+     * Der Beleg am anderen Ende der Kette: nicht die Methode wird geprueft, sondern
+     * das, was der Broadcaster wirklich zu sehen bekommt.
+     */
+    City::factory()->create();
+
+    $sent = broadcastsFor('city');
+
+    expect($sent)->toHaveCount(1)
+        ->and($sent[0]['event'])->toBe('city.created')
+        ->and($sent[0]['event'])->not->toStartWith('.');
 });
 
 /*
@@ -417,7 +451,7 @@ it('broadcasts create, update and delete for every api resource', function (): v
         $sent = broadcastsFor($resource);
 
         expect($sent)->toHaveCount(1)
-            ->and($sent[0]['event'])->toBe(".{$resource}.updated")
+            ->and($sent[0]['event'])->toBe("{$resource}.updated")
             ->and($sent[0]['channels'])->toBe(['portal']);
     }
 });

--- a/tests/Feature/Broadcasting/ResourceChangedTest.php
+++ b/tests/Feature/Broadcasting/ResourceChangedTest.php
@@ -1,0 +1,423 @@
+<?php
+
+use App\Events\ResourceChanged;
+use App\Models\ApiChange;
+use App\Models\City;
+use App\Models\Course;
+use App\Models\CourseEvent;
+use App\Models\Lecturer;
+use App\Models\Meetup;
+use App\Models\MeetupEvent;
+use App\Support\Broadcasting\ChangeRecorder;
+use Illuminate\Broadcasting\BroadcastEvent;
+use Illuminate\Broadcasting\BroadcastException;
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Contracts\Broadcasting\Broadcaster;
+use Illuminate\Contracts\Database\ModelIdentifier;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Queue\Events\JobProcessing;
+use Illuminate\Queue\SerializesModels;
+use Illuminate\Support\Facades\Broadcast;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Log;
+
+/*
+|--------------------------------------------------------------------------
+| ResourceChanged — der Weg vom Observer auf den Kanal (Issue #29, Phase P4)
+|--------------------------------------------------------------------------
+|
+| Der wichtigste Test dieser Datei ist "delivers a delete through a real
+| queue run …". Er ist bewusst NICHT mit Event::fake() gebaut: ein
+| Event::assertDispatched() prueft, dass ein Objekt entstanden ist, und waere
+| auch dann gruen, wenn der Job es niemals ausliefern koennte. Genau das ist
+| der Fehler, den Laravels `deleteWhenMissingModels = true` erzeugt — ein
+| Broadcast-Job, dessen Model verschwunden ist, wird beim Ausfuehren STILL
+| verworfen. Deshalb laeuft der Job hier wirklich, ueber die sync-Queue, mit
+| echter Serialisierung, und ein Broadcaster am Ende der Kette schreibt mit,
+| was tatsaechlich ankommt.
+|
+*/
+
+/**
+ * Ein Broadcaster, der nichts sendet, sondern protokolliert.
+ *
+ * Der letzte Halt vor dem Draht: was hier ankommt, ist genau das, was der
+ * Pusher-/Reverb-Broadcaster ueber die Leitung schicken wuerde. Ein Fake auf
+ * Event-Ebene saehe stattdessen nur die Absicht.
+ */
+class RecordingBroadcaster implements Broadcaster
+{
+    /**
+     * @var array<int, array{channels: array<int, string>, event: string, payload: array<string, mixed>}>
+     */
+    public static array $sent = [];
+
+    public function auth($request)
+    {
+        return true;
+    }
+
+    public function validAuthenticationResponse($request, $result)
+    {
+        return $result;
+    }
+
+    public function broadcast(array $channels, $event, array $payload = [])
+    {
+        self::$sent[] = [
+            'channels' => array_map(static fn ($channel): string => (string) $channel, $channels),
+            'event' => $event,
+            'payload' => $payload,
+        ];
+    }
+}
+
+beforeEach(function (): void {
+    RecordingBroadcaster::$sent = [];
+
+    // In der Testumgebung ist das Log per Default aus (phpunit.xml).
+    config()->set('einundzwanzig.change_log.enabled', true);
+
+    config()->set('broadcasting.connections.recording', ['driver' => 'recording']);
+    config()->set('broadcasting.default', 'recording');
+    Broadcast::extend('recording', fn (): Broadcaster => new RecordingBroadcaster);
+});
+
+/**
+ * Die mitgeschriebenen Broadcasts einer Ressource, in Reihenfolge.
+ *
+ * Gefiltert, weil ein Termin-Write laut Plan zwei Ereignisse erzeugt: das
+ * `meetup-event` und — ueber `recalculateActivity()` — zusaetzlich ein `meetup`.
+ * Das ist gewollt und kein Doppelversand.
+ *
+ * @return array<int, array{channels: array<int, string>, event: string, payload: array<string, mixed>}>
+ */
+function broadcastsFor(string $resource): array
+{
+    return array_values(array_filter(
+        RecordingBroadcaster::$sent,
+        static fn (array $sent): bool => ($sent['payload']['resource'] ?? null) === $resource
+    ));
+}
+
+/**
+ * Ein Umschlag in der Gestalt, die {@see ChangeRecorder} baut — ohne Datenbank.
+ *
+ * @return array<string, mixed>
+ */
+function changeEnvelope(string $resource, string $action): array
+{
+    return [
+        'action' => $action,
+        'resource' => $resource,
+        'id' => 1234,
+        'sequence' => 90412,
+        'occurred_at' => '2026-08-23T16:23:11+00:00',
+        'api_version' => '2.0.0',
+        'data' => ['id' => 1234],
+        'links' => ['self' => null],
+    ];
+}
+
+/*
+|--------------------------------------------------------------------------
+| Die Kerneigenschaft: kein Model im Event
+|--------------------------------------------------------------------------
+*/
+
+it('never carries an eloquent model', function (): void {
+    $reflection = new ReflectionClass(ResourceChanged::class);
+
+    // 1. Kein Konstruktor-Parameter darf ein Model annehmen. Waere hier ein Model,
+    //    laege es anschliessend am Objekt und ginge mit in die Queue.
+    foreach ($reflection->getConstructor()->getParameters() as $parameter) {
+        $type = $parameter->getType();
+        $names = $type instanceof ReflectionNamedType ? [$type->getName()] : array_map(
+            static fn (ReflectionNamedType $inner): string => $inner->getName(),
+            $type?->getTypes() ?? []
+        );
+
+        foreach ($names as $name) {
+            // `is_a(..., allow_string: true)` und nicht `is_subclass_of`: sonst rutschte
+            // ausgerechnet der Typ `Model` selbst durch, weil er keine Unterklasse
+            // seiner selbst ist.
+            expect(class_exists($name) && is_a($name, Model::class, true))
+                ->toBeFalse("Konstruktor-Parameter \${$parameter->getName()} nimmt ein Eloquent-Model ({$name}).");
+        }
+    }
+
+    // 2. Keine Property darf ein Model halten.
+    foreach ($reflection->getProperties() as $property) {
+        $type = $property->getType();
+        $name = $type instanceof ReflectionNamedType ? $type->getName() : null;
+
+        expect($name !== null && class_exists($name) && is_a($name, Model::class, true))
+            ->toBeFalse("Property \${$property->getName()} haelt ein Eloquent-Model ({$name}).");
+    }
+
+    // 3. Kein SerializesModels. Der Trait ist der Mechanismus, der ein Model beim
+    //    Ausfuehren des Jobs nachlaedt — und bei einem `deleted` nie wiederfindet.
+    expect(array_keys(class_uses_recursive(ResourceChanged::class)))
+        ->not->toContain(SerializesModels::class);
+});
+
+it('serializes to a queue payload without a single model identifier', function (): void {
+    $event = new ResourceChanged(changeEnvelope('meetup-event', 'deleted'));
+
+    $serialized = serialize(new BroadcastEvent($event));
+
+    // `ModelIdentifier` ist die Spur, die `SerializesModels` im Queue-Payload
+    // hinterlaesst. Ist sie da, wird beim Ausfuehren nachgeladen — und ein
+    // geloeschtes Model laesst den Job still verschwinden.
+    expect($serialized)->not->toContain(ModelIdentifier::class)
+        ->and($serialized)->not->toContain('App\\Models\\MeetupEvent');
+
+    /** @var BroadcastEvent $revived */
+    $revived = unserialize($serialized);
+
+    expect($revived->event->broadcastWith())->toBe(changeEnvelope('meetup-event', 'deleted'));
+});
+
+/*
+|--------------------------------------------------------------------------
+| Der entscheidende Test: ein echtes Delete durch eine echte Queue
+|--------------------------------------------------------------------------
+*/
+
+it('delivers a delete through a real queue run although the model is gone', function (): void {
+    // Fixtures ohne Log aufbauen — sonst zaehlen die Anlege-Ereignisse mit.
+    config()->set('einundzwanzig.change_log.enabled', false);
+    $meetupEvent = MeetupEvent::factory()->create();
+    $id = $meetupEvent->id;
+    config()->set('einundzwanzig.change_log.enabled', true);
+
+    // Der Beleg, dass die Queue wirklich serialisiert hat: unter der sync-Queue
+    // baut Laravel denselben JSON-Payload wie unter Redis und weckt den Job daraus
+    // wieder auf. Ohne diese Zusicherung koennte ein spaeterer Wechsel des
+    // Queue-Treibers den Test entschaerfen, ohne ihn rot zu faerben.
+    $rawJobBodies = [];
+    Event::listen(JobProcessing::class, function (JobProcessing $processing) use (&$rawJobBodies): void {
+        $rawJobBodies[] = $processing->job->getRawBody();
+    });
+
+    $meetupEvent->delete();
+
+    // Das Model ist wirklich weg — kein SoftDeletes irgendwo in diesem Projekt.
+    expect(MeetupEvent::find($id))->toBeNull();
+
+    $broadcasts = broadcastsFor('meetup-event');
+
+    expect($broadcasts)->toHaveCount(1);
+
+    $sent = $broadcasts[0];
+
+    expect($sent['event'])->toBe('.meetup-event.deleted')
+        ->and($sent['channels'])->toBe(['portal', 'meetup-events'])
+        ->and($sent['payload']['action'])->toBe('deleted')
+        ->and($sent['payload']['id'])->toBe($id)
+        ->and($sent['payload']['data'])->toBeNull()
+        // `previous` ist das Einzige, was ein Konsument nach einer Loeschung noch
+        // zum Invalidieren in der Hand hat.
+        ->and($sent['payload']['previous']['meetup_id'])->toBe($meetupEvent->meetup_id);
+
+    // Der Umschlag ist vollstaendig, nicht nur die zwei Felder oben.
+    $row = ApiChange::query()->where('resource', 'meetup-event')->where('action', 'deleted')->sole();
+
+    expect(Arr::except($sent['payload'], ['socket']))->toBe($row->broadcastPayload())
+        ->and($sent['payload']['sequence'])->toBe($row->id);
+
+    expect($rawJobBodies)->not->toBeEmpty();
+    expect(implode("\n", $rawJobBodies))
+        ->toContain('Illuminate\\\\Broadcasting\\\\BroadcastEvent')
+        ->not->toContain('ModelIdentifier');
+});
+
+/*
+|--------------------------------------------------------------------------
+| Kanaele
+|--------------------------------------------------------------------------
+*/
+
+it('broadcasts a meetup-event on exactly portal and meetup-events', function (string $action): void {
+    $channels = (new ResourceChanged(changeEnvelope('meetup-event', $action)))->broadcastOn();
+
+    expect($channels)->toHaveCount(2)
+        ->and($channels[0])->toBeInstanceOf(Channel::class)
+        ->and(array_map(strval(...), $channels))->toBe(['portal', 'meetup-events']);
+})->with(['created', 'updated', 'deleted']);
+
+it('broadcasts every other resource on portal alone', function (string $resource): void {
+    $channels = (new ResourceChanged(changeEnvelope($resource, 'updated')))->broadcastOn();
+
+    // `meetup-events` heisst so, weil es Meetup-Termine traegt. Ein Kanal, der auch
+    // Staedte und Kurse fuehrte, sagte etwas zu, was er nicht haelt — und ein
+    // oeffentlicher Pusher-Kanal hat keinen Rueckkanal, ueber den das auffiele.
+    expect(array_map(strval(...), $channels))->toBe(['portal']);
+})->with(['meetup', 'city', 'course', 'course-event', 'lecturer']);
+
+it('names the event with a leading dot for every action', function (string $action): void {
+    expect((new ResourceChanged(changeEnvelope('meetup-event', $action)))->broadcastAs())
+        ->toBe(".meetup-event.{$action}");
+})->with(['created', 'updated', 'deleted']);
+
+it('names the event after the resource in the payload', function (): void {
+    expect((new ResourceChanged(changeEnvelope('course-event', 'created')))->broadcastAs())
+        ->toBe('.course-event.created')
+        ->and((new ResourceChanged(changeEnvelope('lecturer', 'deleted')))->broadcastAs())
+        ->toBe('.lecturer.deleted');
+});
+
+/*
+|--------------------------------------------------------------------------
+| Ein Format, nicht zwei
+|--------------------------------------------------------------------------
+*/
+
+it('returns the payload from broadcastWith untouched', function (): void {
+    $payload = changeEnvelope('city', 'created');
+
+    expect((new ResourceChanged($payload))->broadcastWith())->toBe($payload);
+});
+
+it('sends exactly what ChangeRecorder::broadcastPayload produces', function (): void {
+    $city = City::factory()->create();
+
+    $row = ApiChange::query()->where('resource', 'city')->sole();
+    $sent = broadcastsFor('city');
+
+    expect($sent)->toHaveCount(1)
+        // Kein zweites Format: der Kanal traegt denselben Umschlag wie /api/changes,
+        // sonst braeuchte ein Konsument nach einem Verbindungsabriss zwei Parser.
+        ->and(Arr::except($sent[0]['payload'], ['socket']))
+        ->toBe(ChangeRecorder::broadcastPayload($row->payload))
+        ->and(Arr::except($sent[0]['payload'], ['socket']))->toBe($row->broadcastPayload())
+        ->and($sent[0]['payload']['data']['id'])->toBe($city->id);
+});
+
+it('strips data from an oversized broadcast while the row keeps everything', function (): void {
+    $description = str_repeat('Bitcoin. ', 1500); // ~13,5 KB
+
+    MeetupEvent::factory()->create(['description' => $description]);
+
+    $row = ApiChange::query()->where('resource', 'meetup-event')->sole();
+    $sent = broadcastsFor('meetup-event');
+
+    expect($sent)->toHaveCount(1);
+
+    $payload = Arr::except($sent[0]['payload'], ['socket']);
+
+    // Reverb weist alles ueber max_request_size (10 000 Bytes) mit HTTP 413 ab.
+    expect($payload['data'])->toBeNull()
+        ->and($payload['truncated'])->toBeTrue()
+        ->and(strlen((string) json_encode($payload)))->toBeLessThanOrEqual(ChangeRecorder::MAX_BROADCAST_BYTES)
+        // Die Tabelle bleibt vollstaendig — sie ist der Resync-Weg.
+        ->and($row->payload['data']['description'])->toBe($description)
+        ->and($row->payload)->not->toHaveKey('truncated');
+});
+
+/*
+|--------------------------------------------------------------------------
+| Der Kill-Switch schaltet beides ab
+|--------------------------------------------------------------------------
+*/
+
+it('dispatches nothing and writes nothing while the change log is off', function (): void {
+    config()->set('einundzwanzig.change_log.enabled', false);
+
+    // Nur dieses eine Event faken — ein pauschales Event::fake() legte auch die
+    // Model-Events still und der Observer liefe nie.
+    Event::fake([ResourceChanged::class]);
+
+    $city = City::factory()->create();
+    $city->update(['population' => 4242]);
+    $city->delete();
+
+    Event::assertNotDispatched(ResourceChanged::class);
+
+    expect(ApiChange::query()->count())->toBe(0)
+        ->and(RecordingBroadcaster::$sent)->toBe([]);
+});
+
+it('dispatches nothing and writes nothing inside a muted block', function (): void {
+    Event::fake([ResourceChanged::class]);
+
+    ChangeRecorder::muted(function (): void {
+        Lecturer::factory()->create();
+    });
+
+    Event::assertNotDispatched(ResourceChanged::class);
+
+    expect(ApiChange::query()->count())->toBe(0);
+});
+
+/*
+|--------------------------------------------------------------------------
+| Ein kaputter Broadcast reisst den Schreibvorgang nicht mit
+|--------------------------------------------------------------------------
+*/
+
+it('keeps the write and the row when the broadcaster throws', function (): void {
+    Broadcast::extend('recording', function (): Broadcaster {
+        return new class implements Broadcaster
+        {
+            public function auth($request)
+            {
+                return true;
+            }
+
+            public function validAuthenticationResponse($request, $result)
+            {
+                return $result;
+            }
+
+            public function broadcast(array $channels, $event, array $payload = [])
+            {
+                throw new BroadcastException('Reverb ist nicht erreichbar');
+            }
+        };
+    });
+
+    Log::spy();
+
+    // Der Recorder laeuft im Observer, mitten im Schreib-Request. Fiele die Ausnahme
+    // durch, riebe ein nicht erreichbarer Reverb jedes Speichern im Portal auf.
+    $city = City::factory()->create(['name' => 'Rosenheim']);
+
+    expect(City::find($city->id)->name)->toBe('Rosenheim')
+        ->and(ApiChange::query()->where('resource', 'city')->count())->toBe(1);
+
+    // Still ist der Ausfall trotzdem nicht.
+    Log::shouldHaveReceived('warning')
+        ->withArgs(fn (string $message, array $context): bool => $message === 'Broadcast der Aenderung fehlgeschlagen'
+            && $context['resource'] === 'city'
+            && $context['action'] === 'created')
+        ->atLeast()->once();
+});
+
+/*
+|--------------------------------------------------------------------------
+| Der ganze Weg, je Ressource
+|--------------------------------------------------------------------------
+*/
+
+it('broadcasts create, update and delete for every api resource', function (): void {
+    config()->set('einundzwanzig.change_log.enabled', false);
+    $meetup = Meetup::factory()->create();
+    $course = Course::factory()->create();
+    $courseEvent = CourseEvent::factory()->create();
+    $lecturer = Lecturer::factory()->create();
+    config()->set('einundzwanzig.change_log.enabled', true);
+
+    $meetup->update(['intro' => 'Neuer Einleitungstext.']);
+    $course->update(['description' => 'Neue Kursbeschreibung.']);
+    $courseEvent->update(['location' => 'Neuer Ort 7']);
+    $lecturer->update(['subtitle' => 'Neuer Untertitel']);
+
+    foreach (['meetup', 'course', 'course-event', 'lecturer'] as $resource) {
+        $sent = broadcastsFor($resource);
+
+        expect($sent)->toHaveCount(1)
+            ->and($sent[0]['event'])->toBe(".{$resource}.updated")
+            ->and($sent[0]['channels'])->toBe(['portal']);
+    }
+});

--- a/tests/Feature/Database/PruneApiChangesTest.php
+++ b/tests/Feature/Database/PruneApiChangesTest.php
@@ -1,0 +1,44 @@
+<?php
+
+use App\Models\ApiChange;
+use Illuminate\Console\Scheduling\Schedule;
+
+it('deletes changes older than the retention window and keeps younger ones', function (): void {
+    $stale = ApiChange::factory()->create(['occurred_at' => now()->subDays(31)]);
+    $edge = ApiChange::factory()->create(['occurred_at' => now()->subDays(30)->addMinute()]);
+    $fresh = ApiChange::factory()->create(['occurred_at' => now()->subDay()]);
+
+    $this->artisan('api-changes:prune')->assertSuccessful();
+
+    expect(ApiChange::query()->whereKey($stale->id)->exists())->toBeFalse()
+        ->and(ApiChange::query()->whereKey($edge->id)->exists())->toBeTrue()
+        ->and(ApiChange::query()->whereKey($fresh->id)->exists())->toBeTrue();
+});
+
+it('honours an explicit retention window', function (): void {
+    $old = ApiChange::factory()->create(['occurred_at' => now()->subDays(10)]);
+    $recent = ApiChange::factory()->create(['occurred_at' => now()->subDays(2)]);
+
+    $this->artisan('api-changes:prune', ['--days' => 7])->assertSuccessful();
+
+    expect(ApiChange::query()->whereKey($old->id)->exists())->toBeFalse()
+        ->and(ApiChange::query()->whereKey($recent->id)->exists())->toBeTrue();
+});
+
+it('refuses a retention window below one day', function (): void {
+    // Ein Fenster von 0 Tagen wuerde das Log beim naechsten Lauf leeren und damit den
+    // Resync-Weg abschalten — lieber ein Fehlschlag als eine stille Loeschung.
+    $change = ApiChange::factory()->create(['occurred_at' => now()->subYear()]);
+
+    $this->artisan('api-changes:prune', ['--days' => 0])->assertFailed();
+
+    expect(ApiChange::query()->whereKey($change->id)->exists())->toBeTrue();
+});
+
+it('is scheduled daily', function (): void {
+    $events = collect(app(Schedule::class)->events())
+        ->filter(fn ($event) => str_contains((string) $event->command, 'api-changes:prune'));
+
+    expect($events)->toHaveCount(1)
+        ->and($events->first()->expression)->toBe('0 4 * * *');
+});


### PR DESCRIPTION
Beantwortet #29 („Webhooks for events CRUD").

## Was drin ist

**Der verlässliche Weg zuerst.** Jede Änderung an den sechs öffentlichen Ressourcen
(`meetup`, `meetup-event`, `city`, `course`, `course-event`, `lecturer`) schreibt eine
Zeile nach `api_changes` — mit dem vollständigen Objekt **im Schema der REST-API**, damit
TypeScript-Konsumenten keine zweite Typmenge pflegen. `GET /api/changes` gibt sie ab einem
Cursor wieder aus.

**Warum das der Kern ist und nicht der WebSocket:** Kein Model in diesem Projekt nutzt
SoftDeletes. Ein gelöschter Datensatz ist restlos weg — ein Konsument, der offline war,
könnte das aus keinem Export rekonstruieren. Der Feed ist der einzige Weg, auf dem ein
Löschen je ankommt.

**Reverb obendrauf.** Zwei öffentliche Kanäle: `portal` (alles) und `meetup-events` (nur
Termine). Gleicher Umschlag wie im Feed — eine Nachricht vom Kanal und ein Eintrag aus
`/api/changes` sind byte für byte dasselbe Objekt.

**Doku** unter `/docs/websockets`, verlinkt aus `/docs/api`.

## Drei Entscheidungen, die nicht offensichtlich sind

**Das Payload entsteht genau einmal, synchron im Observer.** Der naheliegende Weg wäre
gewesen, das Model in ein Event zu legen. Aber Laravels Broadcast-Job trägt
`deleteWhenMissingModels = true` und verwirft einen Job, dessen Model verschwunden ist —
ohne Fehler, ohne `failed_jobs`-Eintrag. Genau die `deleted`-Meldung wäre in Produktion nie
angekommen und im Test grün gewesen. Zwei Tests halten fest, dass das Event kein Model
trägt; beide wurden durch Mutation geprüft, nicht behauptet.

**`recalculateActivity()` meldet sich ausdrücklich**, obwohl es `saveQuietly()` benutzt und
damit kein Model-Event feuert. `is_active` und `last_event_at` stehen in der
`MeetupResource` und ändern sich nachts für viele Meetups — ohne den expliziten Aufruf wäre
jeder Listen-Cache still veraltet.

**`cursor_expired` steht in jeder Antwort.** Das Log wird nach 30 Tagen geprunt; ohne
dieses Feld bekäme ein länger abwesender Konsument eine leere Liste, die von „nichts
geändert" nicht zu unterscheiden ist.

## Was bewusst fehlt

Echte HTTP-Webhooks (der Issue fragte danach) — Reverb liefert keine Zustellgarantie, kein
Retry, kein Replay und keine Signatur pro Nachricht. `api_changes` ist der Unterbau, falls
sie später kommen sollen: ein Webhook-Fanout liest dieselbe Tabelle. Die sechs Lücken
stehen offen auf `/docs/websockets`.

Ebenso fehlen Länder-, Stadt- und Entity-Kanäle. Sie hat niemand angefragt, und ein Abo auf
einen Kanal, den es nicht mehr gibt, ist erfolgreich und für immer still.

## Vor dem Merge

`BROADCAST_CONNECTION` ist ungesetzt gleichbedeutend mit `null` — ohne Env-Eintrag ändert
der Merge am Laufzeitverhalten nichts außer der neuen Tabelle und dem neuen Endpunkt.
Reverb wird danach von Hand aktiviert (Daemon, nginx-Proxy auf `--path=reverb`, Env).

## Tests

`177 / 70 / 115 / 97 passed`, null rot. Jede Phase einzeln gegen ihre Definition of Done
geprüft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)