### PR TITLE
Stop rendering German at an English visitor

### DIFF
--- a/lang/cs.json
+++ b/lang/cs.json
@@ -635,7 +635,6 @@
     "URL (Onion/Tor)": "URL (Onion/Tor)",
     "URL (pkdns)": "URL (pkdns)",
     "URLs & Erreichbarkeit": "URL adresy a dostupnost",
-    "Uhr": "hod.",
     "Uhrzeit": "Čas",
     "Um wie viel Uhr beginnt das Event?": "V kolik hodin událost začíná?",
     "Um wie viel Uhr endet das Event?": "V kolik hodin událost končí?",
@@ -878,5 +877,7 @@
     "Suche deine Sprache...": "Hledat jazyk...",
     "Serie": "Série",
     "Dieser Termin gehört zu einer wiederkehrenden Serie.": "Tato událost je součástí opakující se série.",
-    "Serientermine bestimmst du beim Erstellen. Später geht das nicht mehr.": "Opakování nastavuješ při vytváření události, později už ne."
+    "Serientermine bestimmst du beim Erstellen. Später geht das nicht mehr.": "Opakování nastavuješ při vytváření události, později už ne.",
+    ":time Uhr": ":time",
+    ":from - :to Uhr": ":from - :to"
 }

--- a/lang/de.json
+++ b/lang/de.json
@@ -635,7 +635,6 @@
     "URL (Onion/Tor)": "",
     "URL (pkdns)": "",
     "URLs & Erreichbarkeit": "",
-    "Uhr": "",
     "Uhrzeit": "",
     "Um wie viel Uhr beginnt das Event?": "",
     "Um wie viel Uhr endet das Event?": "",
@@ -878,5 +877,7 @@
     "Suche deine Sprache...": "",
     "Serie": "",
     "Dieser Termin gehört zu einer wiederkehrenden Serie.": "",
-    "Serientermine bestimmst du beim Erstellen. Später geht das nicht mehr.": ""
+    "Serientermine bestimmst du beim Erstellen. Später geht das nicht mehr.": "",
+    ":time Uhr": "",
+    ":from - :to Uhr": ""
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -635,7 +635,6 @@
     "URL (Onion/Tor)": "URL (Onion/Tor)",
     "URL (pkdns)": "URL (pkdns)",
     "URLs & Erreichbarkeit": "URLs & Accessibility",
-    "Uhr": "o'clock",
     "Uhrzeit": "Time",
     "Um wie viel Uhr beginnt das Event?": "At what time does the event start?",
     "Um wie viel Uhr endet das Event?": "At what time does the event end?",
@@ -878,5 +877,7 @@
     "Suche deine Sprache...": "Search your language...",
     "Serie": "Series",
     "Dieser Termin gehört zu einer wiederkehrenden Serie.": "This event is part of a recurring series.",
-    "Serientermine bestimmst du beim Erstellen. Später geht das nicht mehr.": "You set recurring dates when you create the event, not afterwards."
+    "Serientermine bestimmst du beim Erstellen. Später geht das nicht mehr.": "You set recurring dates when you create the event, not afterwards.",
+    ":time Uhr": ":time",
+    ":from - :to Uhr": ":from - :to"
 }

--- a/lang/es.json
+++ b/lang/es.json
@@ -635,7 +635,6 @@
     "URL (Onion/Tor)": "URL (Onion/Tor)",
     "URL (pkdns)": "URL (pkdns)",
     "URLs & Erreichbarkeit": "URLs y accesibilidad",
-    "Uhr": "hora",
     "Uhrzeit": "Hora",
     "Um wie viel Uhr beginnt das Event?": "¿A qué hora comienza el evento?",
     "Um wie viel Uhr endet das Event?": "¿A qué hora termina el evento?",
@@ -878,5 +877,7 @@
     "Suche deine Sprache...": "Busca tu idioma...",
     "Serie": "Serie",
     "Dieser Termin gehört zu einer wiederkehrenden Serie.": "Este evento forma parte de una serie recurrente.",
-    "Serientermine bestimmst du beim Erstellen. Später geht das nicht mehr.": "Defines las fechas periódicas al crear el evento, no después."
+    "Serientermine bestimmst du beim Erstellen. Später geht das nicht mehr.": "Defines las fechas periódicas al crear el evento, no después.",
+    ":time Uhr": ":time h",
+    ":from - :to Uhr": ":from - :to h"
 }

--- a/lang/hu.json
+++ b/lang/hu.json
@@ -635,7 +635,6 @@
     "URL (Onion/Tor)": "URL (Onion/Tor)",
     "URL (pkdns)": "URL (pkdns)",
     "URLs & Erreichbarkeit": "URL-ek & Elérhetőség",
-    "Uhr": "óra",
     "Uhrzeit": "Időpont",
     "Um wie viel Uhr beginnt das Event?": "Hány órakor kezdődik az esemény?",
     "Um wie viel Uhr endet das Event?": "Hány órakor ér véget az esemény?",
@@ -878,5 +877,7 @@
     "Suche deine Sprache...": "Nyelv keresése...",
     "Serie": "Sorozat",
     "Dieser Termin gehört zu einer wiederkehrenden Serie.": "Ez az esemény egy ismétlődő sorozat része.",
-    "Serientermine bestimmst du beim Erstellen. Später geht das nicht mehr.": "Az ismétlődést a létrehozáskor állítod be, utólag már nem."
+    "Serientermine bestimmst du beim Erstellen. Später geht das nicht mehr.": "Az ismétlődést a létrehozáskor állítod be, utólag már nem.",
+    ":time Uhr": ":time",
+    ":from - :to Uhr": ":from - :to"
 }

--- a/lang/lv.json
+++ b/lang/lv.json
@@ -635,7 +635,6 @@
     "URL (Onion/Tor)": "URL (Onion/Tor)",
     "URL (pkdns)": "URL (pkdns)",
     "URLs & Erreichbarkeit": "URL un pieejamība",
-    "Uhr": "plkst.",
     "Uhrzeit": "Laiks",
     "Um wie viel Uhr beginnt das Event?": "Cikos pasākums sākas?",
     "Um wie viel Uhr endet das Event?": "Cikos pasākums beidzas?",
@@ -878,5 +877,7 @@
     "Suche deine Sprache...": "Meklēt valodu...",
     "Serie": "Sērija",
     "Dieser Termin gehört zu einer wiederkehrenden Serie.": "Šis pasākums ir daļa no atkārtojošās sērijas.",
-    "Serientermine bestimmst du beim Erstellen. Später geht das nicht mehr.": "Atkārtošanos iestati, veidojot pasākumu, vēlāk vairs ne."
+    "Serientermine bestimmst du beim Erstellen. Später geht das nicht mehr.": "Atkārtošanos iestati, veidojot pasākumu, vēlāk vairs ne.",
+    ":time Uhr": ":time",
+    ":from - :to Uhr": ":from - :to"
 }

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -635,7 +635,6 @@
     "URL (Onion/Tor)": "URL (Onion/Tor)",
     "URL (pkdns)": "URL (pkdns)",
     "URLs & Erreichbarkeit": "URL's & Bereikbaarheid",
-    "Uhr": "uur",
     "Uhrzeit": "Tijd",
     "Um wie viel Uhr beginnt das Event?": "Hoe laat begint het evenement?",
     "Um wie viel Uhr endet das Event?": "Hoe laat eindigt het evenement?",
@@ -878,5 +877,7 @@
     "Suche deine Sprache...": "Zoek je taal...",
     "Serie": "Reeks",
     "Dieser Termin gehört zu einer wiederkehrenden Serie.": "Dit evenement maakt deel uit van een terugkerende reeks.",
-    "Serientermine bestimmst du beim Erstellen. Später geht das nicht mehr.": "Je stelt de reeks in bij het aanmaken, later niet meer."
+    "Serientermine bestimmst du beim Erstellen. Später geht das nicht mehr.": "Je stelt de reeks in bij het aanmaken, later niet meer.",
+    ":time Uhr": ":time uur",
+    ":from - :to Uhr": ":from - :to uur"
 }

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -635,7 +635,6 @@
     "URL (Onion/Tor)": "URL (Onion/Tor)",
     "URL (pkdns)": "URL (pkdns)",
     "URLs & Erreichbarkeit": "URLe & Dostępność",
-    "Uhr": "godz.",
     "Uhrzeit": "Godzina",
     "Um wie viel Uhr beginnt das Event?": "O której godzinie rozpoczyna się wydarzenie?",
     "Um wie viel Uhr endet das Event?": "O której godzinie kończy się wydarzenie?",
@@ -878,5 +877,7 @@
     "Suche deine Sprache...": "Szukaj języka...",
     "Serie": "Seria",
     "Dieser Termin gehört zu einer wiederkehrenden Serie.": "To wydarzenie jest częścią serii cyklicznej.",
-    "Serientermine bestimmst du beim Erstellen. Später geht das nicht mehr.": "Cykliczność ustawiasz przy tworzeniu wydarzenia, później już nie."
+    "Serientermine bestimmst du beim Erstellen. Später geht das nicht mehr.": "Cykliczność ustawiasz przy tworzeniu wydarzenia, później już nie.",
+    ":time Uhr": ":time",
+    ":from - :to Uhr": ":from - :to"
 }

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -635,7 +635,6 @@
     "URL (Onion/Tor)": "URL (Onion/Tor)",
     "URL (pkdns)": "URL (pkdns)",
     "URLs & Erreichbarkeit": "URLs & Acessibilidade",
-    "Uhr": "horas",
     "Uhrzeit": "Hora",
     "Um wie viel Uhr beginnt das Event?": "A que hora começa o evento?",
     "Um wie viel Uhr endet das Event?": "A que hora termina o evento?",
@@ -878,5 +877,7 @@
     "Suche deine Sprache...": "Procurar idioma...",
     "Serie": "Série",
     "Dieser Termin gehört zu einer wiederkehrenden Serie.": "Este evento faz parte de uma série recorrente.",
-    "Serientermine bestimmst du beim Erstellen. Später geht das nicht mehr.": "Defines a recorrência ao criar o evento, não depois."
+    "Serientermine bestimmst du beim Erstellen. Später geht das nicht mehr.": "Defines a recorrência ao criar o evento, não depois.",
+    ":time Uhr": ":time",
+    ":from - :to Uhr": ":from - :to"
 }

--- a/resources/views/components/meetup-popup.blade.php
+++ b/resources/views/components/meetup-popup.blade.php
@@ -35,7 +35,7 @@
 
             <flux:text class="text-sm flex items-center gap-2">
                 <flux:icon.clock class="w-4 h-4"/>
-                {{ $meetup->nextEvent['start']->asTime() }} Uhr
+                {{ __(':time Uhr', ['time' => $meetup->nextEvent['start']->asTime()]) }}
             </flux:text>
 
             {{-- x-osm-place erwartet ein Objekt; nextEvent ist ein Array — der Cast

--- a/resources/views/livewire/courses/landingpage.blade.php
+++ b/resources/views/livewire/courses/landingpage.blade.php
@@ -146,7 +146,7 @@ class extends Component {
 
                         <flux:text class="mt-2 text-sm text-zinc-600 dark:text-zinc-300">
                             <flux:icon.clock class="inline w-4 h-4"/>
-                            {{ $event->from->format('H:i') }} - {{ $event->to->format('H:i') }} Uhr
+                            {{ __(':from - :to Uhr', ['from' => $event->from->format('H:i'), 'to' => $event->to->format('H:i')]) }}
                         </flux:text>
 
                         {{-- Die Whitelist fuer osm_type, das 24px-Ziel und der Pfeil stehen

--- a/resources/views/livewire/meetups/create-edit-events.blade.php
+++ b/resources/views/livewire/meetups/create-edit-events.blade.php
@@ -724,7 +724,7 @@ class extends Component
                                 </div>
                                 <div class="flex-1 min-w-0">
                                     <flux:text class="font-semibold text-sm truncate">{{ $dateInfo['formatted'] }}</flux:text>
-                                    <flux:text class="text-xs text-zinc-500 dark:text-zinc-400">{{ $dateInfo['time'] }} {{ __('Uhr') }}</flux:text>
+                                    <flux:text class="text-xs text-zinc-500 dark:text-zinc-400">{{ __(':time Uhr', ['time' => $dateInfo['time']]) }}</flux:text>
                                 </div>
                             </div>
                         </flux:card>

--- a/resources/views/livewire/meetups/landingpage-event.blade.php
+++ b/resources/views/livewire/meetups/landingpage-event.blade.php
@@ -220,7 +220,7 @@ class extends Component {
                     <div class="flex items-center text-zinc-700 dark:text-zinc-300">
                         <flux:icon.clock class="w-5 h-5 mr-3"/>
                         <div>
-                            <div class="font-semibold">{{ $event->start->asTime() }} Uhr</div>
+                            <div class="font-semibold">{{ __(':time Uhr', ['time' => $event->start->asTime()]) }}</div>
                             <div
                                 class="text-sm text-zinc-600 dark:text-zinc-400">{{ $event->start->asDate() }}</div>
                         </div>

--- a/resources/views/livewire/meetups/landingpage.blade.php
+++ b/resources/views/livewire/meetups/landingpage.blade.php
@@ -102,7 +102,7 @@ class extends Component
                         <flux:button href="{{ $meetup->webpage }}" target="_blank" rel="noopener noreferrer" variant="ghost"
                                      class="justify-start">
                             <flux:icon.globe-alt class="w-5 h-5 mr-2"/>
-                            Webseite
+                            {{ __('Webseite') }}
                         </flux:button>
                     @endif
 
@@ -292,7 +292,7 @@ class extends Component
 
                         <flux:text class="mt-2 text-sm text-zinc-600 dark:text-zinc-400">
                             <flux:icon.clock class="inline w-4 h-4"/>
-                            {{ $event->start->asTime() }} Uhr
+                            {{ __(':time Uhr', ['time' => $event->start->asTime()]) }}
                         </flux:text>
 
                         {{-- Einzeilig: die Kachel beantwortet "welcher Termin", der Ortsname

--- a/tests/Feature/Lang/RenderedLocaleTest.php
+++ b/tests/Feature/Lang/RenderedLocaleTest.php
@@ -1,0 +1,235 @@
+<?php
+
+use App\Models\City;
+use App\Models\Country;
+use App\Models\Course;
+use App\Models\CourseEvent;
+use App\Models\Lecturer;
+use App\Models\Meetup;
+use App\Models\MeetupEvent;
+use Illuminate\Support\Facades\Blade;
+
+/*
+|--------------------------------------------------------------------------
+| German text must not reach an English visitor — asserted on RENDERED HTML
+|--------------------------------------------------------------------------
+|
+| LangKeyParityTest and LangCodeCoverageTest look at lang/*.json only. They
+| stay green while the interface is German, in two ways neither of them can
+| see:
+|
+|   1. German text hardcoded in a Blade file, outside __() — no key exists,
+|      so there is nothing for a key test to miss. That is how "Webseite"
+|      and "… Uhr" reached the English screenshots of 2026-09-03.
+|   2. A __() key that is missing from EVERY lang/*.json. The key sets stay
+|      identical (parity green) and Laravel echoes the key itself, which is
+|      German: __(':time Uhr') renders "21:30 Uhr" for an English visitor.
+|      Note that an EMPTY value has the same effect — Translator::get()
+|      returns `$line ?: $key`, so "":time Uhr": """ falls back to the German
+|      key too. That is exactly how lang/de.json is written here.
+|
+| So the assertion has to happen on what the page actually sends. Every test
+| below performs a real HTTP request and searches the response body. A test
+| in this file that can pass without a page having been rendered is the wrong
+| test.
+|
+| Known and deliberately NOT asserted: App\Support\Carbon::asDate() and its
+| siblings hardcode ->locale('de'), so month and weekday names render in
+| German for every visitor ("05. Januar 2027"). Separate defect, separate
+| owner; putting it in the list below would leave this guard permanently red,
+| and a permanently red guard gets switched off.
+*/
+
+/**
+ * The German literals that were found in English screenshots on 2026-09-03.
+ *
+ * @var list<string>
+ */
+const RENDERED_GERMAN_LITERALS = ['Uhr', 'Webseite'];
+
+/**
+ * Returns those of $words that occur in $html as WHOLE words.
+ *
+ * Whole-word matching is the point, not an optimisation. A plain
+ * str_contains($html, 'Uhr') reports a hit on the perfectly correct German-only
+ * "Uhrzeit" and on any class or attribute that happens to embed the three
+ * letters; the mirror-image mistake is a word such as 'Serie', whose substring
+ * check fires on the correct English "Series" — a word this very release
+ * added. Both directions produce a guard nobody trusts, and an untrusted guard
+ * gets deleted rather than fixed.
+ *
+ * \b is not used: without /u it is ASCII-only, and even with /u PCRE keeps \w
+ * ASCII unless UCP is on, so \bÖffnungszeit\b matches mid-word. The explicit
+ * \p{L}\p{N} lookarounds hold for the accented words this list will grow.
+ *
+ * @param  list<string>  $words
+ * @return list<string>
+ */
+function renderedGermanWords(string $html, array $words): array
+{
+    return array_values(array_filter(
+        $words,
+        fn (string $word): bool => preg_match(
+            '/(?<![\p{L}\p{N}])'.preg_quote($word, '/').'(?![\p{L}\p{N}])/u',
+            $html
+        ) === 1
+    ));
+}
+
+/**
+ * Requests $url the way a browser of $locale does, and returns the body.
+ *
+ * The locale comes from the Accept-Language header on purpose: that is the
+ * path DomainMiddleware actually takes for a first-time visitor, and it is
+ * where the English screenshots came from. Tests\TestCase blanks the synthetic
+ * Accept-Language default Symfony injects, so this header is the only thing
+ * speaking here.
+ *
+ * The getLocale() check is a positive control. Without it, a request that
+ * silently stayed on the German domain default would still satisfy "no German
+ * words" for the wrong reason — the words would simply be somewhere else.
+ */
+function renderAsVisitor(object $case, string $url, string $locale): string
+{
+    $header = match ($locale) {
+        'en' => 'en-US,en;q=0.9',
+        'de' => 'de-DE,de;q=0.9',
+    };
+
+    $response = $case->withHeaders(['Accept-Language' => $header])->get($url);
+
+    $response->assertSuccessful();
+
+    expect(app()->getLocale())->toBe($locale, "Request to {$url} did not run under the '{$locale}' locale.");
+
+    return (string) $response->getContent();
+}
+
+beforeEach(function () {
+    $this->country = Country::factory()->create(['code' => 'de']);
+    $this->city = City::factory()->create(['country_id' => $this->country->id]);
+
+    // Every free-text field these pages echo is set explicitly. The factories
+    // fill them from fake(), and a random German paragraph is exactly the kind
+    // of input that makes a text-matching guard flap.
+    $this->meetup = Meetup::factory()->create([
+        'city_id' => $this->city->id,
+        'name' => 'Bitcoin Meetup Testhausen',
+        'slug' => 'bitcoin-meetup-testhausen',
+        'intro' => 'A regular gathering for bitcoiners.',
+        'webpage' => 'https://example.com/meetup',
+        'visible_on_map' => true,
+    ]);
+
+    $this->event = MeetupEvent::factory()->create([
+        'meetup_id' => $this->meetup->id,
+        'start' => now()->addDays(7)->setTime(19, 30),
+        'location' => 'Main Street 1',
+        'description' => 'An evening about bitcoin.',
+        'link' => 'https://example.com/event',
+        'recurrence_type' => null,
+    ]);
+
+    $this->course = Course::factory()->create([
+        'lecturer_id' => Lecturer::factory()->create(['name' => 'Jane Doe'])->id,
+        'name' => 'Bitcoin Basics',
+        'description' => 'An introduction to bitcoin.',
+    ]);
+
+    CourseEvent::factory()->create([
+        'course_id' => $this->course->id,
+        'city_id' => $this->city->id,
+        'from' => now()->addDays(7)->setTime(18, 0),
+        'to' => now()->addDays(7)->setTime(20, 0),
+        'location' => 'Main Street 1',
+        'link' => 'https://example.com/course-event',
+    ]);
+
+    $this->meetupUrl = route('meetups.landingpage', ['country' => 'de', 'meetup' => $this->meetup->slug]);
+    $this->eventUrl = route('meetups.landingpage-event', [
+        'country' => 'de',
+        'meetup' => $this->meetup->slug,
+        'event' => $this->event->id,
+    ]);
+    $this->courseUrl = route('courses.landingpage', ['country' => 'de', 'course' => $this->course->id]);
+    // The map popup (components/meetup-popup.blade.php) has no route of its own.
+    // meetups.map renders it server-side and hands the finished markup to Leaflet
+    // as `popupHtml` inside @js($meetups), so the map page IS the renderable
+    // surface for that component — no browser needed.
+    $this->mapUrl = route('meetups.map', ['country' => 'de']);
+});
+
+it('renders the meetup landing page without German literals for an English visitor', function () {
+    $html = renderAsVisitor($this, $this->meetupUrl, 'en');
+
+    expect(renderedGermanWords($html, RENDERED_GERMAN_LITERALS))
+        ->toBe([], 'German words rendered at an English visitor on '.$this->meetupUrl);
+});
+
+it('renders the meetup event page without German literals for an English visitor', function () {
+    $html = renderAsVisitor($this, $this->eventUrl, 'en');
+
+    expect(renderedGermanWords($html, RENDERED_GERMAN_LITERALS))
+        ->toBe([], 'German words rendered at an English visitor on '.$this->eventUrl);
+});
+
+it('renders the course landing page without German literals for an English visitor', function () {
+    $html = renderAsVisitor($this, $this->courseUrl, 'en');
+
+    expect(renderedGermanWords($html, RENDERED_GERMAN_LITERALS))
+        ->toBe([], 'German words rendered at an English visitor on '.$this->courseUrl);
+});
+
+it('renders the map popup markup without German literals for an English visitor', function () {
+    $html = renderAsVisitor($this, $this->mapUrl, 'en');
+
+    // Without the popup in the body the assertion below would be green for the
+    // wrong reason, and the map page would still return 200.
+    expect($html)->toContain($this->meetup->name);
+
+    expect(renderedGermanWords($html, RENDERED_GERMAN_LITERALS))
+        ->toBe([], 'German words rendered at an English visitor on '.$this->mapUrl);
+});
+
+/*
+|--------------------------------------------------------------------------
+| Negative control — the four assertions above must be able to fail
+|--------------------------------------------------------------------------
+|
+| Each surface is rendered a second time, changing nothing but the visitor's
+| Accept-Language, and the very same matcher must now FIND the literals. This
+| is what separates "the English page is translated" from "the page never
+| rendered that region at all" — the second would make the tests above green
+| for free, and no assertion on the English render can tell the two apart.
+|
+| It holds as long as German stays German: lang/de.json carries "" for these
+| keys, which Laravel resolves back to the German key.
+*/
+it('finds the same German literals on the same pages for a German visitor', function () {
+    $expected = [
+        $this->meetupUrl => ['Uhr', 'Webseite'],
+        $this->eventUrl => ['Uhr'],
+        $this->courseUrl => ['Uhr'],
+        $this->mapUrl => ['Uhr'],
+    ];
+
+    foreach ($expected as $url => $literals) {
+        $html = renderAsVisitor($this, $url, 'de');
+
+        expect(renderedGermanWords($html, RENDERED_GERMAN_LITERALS))
+            ->toBe($literals, 'German render of '.$url.' no longer carries the words the English guard watches for — the guard above is now vacuous.');
+    }
+});
+
+/*
+ * Calibration of the matcher itself, on a fixture rather than on a page, so
+ * the word-boundary rule keeps being exercised no matter what the pages do.
+ */
+it('flags a whole German word in rendered output and spares English words that contain one', function () {
+    $html = Blade::render(
+        '<p>{{ $time }} Uhr</p><p>Uhrzeit</p><p>Series</p><p>Website</p><div class="webseiten-link">x</div>',
+        ['time' => '19:30']
+    );
+
+    expect(renderedGermanWords($html, ['Uhr', 'Webseite', 'Serie']))->toBe(['Uhr']);
+});


### PR DESCRIPTION
Found while taking English screenshots for the #43 reply: the portal renders German words in an otherwise English interface. `lang/en.json` was complete and both translation guards were green — they compare key **sets** and never look at what a page actually renders.

Five sites. Four were plain text outside `__()` (`Uhr` three times, `Webseite` once). The fifth was already wrapped but at the wrong granularity and shipping today: the series preview of the create-event form rendered `__('Uhr')`, which is "o'clock" in English, "hora" in Spanish and "plkst." in Latvian.

**The translatable unit is the phrase, not the word.** Nine languages disagree on what follows a clock time: de `Uhr`, nl `uur`, es `h`, and cs/en/hu/lv/pl/pt append nothing. A word-level key forces every locale to append *something*. Latvian settles it from the other side — `plkst.` precedes the time, so a suffix slot could never render it correctly.

`tests/Feature/Lang/RenderedLocaleTest.php` guards what the key tests cannot: assertions on a real response body under `Accept-Language: en`, a positive control on the resolved locale, and a German-visitor counterpart so the English guards cannot pass by rendering nothing.

Not covered on purpose: `App\Support\Carbon` pins `->locale('de')` in all four formatters, so month names stay German for everyone. That needs its own change — adding it here would leave the guard permanently red.

Full non-Browser suite: 1780 passed, 6492 assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A4BKf2zxFNSRKBoMUB8EUW