### PR TITLE
🔌 WebSocket-Doku auf die Reverb-Subdomain nachziehen

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -83,10 +83,17 @@ REVERB_APP_SECRET=
 # Wohin der Daemon selbst bindet.
 REVERB_SERVER_HOST=127.0.0.1
 REVERB_SERVER_PORT=8080
-# Pfad-Praefix des Handshakes. NICHT der Default "app": die Site hat bereits eine
-# Route `GET app/auth` (Mobile-Login-Handoff), die ein nginx-Proxy auf /app/ verdecken
-# wuerde. Muss zu `reverb:start --path=` und zum nginx-location passen.
-REVERB_SERVER_PATH=reverb
+# Pfad-Praefix des Handshakes. LEER in Produktion: seit P5 laeuft Reverb ueber Forges
+# Reverb-Integration auf einer eigenen Subdomain, damit steht der Handshake unter dem
+# Standardpfad /app und kollidiert mit nichts. (Ein Pfad-Praefix braeuchte es nur,
+# wenn Reverb unter der Portal-Domain haengt — dort ist `GET app/auth` als
+# Mobile-Login-Handoff bereits vergeben.) Muss zu `reverb:start --path=` passen.
+REVERB_SERVER_PATH=
+# WOHIN EIN KONSUMENT VERBINDET — nur der Hostname, ohne Schema, Port optional
+# (`ws.example.test:8443`). Nicht zu verwechseln mit REVERB_HOST weiter unten, das
+# sagt, wohin die ANWENDUNG publiziert. Diese Variable speist die Verbindungsangaben
+# auf /docs/websockets; leer heisst "Host aus APP_URL", was lokal richtig ist.
+REVERB_PUBLIC_HOST=
 # Wohin die ANWENDUNG publiziert. In Produktion der lokale Daemon, nicht der
 # oeffentliche Hostname — sonst geht jeder Broadcast als TLS-Roundtrip durch nginx auf
 # denselben Server zurueck.

--- a/config/einundzwanzig.php
+++ b/config/einundzwanzig.php
@@ -99,4 +99,38 @@ return [
         'prune_days' => (int) env('CHANGE_LOG_PRUNE_DAYS', 30),
     ],
 
+    /*
+    |--------------------------------------------------------------------------
+    | Realtime — wohin ein KONSUMENT verbindet
+    |--------------------------------------------------------------------------
+    |
+    | `public_host` ist der oeffentliche Hostname des WebSocket-Servers, so wie
+    | ihn /docs/websockets ausweist. Er hat einen eigenen Schluessel, weil ihn
+    | sonst nichts kennt:
+    |
+    |  - `REVERB_HOST` (config/broadcasting.php) sagt, wohin die ANWENDUNG
+    |    publiziert. In Produktion steht dort 127.0.0.1:8080 — der lokale
+    |    Daemon, damit ein Broadcast nicht als TLS-Roundtrip nach draussen und
+    |    wieder herein laeuft. Als Verbindungsangabe fuer einen Konsumenten
+    |    waere das die Anweisung, sich mit sich selbst zu verbinden.
+    |  - `app.url` ist die Portal-Domain. Sie stimmte, solange Reverb als
+    |    Pfad-Proxy unter derselben Domain hing. Seit P5 laeuft der Server ueber
+    |    Forges Reverb-Integration auf einer EIGENEN Subdomain
+    |    (ws.portal.einundzwanzig.space) mit eigenem Zertifikat — dieselbe
+    |    Domain anzunehmen, waere schlicht falsch.
+    |
+    | Genau diese Verwechslung — Publish-Ziel gegen Verbindungsziel — ist der
+    | Grund fuer den eigenen Schluessel. Leer heisst: Host aus `app.url`, was
+    | lokal (`composer run dev`) das Richtige ist.
+    |
+    | Nur Host, ohne Schema. Ein abweichender Port darf angehaengt werden
+    | (`ws.example.test:8443`); ohne Angabe gilt der Standardport des Schemas.
+    | Das Schema selbst folgt `app.url`: http lokal, https in Produktion.
+    |
+    */
+
+    'realtime' => [
+        'public_host' => env('REVERB_PUBLIC_HOST'),
+    ],
+
 ];

--- a/resources/views/livewire/docs/websockets.blade.php
+++ b/resources/views/livewire/docs/websockets.blade.php
@@ -37,8 +37,6 @@ class extends Component {
      * bei sich. Die Platzhalter tragen den Namen der Env-Variablen, aus der der Wert
      * kommt, damit erkennbar ist, worauf gewartet wird.
      */
-    private const PATH_PLACEHOLDER = '{REVERB_SERVER_PATH}';
-
     private const KEY_PLACEHOLDER = '{REVERB_APP_KEY}';
 
     /**
@@ -61,31 +59,52 @@ class extends Component {
     /**
      * Die Verbindungsangaben, vollstaendig aus der Konfiguration gelesen.
      *
-     * Nichts davon ist hier fest verdrahtet — sobald P5 die Produktionswerte setzt,
-     * zeigt die Seite sie, ohne dass jemand sie nachtraegt.
+     * Nichts davon ist hier fest verdrahtet: aendert sich der Betrieb, aendert sich
+     * die Seite mit — genau das war der Punkt, und P5 hat ihn eingeloest.
      *
-     * EINE ABWEICHUNG, MIT ABSICHT: Host, Schema und Port kommen aus `app.url` und
-     * NICHT aus `broadcasting.connections.reverb.options.*`. Die dortigen Werte sagen,
-     * wohin die ANWENDUNG publiziert; auf Produktion steht da laut Plan
-     * `127.0.0.1:8080/http`, damit ein Broadcast nicht als TLS-Roundtrip durch nginx
-     * auf denselben Server zurueckläuft. Ein Konsument, der sich zu 127.0.0.1
-     * verbindet, verbindet sich zu seiner eigenen Maschine. Der Weg nach aussen ist der
-     * Pfad-Proxy auf demselben Hostnamen wie das Portal — also `app.url`.
+     * DREI QUELLEN, WEIL ES DREI VERSCHIEDENE DINGE SIND:
      *
-     * Der Pfad kommt aus `reverb.servers.reverb.path` (das ist das `--path` des
-     * Daemons und damit genau das Praefix, das nginx nach aussen reicht), mit
-     * `broadcasting.connections.reverb.options.path` als zweiter Quelle, weil beide
-     * dieselbe Env-Variable lesen.
+     *  1. HOST — `einundzwanzig.realtime.public_host` (`REVERB_PUBLIC_HOST`), mit
+     *     `app.url` als Rueckfall. NICHT
+     *     `broadcasting.connections.reverb.options.host`: dort steht das
+     *     PUBLISH-Ziel, in Produktion `127.0.0.1:8080`, damit ein Broadcast nicht als
+     *     TLS-Roundtrip nach draussen und wieder herein laeuft. Und seit P5 auch
+     *     nicht mehr `app.url` allein: Reverb haengt nicht als Pfad-Proxy unter der
+     *     Portal-Domain, sondern laeuft ueber Forges Reverb-Integration auf einer
+     *     eigenen Subdomain mit eigenem Zertifikat. Lokal, wo beides zusammenfaellt,
+     *     bleibt der Rueckfall auf `app.url` richtig.
+     *  2. SCHEMA und PORT — aus `app.url`. Das Schema, weil `wss` genau dann gilt,
+     *     wenn das Portal selbst per TLS laeuft. Der Port nur dann, wenn auch der
+     *     Host von dort kommt: einen abweichenden Port an einen ANDEREN Hostnamen zu
+     *     kleben, ergaebe lokal `wss://ws.example.test:8000` — eine Adresse, die es
+     *     nirgends gibt. Steht der Port am konfigurierten Host (`host:8443`), wird er
+     *     von dort gelesen.
+     *  3. PFAD und KEY — aus den Reverb-Configs. Der Pfad kommt aus
+     *     `reverb.servers.reverb.path` (dem `--path` des Daemons), mit
+     *     `broadcasting.connections.reverb.options.path` als zweiter Quelle, weil
+     *     beide dieselbe Env-Variable lesen. LEER IST DER NORMALFALL: auf einer
+     *     eigenen Subdomain steht der Handshake unter dem Standardpfad `/app`, und
+     *     dann darf in der URL kein leeres Segment und erst recht kein Platzhalter
+     *     stehen. Nur der Key hat einen Platzhalter — er ist der einzige Wert, den
+     *     man nicht raten und nicht weglassen kann.
      *
-     * @return array{scheme:string, host:string, port:int, ws_path:string, key:string, url:string, published:bool}
+     * @return array{scheme:string, host:string, port:int, has_path:bool, ws_path:string, key:string, url:string, published:bool}
      */
     #[Computed]
     public function connection(): array
     {
         $appUrl = (string) config('app.url');
-        $host = parse_url($appUrl, PHP_URL_HOST) ?: request()->getHost();
-        $port = parse_url($appUrl, PHP_URL_PORT);
         $scheme = parse_url($appUrl, PHP_URL_SCHEME) === 'http' ? 'ws' : 'wss';
+
+        $publicHost = trim((string) config('einundzwanzig.realtime.public_host'), " \t\n\r\0\x0B/");
+
+        if ($publicHost !== '') {
+            // Ein optionaler Port darf am konfigurierten Host haengen.
+            [$host, $port] = array_pad(explode(':', $publicHost, 2), 2, null);
+        } else {
+            $host = parse_url($appUrl, PHP_URL_HOST) ?: request()->getHost();
+            $port = parse_url($appUrl, PHP_URL_PORT);
+        }
 
         $path = trim((string) (
             config('reverb.servers.reverb.path')
@@ -94,22 +113,22 @@ class extends Component {
 
         $key = trim((string) config('broadcasting.connections.reverb.key'));
 
-        $authority = $host.($port ? ':'.$port : '');
-
         return [
             'scheme' => $scheme,
             'host' => $host,
             'port' => (int) ($port ?: ($scheme === 'wss' ? 443 : 80)),
-            'ws_path' => $path === '' ? self::PATH_PLACEHOLDER : '/'.$path,
+            'has_path' => $path !== '',
+            'ws_path' => $path === '' ? '' : '/'.$path,
             'key' => $key === '' ? self::KEY_PLACEHOLDER : $key,
             'url' => sprintf(
-                '%s://%s/%s/app/%s',
+                '%s://%s%s%s/app/%s',
                 $scheme,
-                $authority,
-                $path === '' ? self::PATH_PLACEHOLDER : $path,
+                $host,
+                $port ? ':'.$port : '',
+                $path === '' ? '' : '/'.$path,
                 $key === '' ? self::KEY_PLACEHOLDER : $key,
             ),
-            'published' => $path !== '' && $key !== '',
+            'published' => $key !== '',
         ];
     }
 
@@ -348,6 +367,20 @@ class extends Component {
         $connection = $this->connection();
         $changesUrl = $this->changesUrl();
         $forceTls = $connection['scheme'] === 'wss' ? 'true' : 'false';
+
+        /*
+         * `wsPath` steht nur da, wenn es einen Pfad gibt. Der Default in pusher-js ist
+         * der leere String (`wsPath: opts.wsPath || Defaults.wsPath`, `wsPath: ''` in
+         * src/core/defaults.ts) — weglassen und `''` sind also dasselbe. Eine Zeile
+         * `wsPath: ''` in ein Copy-paste-Beispiel zu schreiben, laedt trotzdem dazu
+         * ein, sie fuer noetig zu halten und irgendwann falsch zu fuellen.
+         */
+        $wsPathConst = $connection['has_path']
+            ? "\nconst WS_PATH = '{$connection['ws_path']}';   // the proxy only forwards this prefix"
+            : '';
+        $wsPathOption = $connection['has_path']
+            ? "\n  wsPath: WS_PATH,"
+            : '';
         $maxBytes = ChangeRecorder::MAX_BROADCAST_BYTES;
         $pruneDays = $this->pruneDays();
 
@@ -361,8 +394,7 @@ class extends Component {
         import Pusher from 'pusher-js';
 
         const WS_HOST = '{$connection['host']}';
-        const WS_PATH = '{$connection['ws_path']}';        // nginx proxies only this prefix
-        const APP_KEY = '{$connection['key']}';
+        const APP_KEY = '{$connection['key']}';{$wsPathConst}
         const CHANGES = '{$changesUrl}';
 
         type Change = {
@@ -445,8 +477,7 @@ class extends Component {
         }
 
         const pusher = new Pusher(APP_KEY, {
-          wsHost: WS_HOST,
-          wsPath: WS_PATH,
+          wsHost: WS_HOST,{$wsPathOption}
           wsPort: {$connection['port']},
           wssPort: {$connection['port']},
           forceTLS: {$forceTls},
@@ -669,10 +700,10 @@ class extends Component {
                 <flux:icon name="wrench-screwdriver" class="mt-0.5 size-5 shrink-0 text-amber-500"/>
                 <p class="text-pretty leading-relaxed text-zinc-700 dark:text-zinc-200">
                     <strong>The socket is not published in this environment yet.</strong>
-                    Everything in curly braces below is a placeholder named after the environment
-                    variable it will come from. The values on this page are read from the running
-                    configuration, so the moment the server is deployed they appear here by themselves
-                    — there is nothing on this page to keep up to date by hand.
+                    The app key in curly braces below is a placeholder named after the environment
+                    variable it will come from. Every value on this page is read from the running
+                    configuration, so the moment the server is deployed they appear here by
+                    themselves — there is nothing on this page to keep up to date by hand.
                 </p>
             </div>
         @endunless
@@ -686,7 +717,14 @@ class extends Component {
                     </tr>
                     <tr class="bg-white/60 dark:bg-white/[0.03]">
                         <th scope="row" class="px-5 py-4 align-top font-semibold">Host</th>
-                        <td class="px-5 py-4 font-mono break-all">{{ $this->connection['host'] }}</td>
+                        <td class="px-5 py-4">
+                            <span class="font-mono break-all">{{ $this->connection['host'] }}</span>
+                            <span class="mt-1 block text-zinc-500 dark:text-zinc-400">
+                                The socket has its own hostname with its own certificate — it is not the
+                                portal domain. The REST endpoints, <code>/api/changes</code> included, stay
+                                where they are.
+                            </span>
+                        </td>
                     </tr>
                     <tr class="bg-white/60 dark:bg-white/[0.03]">
                         <th scope="row" class="px-5 py-4 align-top font-semibold">Scheme / port</th>
@@ -695,11 +733,21 @@ class extends Component {
                     <tr class="bg-white/60 dark:bg-white/[0.03]">
                         <th scope="row" class="px-5 py-4 align-top font-semibold"><code>wsPath</code></th>
                         <td class="px-5 py-4">
-                            <span class="font-mono">{{ $this->connection['ws_path'] }}</span>
-                            <span class="mt-1 block text-zinc-500 dark:text-zinc-400">
-                                Not the Pusher default <code>/app</code>: that prefix is already taken by the
-                                portal's mobile login handoff, so only this path is proxied through to Reverb.
-                            </span>
+                            @if ($this->connection['has_path'])
+                                <span class="font-mono">{{ $this->connection['ws_path'] }}</span>
+                                <span class="mt-1 block text-zinc-500 dark:text-zinc-400">
+                                    A path prefix is in play here: only this prefix is proxied through to
+                                    Reverb, so <code>wsPath</code> has to be set on the client.
+                                </span>
+                            @else
+                                <span class="font-mono">— none —</span>
+                                <span class="mt-1 block text-zinc-500 dark:text-zinc-400">
+                                    No prefix. The handshake sits at the default <code>/app</code> of its own
+                                    hostname, so leave <code>wsPath</code> out entirely — in
+                                    <code>pusher-js</code> it defaults to the empty string, and omitting it
+                                    and passing <code>''</code> are the same thing.
+                                </span>
+                            @endif
                         </td>
                     </tr>
                     <tr class="bg-white/60 dark:bg-white/[0.03]">

--- a/tests/Feature/Api/WebSocketDocsPageTest.php
+++ b/tests/Feature/Api/WebSocketDocsPageTest.php
@@ -90,8 +90,14 @@ it('shows a placeholder instead of an invented value while reverb is unpublished
     $this->get(route('docs.websockets'))
         ->assertSuccessful()
         ->assertSee('{REVERB_APP_KEY}')
-        ->assertSee('{REVERB_SERVER_PATH}')
-        ->assertSee('The socket is not published in this environment yet.');
+        ->assertSee('The socket is not published in this environment yet.')
+        /*
+         * Fuer den PFAD gibt es bewusst keinen Platzhalter mehr: leer ist seit P5 der
+         * Normalfall (eigene Subdomain, Handshake unter dem Standardpfad /app), und
+         * ein Platzhalter an dieser Stelle stuende in der URL und liesse eine
+         * vollstaendige Adresse wie eine unfertige aussehen.
+         */
+        ->assertDontSee('{REVERB_SERVER_PATH}');
 });
 
 it('reads the connection details from the configuration, not from the page', function () {
@@ -101,7 +107,8 @@ it('reads the connection details from the configuration, not from the page', fun
      * niemand nachfaehrt, sobald P5 die Produktionswerte setzt.
      */
     config([
-        'app.url' => 'https://ws.example.test',
+        'app.url' => 'https://portal.example.test',
+        'einundzwanzig.realtime.public_host' => 'ws.portal.example.test',
         'broadcasting.connections.reverb.key' => 'schluessel-aus-der-config',
         'reverb.servers.reverb.path' => 'reverb-pfad-aus-der-config',
     ]);
@@ -110,9 +117,77 @@ it('reads the connection details from the configuration, not from the page', fun
         ->assertSuccessful()
         ->assertSee('schluessel-aus-der-config')
         ->assertSee('/reverb-pfad-aus-der-config')
-        ->assertSee('wss://ws.example.test/reverb-pfad-aus-der-config/app/schluessel-aus-der-config')
+        ->assertSee('wss://ws.portal.example.test/reverb-pfad-aus-der-config/app/schluessel-aus-der-config')
         ->assertDontSee('{REVERB_APP_KEY}')
         ->assertDontSee('{REVERB_SERVER_PATH}');
+});
+
+it('sends consumers to the configured public host, not to the portal domain', function () {
+    /*
+     * Der Befund aus P5: Reverb haengt NICHT als Pfad-Proxy unter der Portal-Domain,
+     * sondern auf einer eigenen Subdomain mit eigenem Zertifikat. Wer hier `app.url`
+     * annimmt, schickt jeden Konsumenten an einen Host, auf dem kein Socket steht —
+     * und der Fehler faellt erst beim Verbinden auf, nicht beim Lesen.
+     */
+    config([
+        'app.url' => 'https://portal.example.test',
+        'einundzwanzig.realtime.public_host' => 'ws.portal.example.test',
+        'reverb.servers.reverb.path' => '',
+        'broadcasting.connections.reverb.options.path' => '',
+        'broadcasting.connections.reverb.key' => 'ein-key',
+    ]);
+
+    $this->get(route('docs.websockets'))
+        ->assertSuccessful()
+        ->assertSee('wss://ws.portal.example.test/app/ein-key')
+        // Die Portal-Domain bleibt der REST-Host — aber nicht der Socket-Host.
+        ->assertDontSee('wss://portal.example.test');
+});
+
+it('falls back to the app url host when no public host is configured', function () {
+    /*
+     * Lokal (`composer run dev`) faellt beides zusammen, und der Rueckfall ist das,
+     * was diese Seite auf einer Entwicklermaschine ueberhaupt brauchbar haelt.
+     */
+    config([
+        'app.url' => 'http://localhost:8000',
+        'einundzwanzig.realtime.public_host' => null,
+        'reverb.servers.reverb.path' => '',
+        'broadcasting.connections.reverb.options.path' => '',
+        'broadcasting.connections.reverb.key' => 'lokaler-key',
+    ]);
+
+    $this->get(route('docs.websockets'))
+        ->assertSuccessful()
+        // http → ws, und der Port aus app.url bleibt stehen, weil auch der Host von
+        // dort kommt.
+        ->assertSee('ws://localhost:8000/app/lokaler-key');
+});
+
+it('builds a url without an empty path segment when there is no prefix', function () {
+    /*
+     * Der Fehler, den diese Zusicherung ausschliesst, ist ein doppelter Schraegstrich
+     * oder ein stehengebliebener Platzhalter mitten in einer Adresse, die man kopieren
+     * soll. Beides verbindet nicht, und beides sieht auf den ersten Blick richtig aus.
+     */
+    config([
+        'app.url' => 'https://portal.example.test',
+        'einundzwanzig.realtime.public_host' => 'ws.portal.example.test',
+        'reverb.servers.reverb.path' => '',
+        'broadcasting.connections.reverb.options.path' => '',
+        'broadcasting.connections.reverb.key' => 'ein-key',
+    ]);
+
+    $response = $this->get(route('docs.websockets'))->assertSuccessful();
+
+    $response->assertSee('wss://ws.portal.example.test/app/ein-key');
+    $response->assertDontSee('ws.portal.example.test//app');
+    $response->assertDontSee('{REVERB_SERVER_PATH}');
+    // Ohne Praefix gehoert auch keine wsPath-Zeile ins TypeScript-Beispiel: der
+    // pusher-js-Default ist der leere String, die Zeile waere eine Einladung, sie
+    // spaeter falsch zu fuellen.
+    $response->assertDontSee('wsPath: WS_PATH', false);
+    $response->assertSee('— none —');
 });
 
 it('falls back to the broadcasting path when the reverb server path is unset', function () {


### PR DESCRIPTION
Nachzug zu #31, nachdem Reverb auf Produktion aktiviert wurde.

## Das Problem

Reverb läuft über Laravel Forges eigene Integration auf **`ws.portal.einundzwanzig.space`** —
eigene Subdomain, eigenes Zertifikat, Standardpfad `/app`, kein Präfix. Die Doku-Seite baute
ihre Verbindungsadresse aber aus `app.url` und schickte damit jeden Konsumenten an die
Portal-Domain, wo nichts lauscht. Live sichtbar war
`wss://portal.einundzwanzig.space/{REVERB_SERVER_PATH}/app/<key>` — falscher Host **und** ein
Platzhalter mitten in der URL.

## Warum das passieren konnte

Es sind **drei** Hostnamen im Spiel, und keiner der beiden vorhandenen war der richtige:

| Wert | Bedeutung |
|---|---|
| `REVERB_HOST` | wohin die **Anwendung publiziert** — `127.0.0.1:8080` |
| `app.url` | die **Portal-Domain**, wo die REST-Endpunkte liegen |
| *fehlte* | wohin ein **Konsument verbindet** |

Dafür gibt es jetzt `REVERB_PUBLIC_HOST`, und der Kommentar daneben nennt beide
Verwechslungskandidaten beim Namen.

## Umsetzung

Der Schlüssel liegt unter `einundzwanzig.realtime.public_host`, **nicht** in
`config/reverb.php`: das ist publizierte Vendor-Config, ein fremder Schlüssel darin liest
sich, als würde Reverb ihn selbst auswerten, und ein späteres `vendor:publish` verlöre ihn.
`connection()` liest aus drei getrennten Quellen, jede mit dem Grund im Kommentar.

Das leere Pfadsegment ist mit verschwunden — leer ist auf der Subdomain der Normalfall.
Im TypeScript-Beispiel entfällt die `wsPath`-Zeile dann ganz, statt als leerer String
dazustehen und jemanden einzuladen, sie später falsch zu füllen; `pusher-js` hat als Default
für `wsPath` ohnehin den leeren String (nachgelesen, nicht vermutet).

Der Port folgt jetzt dem Host: er wird nur aus `app.url` übernommen, wenn auch der Host von
dort kommt — sonst klebte lokal ein Port an einem fremden Hostnamen.

## Nach dem Merge auf Produktion setzen

```
REVERB_PUBLIC_HOST=ws.portal.einundzwanzig.space
```

Dazu eine **Kontrolle, keine neue Zeile**: `REVERB_SERVER_PATH` muss leer sein oder fehlen.
Steht dort noch `reverb`, baut die Seite eine Adresse, die es auf der Forge-Integration nicht
gibt.

## Tests

`180 / 70 / 115 / 97 passed`. Drei neue: konfigurierter Host, `app.url`-Rückfall, URL ohne
Pfadsegment. Die übrigen drei Läufe unverändert.

🤖 Generated with [Claude Code](https://claude.com/claude-code)