### PR TITLE
Identify recurring-series events, and answer the recurrence question everywhere

### DIFF
--- a/lang/cs.json
+++ b/lang/cs.json
@@ -866,8 +866,8 @@
     "Kalender abonnieren": "Subscribe to calendar",
     "Kalenderlink kopieren (alle Länder)": "Copy calendar link (all countries)",
     "Kalenderlink kopieren (nur :country)": "Copy calendar link (:country only)",
-    "Dieses Event gehört zu einer Serie": "This event is part of a series",
-    "Die Serieneinstellungen lassen sich nach dem Anlegen nicht mehr ändern. Was du hier speicherst, gilt nur für diesen einen Termin — die übrigen Termine der Serie bleiben unverändert.": "Series settings can no longer be changed after creation. What you save here applies only to this one event — the other events in the series remain unchanged.",
+    "Dieses Event gehört zu einer Serie": "Tato událost je součástí série",
+    "Die Serieneinstellungen lassen sich nach dem Anlegen nicht mehr ändern. Was du hier speicherst, gilt nur für diesen einen Termin — die übrigen Termine der Serie bleiben unverändert.": "Nastavení série už po vytvoření nelze změnit. Co zde uložíš, platí jen pro tento jeden termín — ostatní termíny série zůstanou beze změny.",
     "Webhook-Subscription abgelehnt.": "Webhook subscription rejected.",
     "Diese Anfrage ablehnen? Die Ablehnung lässt sich hier nicht wieder aufheben.": "Reject this request? The rejection cannot be undone here.",
     "Meetup": "Meetups",
@@ -877,5 +877,6 @@
     "Event am :date öffnen": "Open event on :date",
     "Suche deine Sprache...": "Hledat jazyk...",
     "Serie": "Série",
-    "Dieser Termin gehört zu einer wiederkehrenden Serie.": "Tato událost je součástí opakující se série."
+    "Dieser Termin gehört zu einer wiederkehrenden Serie.": "Tato událost je součástí opakující se série.",
+    "Serientermine bestimmst du beim Erstellen. Später geht das nicht mehr.": "Opakování nastavuješ při vytváření události, později už ne."
 }

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -875,5 +875,7 @@
     "Vorstand": "Board",
     "Meetup :name öffnen": "Open meetup :name",
     "Event am :date öffnen": "Open event on :date",
-    "Suche deine Sprache...": "Hledat jazyk..."
+    "Suche deine Sprache...": "Hledat jazyk...",
+    "Serie": "Série",
+    "Dieser Termin gehört zu einer wiederkehrenden Serie.": "Tato událost je součástí opakující se série."
 }

--- a/lang/de.json
+++ b/lang/de.json
@@ -877,5 +877,6 @@
     "Event am :date öffnen": "",
     "Suche deine Sprache...": "",
     "Serie": "",
-    "Dieser Termin gehört zu einer wiederkehrenden Serie.": ""
+    "Dieser Termin gehört zu einer wiederkehrenden Serie.": "",
+    "Serientermine bestimmst du beim Erstellen. Später geht das nicht mehr.": ""
 }

--- a/lang/de.json
+++ b/lang/de.json
@@ -875,5 +875,7 @@
     "Vorstand": "",
     "Meetup :name öffnen": "",
     "Event am :date öffnen": "",
-    "Suche deine Sprache...": ""
+    "Suche deine Sprache...": "",
+    "Serie": "",
+    "Dieser Termin gehört zu einer wiederkehrenden Serie.": ""
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -877,5 +877,6 @@
     "Event am :date öffnen": "Open event on :date",
     "Suche deine Sprache...": "Search your language...",
     "Serie": "Series",
-    "Dieser Termin gehört zu einer wiederkehrenden Serie.": "This event is part of a recurring series."
+    "Dieser Termin gehört zu einer wiederkehrenden Serie.": "This event is part of a recurring series.",
+    "Serientermine bestimmst du beim Erstellen. Später geht das nicht mehr.": "You set recurring dates when you create the event, not afterwards."
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -875,5 +875,7 @@
     "Vorstand": "Board",
     "Meetup :name öffnen": "Open meetup :name",
     "Event am :date öffnen": "Open event on :date",
-    "Suche deine Sprache...": "Search your language..."
+    "Suche deine Sprache...": "Search your language...",
+    "Serie": "Series",
+    "Dieser Termin gehört zu einer wiederkehrenden Serie.": "This event is part of a recurring series."
 }

--- a/lang/es.json
+++ b/lang/es.json
@@ -866,8 +866,8 @@
     "Kalender abonnieren": "Subscribe to calendar",
     "Kalenderlink kopieren (alle Länder)": "Copy calendar link (all countries)",
     "Kalenderlink kopieren (nur :country)": "Copy calendar link (:country only)",
-    "Dieses Event gehört zu einer Serie": "This event is part of a series",
-    "Die Serieneinstellungen lassen sich nach dem Anlegen nicht mehr ändern. Was du hier speicherst, gilt nur für diesen einen Termin — die übrigen Termine der Serie bleiben unverändert.": "Series settings can no longer be changed after creation. What you save here applies only to this one event — the other events in the series remain unchanged.",
+    "Dieses Event gehört zu einer Serie": "Este evento forma parte de una serie",
+    "Die Serieneinstellungen lassen sich nach dem Anlegen nicht mehr ändern. Was du hier speicherst, gilt nur für diesen einen Termin — die übrigen Termine der Serie bleiben unverändert.": "Los ajustes de la serie ya no se pueden cambiar después de crearla. Lo que guardes aquí se aplica solo a esta fecha — las demás fechas de la serie no cambian.",
     "Webhook-Subscription abgelehnt.": "Webhook subscription rejected.",
     "Diese Anfrage ablehnen? Die Ablehnung lässt sich hier nicht wieder aufheben.": "Reject this request? The rejection cannot be undone here.",
     "Meetup": "Meetups",
@@ -877,5 +877,6 @@
     "Event am :date öffnen": "Open event on :date",
     "Suche deine Sprache...": "Busca tu idioma...",
     "Serie": "Serie",
-    "Dieser Termin gehört zu einer wiederkehrenden Serie.": "Este evento forma parte de una serie recurrente."
+    "Dieser Termin gehört zu einer wiederkehrenden Serie.": "Este evento forma parte de una serie recurrente.",
+    "Serientermine bestimmst du beim Erstellen. Später geht das nicht mehr.": "Defines las fechas periódicas al crear el evento, no después."
 }

--- a/lang/es.json
+++ b/lang/es.json
@@ -875,5 +875,7 @@
     "Vorstand": "Board",
     "Meetup :name öffnen": "Open meetup :name",
     "Event am :date öffnen": "Open event on :date",
-    "Suche deine Sprache...": "Busca tu idioma..."
+    "Suche deine Sprache...": "Busca tu idioma...",
+    "Serie": "Serie",
+    "Dieser Termin gehört zu einer wiederkehrenden Serie.": "Este evento forma parte de una serie recurrente."
 }

--- a/lang/hu.json
+++ b/lang/hu.json
@@ -866,8 +866,8 @@
     "Kalender abonnieren": "Subscribe to calendar",
     "Kalenderlink kopieren (alle Länder)": "Copy calendar link (all countries)",
     "Kalenderlink kopieren (nur :country)": "Copy calendar link (:country only)",
-    "Dieses Event gehört zu einer Serie": "This event is part of a series",
-    "Die Serieneinstellungen lassen sich nach dem Anlegen nicht mehr ändern. Was du hier speicherst, gilt nur für diesen einen Termin — die übrigen Termine der Serie bleiben unverändert.": "Series settings can no longer be changed after creation. What you save here applies only to this one event — the other events in the series remain unchanged.",
+    "Dieses Event gehört zu einer Serie": "Ez az esemény egy sorozat része",
+    "Die Serieneinstellungen lassen sich nach dem Anlegen nicht mehr ändern. Was du hier speicherst, gilt nur für diesen einen Termin — die übrigen Termine der Serie bleiben unverändert.": "A sorozat beállításai a létrehozás után már nem módosíthatók. Amit itt mentesz, csak erre az egy időpontra vonatkozik — a sorozat többi időpontja változatlan marad.",
     "Webhook-Subscription abgelehnt.": "Webhook subscription rejected.",
     "Diese Anfrage ablehnen? Die Ablehnung lässt sich hier nicht wieder aufheben.": "Reject this request? The rejection cannot be undone here.",
     "Meetup": "Meetups",
@@ -877,5 +877,6 @@
     "Event am :date öffnen": "Open event on :date",
     "Suche deine Sprache...": "Nyelv keresése...",
     "Serie": "Sorozat",
-    "Dieser Termin gehört zu einer wiederkehrenden Serie.": "Ez az esemény egy ismétlődő sorozat része."
+    "Dieser Termin gehört zu einer wiederkehrenden Serie.": "Ez az esemény egy ismétlődő sorozat része.",
+    "Serientermine bestimmst du beim Erstellen. Später geht das nicht mehr.": "Az ismétlődést a létrehozáskor állítod be, utólag már nem."
 }

--- a/lang/hu.json
+++ b/lang/hu.json
@@ -875,5 +875,7 @@
     "Vorstand": "Board",
     "Meetup :name öffnen": "Open meetup :name",
     "Event am :date öffnen": "Open event on :date",
-    "Suche deine Sprache...": "Nyelv keresése..."
+    "Suche deine Sprache...": "Nyelv keresése...",
+    "Serie": "Sorozat",
+    "Dieser Termin gehört zu einer wiederkehrenden Serie.": "Ez az esemény egy ismétlődő sorozat része."
 }

--- a/lang/lv.json
+++ b/lang/lv.json
@@ -875,5 +875,7 @@
     "Vorstand": "Board",
     "Meetup :name öffnen": "Open meetup :name",
     "Event am :date öffnen": "Open event on :date",
-    "Suche deine Sprache...": "Meklēt valodu..."
+    "Suche deine Sprache...": "Meklēt valodu...",
+    "Serie": "Sērija",
+    "Dieser Termin gehört zu einer wiederkehrenden Serie.": "Šis pasākums ir daļa no atkārtojošās sērijas."
 }

--- a/lang/lv.json
+++ b/lang/lv.json
@@ -866,8 +866,8 @@
     "Kalender abonnieren": "Subscribe to calendar",
     "Kalenderlink kopieren (alle Länder)": "Copy calendar link (all countries)",
     "Kalenderlink kopieren (nur :country)": "Copy calendar link (:country only)",
-    "Dieses Event gehört zu einer Serie": "This event is part of a series",
-    "Die Serieneinstellungen lassen sich nach dem Anlegen nicht mehr ändern. Was du hier speicherst, gilt nur für diesen einen Termin — die übrigen Termine der Serie bleiben unverändert.": "Series settings can no longer be changed after creation. What you save here applies only to this one event — the other events in the series remain unchanged.",
+    "Dieses Event gehört zu einer Serie": "Šis pasākums ir daļa no sērijas",
+    "Die Serieneinstellungen lassen sich nach dem Anlegen nicht mehr ändern. Was du hier speicherst, gilt nur für diesen einen Termin — die übrigen Termine der Serie bleiben unverändert.": "Sērijas iestatījumus pēc izveides vairs nevar mainīt. Tas, ko šeit saglabā, attiecas tikai uz šo vienu pasākumu — pārējie sērijas pasākumi paliek nemainīgi.",
     "Webhook-Subscription abgelehnt.": "Webhook subscription rejected.",
     "Diese Anfrage ablehnen? Die Ablehnung lässt sich hier nicht wieder aufheben.": "Reject this request? The rejection cannot be undone here.",
     "Meetup": "Meetups",
@@ -877,5 +877,6 @@
     "Event am :date öffnen": "Open event on :date",
     "Suche deine Sprache...": "Meklēt valodu...",
     "Serie": "Sērija",
-    "Dieser Termin gehört zu einer wiederkehrenden Serie.": "Šis pasākums ir daļa no atkārtojošās sērijas."
+    "Dieser Termin gehört zu einer wiederkehrenden Serie.": "Šis pasākums ir daļa no atkārtojošās sērijas.",
+    "Serientermine bestimmst du beim Erstellen. Später geht das nicht mehr.": "Atkārtošanos iestati, veidojot pasākumu, vēlāk vairs ne."
 }

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -866,8 +866,8 @@
     "Kalender abonnieren": "Subscribe to calendar",
     "Kalenderlink kopieren (alle Länder)": "Copy calendar link (all countries)",
     "Kalenderlink kopieren (nur :country)": "Copy calendar link (:country only)",
-    "Dieses Event gehört zu einer Serie": "This event is part of a series",
-    "Die Serieneinstellungen lassen sich nach dem Anlegen nicht mehr ändern. Was du hier speicherst, gilt nur für diesen einen Termin — die übrigen Termine der Serie bleiben unverändert.": "Series settings can no longer be changed after creation. What you save here applies only to this one event — the other events in the series remain unchanged.",
+    "Dieses Event gehört zu einer Serie": "Dit evenement maakt deel uit van een reeks",
+    "Die Serieneinstellungen lassen sich nach dem Anlegen nicht mehr ändern. Was du hier speicherst, gilt nur für diesen einen Termin — die übrigen Termine der Serie bleiben unverändert.": "De instellingen van de reeks kun je na het aanmaken niet meer wijzigen. Wat je hier opslaat, geldt alleen voor deze ene afspraak — de overige afspraken van de reeks blijven ongewijzigd.",
     "Webhook-Subscription abgelehnt.": "Webhook subscription rejected.",
     "Diese Anfrage ablehnen? Die Ablehnung lässt sich hier nicht wieder aufheben.": "Reject this request? The rejection cannot be undone here.",
     "Meetup": "Meetups",
@@ -877,5 +877,6 @@
     "Event am :date öffnen": "Open event on :date",
     "Suche deine Sprache...": "Zoek je taal...",
     "Serie": "Reeks",
-    "Dieser Termin gehört zu einer wiederkehrenden Serie.": "Dit evenement maakt deel uit van een terugkerende reeks."
+    "Dieser Termin gehört zu einer wiederkehrenden Serie.": "Dit evenement maakt deel uit van een terugkerende reeks.",
+    "Serientermine bestimmst du beim Erstellen. Später geht das nicht mehr.": "Je stelt de reeks in bij het aanmaken, later niet meer."
 }

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -875,5 +875,7 @@
     "Vorstand": "Board",
     "Meetup :name öffnen": "Open meetup :name",
     "Event am :date öffnen": "Open event on :date",
-    "Suche deine Sprache...": "Zoek je taal..."
+    "Suche deine Sprache...": "Zoek je taal...",
+    "Serie": "Reeks",
+    "Dieser Termin gehört zu einer wiederkehrenden Serie.": "Dit evenement maakt deel uit van een terugkerende reeks."
 }

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -875,5 +875,7 @@
     "Vorstand": "Board",
     "Meetup :name öffnen": "Open meetup :name",
     "Event am :date öffnen": "Open event on :date",
-    "Suche deine Sprache...": "Szukaj języka..."
+    "Suche deine Sprache...": "Szukaj języka...",
+    "Serie": "Seria",
+    "Dieser Termin gehört zu einer wiederkehrenden Serie.": "To wydarzenie jest częścią serii cyklicznej."
 }

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -866,8 +866,8 @@
     "Kalender abonnieren": "Subscribe to calendar",
     "Kalenderlink kopieren (alle Länder)": "Copy calendar link (all countries)",
     "Kalenderlink kopieren (nur :country)": "Copy calendar link (:country only)",
-    "Dieses Event gehört zu einer Serie": "This event is part of a series",
-    "Die Serieneinstellungen lassen sich nach dem Anlegen nicht mehr ändern. Was du hier speicherst, gilt nur für diesen einen Termin — die übrigen Termine der Serie bleiben unverändert.": "Series settings can no longer be changed after creation. What you save here applies only to this one event — the other events in the series remain unchanged.",
+    "Dieses Event gehört zu einer Serie": "To wydarzenie jest częścią serii",
+    "Die Serieneinstellungen lassen sich nach dem Anlegen nicht mehr ändern. Was du hier speicherst, gilt nur für diesen einen Termin — die übrigen Termine der Serie bleiben unverändert.": "Ustawień serii nie można już zmienić po jej utworzeniu. To, co tu zapiszesz, dotyczy tylko tego jednego terminu — pozostałe terminy serii pozostają bez zmian.",
     "Webhook-Subscription abgelehnt.": "Webhook subscription rejected.",
     "Diese Anfrage ablehnen? Die Ablehnung lässt sich hier nicht wieder aufheben.": "Reject this request? The rejection cannot be undone here.",
     "Meetup": "Meetups",
@@ -877,5 +877,6 @@
     "Event am :date öffnen": "Open event on :date",
     "Suche deine Sprache...": "Szukaj języka...",
     "Serie": "Seria",
-    "Dieser Termin gehört zu einer wiederkehrenden Serie.": "To wydarzenie jest częścią serii cyklicznej."
+    "Dieser Termin gehört zu einer wiederkehrenden Serie.": "To wydarzenie jest częścią serii cyklicznej.",
+    "Serientermine bestimmst du beim Erstellen. Später geht das nicht mehr.": "Cykliczność ustawiasz przy tworzeniu wydarzenia, później już nie."
 }

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -875,5 +875,7 @@
     "Vorstand": "Board",
     "Meetup :name öffnen": "Open meetup :name",
     "Event am :date öffnen": "Open event on :date",
-    "Suche deine Sprache...": "Procurar idioma..."
+    "Suche deine Sprache...": "Procurar idioma...",
+    "Serie": "Série",
+    "Dieser Termin gehört zu einer wiederkehrenden Serie.": "Este evento faz parte de uma série recorrente."
 }

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -866,8 +866,8 @@
     "Kalender abonnieren": "Subscribe to calendar",
     "Kalenderlink kopieren (alle Länder)": "Copy calendar link (all countries)",
     "Kalenderlink kopieren (nur :country)": "Copy calendar link (:country only)",
-    "Dieses Event gehört zu einer Serie": "This event is part of a series",
-    "Die Serieneinstellungen lassen sich nach dem Anlegen nicht mehr ändern. Was du hier speicherst, gilt nur für diesen einen Termin — die übrigen Termine der Serie bleiben unverändert.": "Series settings can no longer be changed after creation. What you save here applies only to this one event — the other events in the series remain unchanged.",
+    "Dieses Event gehört zu einer Serie": "Este evento faz parte de uma série",
+    "Die Serieneinstellungen lassen sich nach dem Anlegen nicht mehr ändern. Was du hier speicherst, gilt nur für diesen einen Termin — die übrigen Termine der Serie bleiben unverändert.": "As definições da série já não podem ser alteradas depois de criada. O que guardares aqui aplica-se apenas a esta data — as restantes datas da série ficam inalteradas.",
     "Webhook-Subscription abgelehnt.": "Webhook subscription rejected.",
     "Diese Anfrage ablehnen? Die Ablehnung lässt sich hier nicht wieder aufheben.": "Reject this request? The rejection cannot be undone here.",
     "Meetup": "Meetups",
@@ -877,5 +877,6 @@
     "Event am :date öffnen": "Open event on :date",
     "Suche deine Sprache...": "Procurar idioma...",
     "Serie": "Série",
-    "Dieser Termin gehört zu einer wiederkehrenden Serie.": "Este evento faz parte de uma série recorrente."
+    "Dieser Termin gehört zu einer wiederkehrenden Serie.": "Este evento faz parte de uma série recorrente.",
+    "Serientermine bestimmst du beim Erstellen. Später geht das nicht mehr.": "Defines a recorrência ao criar o evento, não depois."
 }

--- a/resources/views/livewire/meetups/create-edit-events.blade.php
+++ b/resources/views/livewire/meetups/create-edit-events.blade.php
@@ -561,6 +561,27 @@ class extends Component
                 </flux:callout>
             @endif
 
+            {{-- The exact complement of the callout above, so no edit view is ever silent
+                 about recurrence: a series occurrence gets the callout, a standalone event
+                 gets this line, and create mode gets the switch instead of either. Before
+                 this, editing a standalone event just showed no switch at all, which is
+                 what issue #43 reported as "unclear whether recurrence is intentionally
+                 creation-only".
+
+                 It ranks below the callout on purpose, and structurally rather than by
+                 size: no border, no background, no heading, muted text. This is a passive
+                 fact on a form the user came to for something else, not a warning. It sits
+                 in the slot the switch occupies in create mode, so the empty spot explains
+                 itself, and it takes its 24px rhythm from the fieldset's space-y-6 instead
+                 of carrying a margin of its own. --}}
+            @if($event && $event->recurrence_group === null)
+                <div class="flex items-start gap-2 text-sm text-zinc-600 dark:text-zinc-400"
+                     data-testid="recurrence-creation-only-note">
+                    <flux:icon.arrow-path class="mt-0.5 size-4 shrink-0" aria-hidden="true"/>
+                    <span>{{ __('Serientermine bestimmst du beim Erstellen. Später geht das nicht mehr.') }}</span>
+                </div>
+            @endif
+
             <!-- Series Mode Toggle -->
             @if(!$event)
                 <flux:field variant="inline">

--- a/resources/views/livewire/meetups/landingpage-event.blade.php
+++ b/resources/views/livewire/meetups/landingpage-event.blade.php
@@ -197,6 +197,24 @@ class extends Component {
                     {{ $event->start->asDateTime() }}
                 </flux:heading>
 
+                {{-- Series marker (issue #43). `recurrence_group` is the only reliable
+                     series identity: the 2026_08_25_194948 migration backfilled that
+                     column alone, so events of pre-P5 series carry `recurrence_type = null`
+                     and would be missed by it.
+
+                     The note sits between the heading and the data list, pulled up by
+                     -mt-2 so it reads as a qualifier of the date rather than as a fourth
+                     data field beside Zeit/Ort/Beschreibung. It states the fact and
+                     nothing more: no series view exists and a series cannot be edited,
+                     so the wording promises neither. --}}
+                @if($event->recurrence_group !== null)
+                    <div class="-mt-2 mb-4 flex items-start gap-2 text-sm text-zinc-600 dark:text-zinc-400"
+                         data-testid="series-note">
+                        <flux:icon.arrow-path class="mt-0.5 size-4 shrink-0" aria-hidden="true"/>
+                        <span>{{ __('Dieser Termin gehört zu einer wiederkehrenden Serie.') }}</span>
+                    </div>
+                @endif
+
                 <div class="space-y-4">
                     <!-- Date and Time -->
                     <div class="flex items-center text-zinc-700 dark:text-zinc-300">

--- a/resources/views/livewire/meetups/landingpage.blade.php
+++ b/resources/views/livewire/meetups/landingpage.blade.php
@@ -272,6 +272,22 @@ class extends Component
                     <flux:card size="sm" class="h-full flex flex-col">
                         <flux:heading class="flex items-center gap-2">
                             {{ $event->start->asDate() }}
+                            {{-- Series marker (issue #43). `recurrence_group` is the only
+                                 reliable series identity: the 2026_08_25_194948 migration
+                                 backfilled that column alone, so events of pre-P5 series
+                                 carry `recurrence_type = null` and would be missed by it.
+
+                                 `inset="top bottom"` is Flux's own mechanism for an inline
+                                 badge: it cancels the badge's py-1 out of the layout box, so
+                                 a series card's heading stays exactly as tall as a
+                                 badge-free neighbour's and the grid row does not grow.
+                                 `shrink-0` keeps the badge from being squeezed by the date
+                                 beside it, since flux:badge is whitespace-nowrap. --}}
+                            @if($event->recurrence_group !== null)
+                                <flux:badge size="sm" color="zinc" icon="arrow-path"
+                                            inset="top bottom" class="shrink-0"
+                                            data-testid="series-badge">{{ __('Serie') }}</flux:badge>
+                            @endif
                         </flux:heading>
 
                         <flux:text class="mt-2 text-sm text-zinc-600 dark:text-zinc-400">

--- a/resources/views/livewire/meetups/landingpage.blade.php
+++ b/resources/views/livewire/meetups/landingpage.blade.php
@@ -320,12 +320,22 @@ class extends Component
                             </flux:text>
                         @endif
 
-                        <div class="mt-auto pt-4 flex gap-2">
+                        {{-- `flex-wrap` alone would not have fixed the leader row: with
+                             `flex-1` the primary button has flex-basis 0, so it counts as
+                             zero when the browser decides where to break the line, all
+                             three buttons stay on one line, and `min-width: auto` then
+                             floors them back to 312px of content in a 254px box —
+                             "Entfernen" spilling into the neighbouring card. `basis-full`
+                             gives the primary a real basis so it claims the first line and
+                             the two leader actions wrap below it. The visitor view is
+                             unchanged: with a single child, basis-full renders exactly as
+                             flex-1 did. `gap-2` already supplies the 8px row gap. --}}
+                        <div class="mt-auto pt-4 flex flex-wrap gap-2">
                             <flux:button
                                 :href="route('meetups.landingpage-event', ['meetup' => $meetup->slug, 'event' => $event->id, 'country' => $country])"
                                 size="xs"
                                 variant="primary"
-                                class="flex-1"
+                                class="basis-full"
                             >
                                 {{ __('Öffnen/RSVP') }}
                             </flux:button>

--- a/tests/Feature/Meetups/EditRecurringEventControlsTest.php
+++ b/tests/Feature/Meetups/EditRecurringEventControlsTest.php
@@ -118,6 +118,110 @@ it('shows no series note when editing a standalone event', function () {
         ->assertDontSeeHtml('data-testid="series-locked-note"');
 });
 
+/*
+ * The two edit-mode recurrence notes are COMPLEMENTS (#43).
+ *
+ * "It is unclear whether recurrence is intentionally creation-only" is the complaint the
+ * issue actually raises, and silence is what caused it: before the series callout, an
+ * edit form that simply omitted the series controls left the editor guessing whether the
+ * setting was missing, hidden or broken. Answering only half of it — telling occurrences
+ * of a series why they cannot change it, while a standalone event still says nothing —
+ * would leave exactly that gap open for every event that is NOT part of a series.
+ *
+ * So edit mode owes an answer in BOTH shapes:
+ *   `data-testid="series-locked-note"`             gated `$event && $event->recurrence_group !== null`
+ *   `data-testid="recurrence-creation-only-note"`  gated `$event && $event->recurrence_group === null`
+ *
+ * One condition, negated. Exactly one of the two must therefore render for any stored
+ * event — never both (contradictory advice), never neither (the silence that started
+ * this). The counting assertion below is what makes "neither" fail; a pair of
+ * assertDontSeeHtml() calls would pass happily on an edit form that says nothing at all.
+ */
+
+it('tells the editor that recurrence cannot be added afterwards when editing a standalone event', function () {
+    $meetup = meetupWithActingUserAsLeader();
+
+    $event = MeetupEvent::factory()->for($meetup)->create([
+        'recurrence_type' => null,
+        'recurrence_end_date' => null,
+        'recurrence_group' => null,
+    ]);
+
+    Livewire::test('meetups.create-edit-events', ['meetup' => $meetup, 'event' => $event])
+        ->assertSeeHtml('data-testid="recurrence-creation-only-note"')
+        ->assertDontSeeHtml('data-testid="series-locked-note"');
+});
+
+it('shows the series callout and not the creation-only note when editing a series occurrence', function () {
+    $meetup = meetupWithActingUserAsLeader();
+
+    $event = MeetupEvent::factory()->for($meetup)->create([
+        'recurrence_type' => RecurrenceType::Weekly->value,
+        'recurrence_end_date' => now()->addYear(),
+        'recurrence_group' => (string) Str::uuid(),
+    ]);
+
+    Livewire::test('meetups.create-edit-events', ['meetup' => $meetup, 'event' => $event])
+        ->assertSeeHtml('data-testid="series-locked-note"')
+        ->assertDontSeeHtml('data-testid="recurrence-creation-only-note"');
+});
+
+it('shows neither recurrence note when creating an event', function () {
+    $meetup = meetupWithActingUserAsLeader();
+
+    // Both notes speak about a setting that is already decided. While it is still open —
+    // the switch and the series fields are right there — neither has anything to say.
+    Livewire::test('meetups.create-edit-events', ['meetup' => $meetup])
+        ->assertDontSeeHtml('data-testid="series-locked-note"')
+        ->assertDontSeeHtml('data-testid="recurrence-creation-only-note"');
+});
+
+/**
+ * The complement itself, over the four shapes an edit form can be opened on.
+ *
+ * The two shapes in the middle are the ones that separate `recurrence_group` from
+ * `recurrence_type`, and they are why the count is asserted per shape rather than once:
+ *
+ *  - "pre-backfill series" carries a group and NO rule — the state
+ *    2026_08_25_194948_group_existing_meetup_event_series left behind on every series
+ *    that existed before P5. A gate keyed off `recurrence_type` would hand it the
+ *    creation-only note and tell the editor of a real series that it is not one; the
+ *    `$notes[$expected]` assertion falls with "Failed asserting that 0 is identical to 1".
+ *  - "rule without a group" is the mirror image, writable through
+ *    `POST/PATCH /api/meetup-events` since forever (see the third branch of
+ *    Meetup::recalculateActivity()). It is a single event: a gate on `recurrence_type`
+ *    would show it the series callout, and the same assertion falls on the other note.
+ *
+ * The `array_sum(...)` assertion is independent of both: it fails whenever an edit view
+ * stops answering the recurrence question at all, whichever column someone gates on.
+ */
+it('renders exactly one of the two recurrence notes in edit mode', function (?RecurrenceType $rule, bool $belongsToSeries, string $expectedNote) {
+    $meetup = meetupWithActingUserAsLeader();
+
+    $event = MeetupEvent::factory()->for($meetup)->create([
+        'recurrence_type' => $rule?->value,
+        'recurrence_end_date' => $rule !== null ? now()->addYear() : null,
+        'recurrence_group' => $belongsToSeries ? (string) Str::uuid() : null,
+    ]);
+
+    $html = Livewire::test('meetups.create-edit-events', ['meetup' => $meetup, 'event' => $event])->html();
+
+    $notes = [
+        'series-locked-note' => substr_count($html, 'data-testid="series-locked-note"'),
+        'recurrence-creation-only-note' => substr_count($html, 'data-testid="recurrence-creation-only-note"'),
+    ];
+
+    // Exactly one note, and it is the right one — together these also rule out a form
+    // that renders both, which would give contradictory advice about the same event.
+    expect(array_sum($notes))->toBe(1)
+        ->and($notes[$expectedNote])->toBe(1);
+})->with([
+    'standalone — neither rule nor group' => [null, false, 'recurrence-creation-only-note'],
+    'rule without a group — single event written through the REST path' => [RecurrenceType::Weekly, false, 'recurrence-creation-only-note'],
+    'series occurrence — rule and group' => [RecurrenceType::Weekly, true, 'series-locked-note'],
+    'pre-backfill series — group, no rule' => [null, true, 'series-locked-note'],
+]);
+
 it('still offers the switch, the series fields and the series button when creating', function () {
     $meetup = meetupWithActingUserAsLeader();
 

--- a/tests/Feature/Meetups/SeriesIdentificationTest.php
+++ b/tests/Feature/Meetups/SeriesIdentificationTest.php
@@ -1,0 +1,210 @@
+<?php
+
+use App\Enums\RecurrenceType;
+use App\Models\Meetup;
+use App\Models\MeetupEvent;
+use Illuminate\Support\Str;
+use Livewire\Livewire;
+
+/*
+ * Events of a recurring series must be identifiable outside the edit form (#43).
+ *
+ * Until now the only marker lived in `create-edit-events.blade.php`
+ * (`data-testid="series-locked-note"`, pinned by EditRecurringEventControlsTest) —
+ * visible to a leader in edit mode and to nobody else. These tests pin the two public
+ * markers:
+ *
+ *  - `data-testid="series-badge"` on every card of the "Kommende Veranstaltungen" grid
+ *    in `meetups/landingpage.blade.php` whose event belongs to a series
+ *  - `data-testid="series-note"` on the single-event page
+ *    `meetups/landingpage-event.blade.php` when the shown event belongs to a series
+ *
+ * The gate is `$event->recurrence_group !== null` and NOTHING ELSE. `recurrence_type`
+ * is the wrong column, in both directions:
+ *
+ *  - 2026_08_25_194948_group_existing_meetup_event_series backfilled `recurrence_group`
+ *    only and set no `recurrence_*` rule column, so every pre-P5 series carries
+ *    `recurrence_type = null`. A gate on the rule would leave exactly the series that
+ *    #43 was filed about unmarked.
+ *  - The reverse state is reachable too: `POST /api/meetup-events` and `PATCH` have
+ *    always accepted `recurrence_type` on a single event without a group (see the
+ *    third branch of Meetup::recalculateActivity()). A gate on the rule would mark a
+ *    lone event as a series.
+ *
+ * Both directions have their own test below; together they fail whenever someone keys
+ * the gate off `recurrence_type`.
+ *
+ * The assertions deliberately look at the `data-testid` attributes, never at the German
+ * copy — the wording belongs to the markup author and may change without changing the
+ * behaviour this file guards.
+ */
+
+/**
+ * A meetup that renders on the public landing page. Ownership is irrelevant here: the
+ * markers are for visitors, so every case below runs as a guest.
+ */
+function meetupForSeriesIdentification(): Meetup
+{
+    return Meetup::factory()->create();
+}
+
+/**
+ * An occurrence of a series in its post-P5 shape: group AND rule.
+ * `start` is pinned into the future because the card grid only lists
+ * `start >= now()`.
+ */
+function seriesOccurrence(Meetup $meetup): MeetupEvent
+{
+    return MeetupEvent::factory()->for($meetup)->create([
+        'start' => now()->addWeek(),
+        'recurrence_type' => RecurrenceType::Weekly->value,
+        'recurrence_end_date' => now()->addYear(),
+        'recurrence_group' => (string) Str::uuid(),
+    ]);
+}
+
+/**
+ * The pre-backfill shape: `recurrence_group` set by the grouping migration, no rule
+ * column at all. This is the fixture that separates the two columns — a gate on
+ * `recurrence_type` renders nothing for it.
+ */
+function backfilledSeriesOccurrence(Meetup $meetup): MeetupEvent
+{
+    return MeetupEvent::factory()->for($meetup)->create([
+        'start' => now()->addWeek(),
+        'recurrence_type' => null,
+        'recurrence_day_of_week' => null,
+        'recurrence_day_position' => null,
+        'recurrence_end_date' => null,
+        'recurrence_group' => (string) Str::uuid(),
+    ]);
+}
+
+/**
+ * A single event, no series in any sense. The factory sets `recurrence_type` on roughly
+ * 40 % of its rows, so both columns are pinned explicitly — otherwise this fixture would
+ * randomly turn into the "rule without group" case below and the test would only
+ * sometimes measure what it claims to.
+ */
+function standaloneEvent(Meetup $meetup): MeetupEvent
+{
+    return MeetupEvent::factory()->for($meetup)->create([
+        'start' => now()->addWeek(),
+        'recurrence_type' => null,
+        'recurrence_end_date' => null,
+        'recurrence_group' => null,
+    ]);
+}
+
+/**
+ * A single event carrying a recurrence rule but no group — writable through the REST
+ * single-event path since forever. It is NOT a series: nothing ties it to a second
+ * event.
+ */
+function ruleWithoutGroupEvent(Meetup $meetup): MeetupEvent
+{
+    return MeetupEvent::factory()->for($meetup)->create([
+        'start' => now()->addWeek(),
+        'recurrence_type' => RecurrenceType::Weekly->value,
+        'recurrence_end_date' => now()->addYear(),
+        'recurrence_group' => null,
+    ]);
+}
+
+it('marks the card of an event that belongs to a series', function () {
+    $meetup = meetupForSeriesIdentification();
+    seriesOccurrence($meetup);
+
+    Livewire::test('meetups.landingpage', ['meetup' => $meetup])
+        ->assertStatus(200)
+        ->assertSeeHtml('data-testid="series-badge"');
+});
+
+it('marks the card of a pre-backfill series event that carries no recurrence type', function () {
+    $meetup = meetupForSeriesIdentification();
+    $event = backfilledSeriesOccurrence($meetup);
+
+    // The whole point of #43: this row is a series and has been one since long before
+    // any `recurrence_*` column was written.
+    expect($event->recurrence_type)->toBeNull()
+        ->and($event->recurrence_group)->not->toBeNull();
+
+    Livewire::test('meetups.landingpage', ['meetup' => $meetup])
+        ->assertStatus(200)
+        ->assertSeeHtml('data-testid="series-badge"');
+});
+
+it('leaves the card of a standalone event unmarked', function () {
+    $meetup = meetupForSeriesIdentification();
+    standaloneEvent($meetup);
+
+    Livewire::test('meetups.landingpage', ['meetup' => $meetup])
+        ->assertStatus(200)
+        ->assertDontSeeHtml('data-testid="series-badge"');
+});
+
+it('leaves the card unmarked for an event that carries a recurrence rule but no group', function () {
+    $meetup = meetupForSeriesIdentification();
+    ruleWithoutGroupEvent($meetup);
+
+    Livewire::test('meetups.landingpage', ['meetup' => $meetup])
+        ->assertStatus(200)
+        ->assertDontSeeHtml('data-testid="series-badge"');
+});
+
+it('marks only the series cards when the list mixes a series with single events', function () {
+    $meetup = meetupForSeriesIdentification();
+
+    // Two occurrences of one series, plus two events that must stay unmarked. Counting
+    // instead of asserting mere presence: a marker rendered unconditionally on every
+    // card would satisfy assertSeeHtml just as well.
+    $group = (string) Str::uuid();
+    MeetupEvent::factory()->count(2)->for($meetup)->series($group, start: now()->addWeek())->create();
+    standaloneEvent($meetup);
+    ruleWithoutGroupEvent($meetup);
+
+    $html = Livewire::test('meetups.landingpage', ['meetup' => $meetup])
+        ->assertStatus(200)
+        ->html();
+
+    expect(substr_count($html, 'data-testid="series-badge"'))->toBe(2);
+});
+
+it('marks the detail page of an event that belongs to a series', function () {
+    $meetup = meetupForSeriesIdentification();
+    $event = seriesOccurrence($meetup);
+
+    Livewire::test('meetups.landingpage-event', ['event' => $event])
+        ->assertStatus(200)
+        ->assertSeeHtml('data-testid="series-note"');
+});
+
+it('marks the detail page of a pre-backfill series event that carries no recurrence type', function () {
+    $meetup = meetupForSeriesIdentification();
+    $event = backfilledSeriesOccurrence($meetup);
+
+    expect($event->recurrence_type)->toBeNull()
+        ->and($event->recurrence_group)->not->toBeNull();
+
+    Livewire::test('meetups.landingpage-event', ['event' => $event])
+        ->assertStatus(200)
+        ->assertSeeHtml('data-testid="series-note"');
+});
+
+it('leaves the detail page of a standalone event unmarked', function () {
+    $meetup = meetupForSeriesIdentification();
+    $event = standaloneEvent($meetup);
+
+    Livewire::test('meetups.landingpage-event', ['event' => $event])
+        ->assertStatus(200)
+        ->assertDontSeeHtml('data-testid="series-note"');
+});
+
+it('leaves the detail page unmarked for an event that carries a recurrence rule but no group', function () {
+    $meetup = meetupForSeriesIdentification();
+    $event = ruleWithoutGroupEvent($meetup);
+
+    Livewire::test('meetups.landingpage-event', ['event' => $event])
+        ->assertStatus(200)
+        ->assertDontSeeHtml('data-testid="series-note"');
+});


### PR DESCRIPTION
Closes #43.

#52 announced this issue as closed. Re-reading its six requested behaviours against the code showed two of them were not delivered.

**Series events were identifiable only from inside the edit form.** The event list and the event detail page said nothing, so you had to already be editing an event to learn it was one occurrence of a series. Both surfaces now carry a marker, gated on `recurrence_group` rather than `recurrence_type` — the migration that grouped existing series backfilled only that column, so a gate on the rule column would miss exactly the older series whose inconsistent display started the issue.

**The explanation "recurrence is set at creation" reached only half its audience, and only in two languages.** Someone editing a standalone event saw the switch absent with no word about why — this issue's own complaint. And both strings from #52 carried the English text verbatim in seven locales; key-parity tests pass on key presence, so nothing flagged it. Fixed on both counts.

Along the way, the card action row was overflowing its own card by 58px for meetup leaders, spilling "Entfernen" into the neighbouring card.

**Verified:** full non-Browser suite 1774 passed / 6466 assertions. Thirteen feature tests cover the markers, including the pre-backfill shape and its inverse; a gate on the wrong column fails five assertions. Browser-measured at 1280px and 375px with a negative control — numbers and screenshots are in the issue comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A4BKf2zxFNSRKBoMUB8EUW