### PR TITLE
Put the event list and Create event above the fold

### DIFF
--- a/lang/cs.json
+++ b/lang/cs.json
@@ -879,5 +879,6 @@
     "Dieser Termin gehört zu einer wiederkehrenden Serie.": "Tato událost je součástí opakující se série.",
     "Serientermine bestimmst du beim Erstellen. Später geht das nicht mehr.": "Opakování nastavuješ při vytváření události, později už ne.",
     ":time Uhr": ":time",
-    ":from - :to Uhr": ":from - :to"
+    ":from - :to Uhr": ":from - :to",
+    "Besucher sehen an dieser Stelle dasselbe.": "Návštěvníci zde vidí totéž."
 }

--- a/lang/de.json
+++ b/lang/de.json
@@ -879,5 +879,6 @@
     "Dieser Termin gehört zu einer wiederkehrenden Serie.": "",
     "Serientermine bestimmst du beim Erstellen. Später geht das nicht mehr.": "",
     ":time Uhr": "",
-    ":from - :to Uhr": ""
+    ":from - :to Uhr": "",
+    "Besucher sehen an dieser Stelle dasselbe.": ""
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -879,5 +879,6 @@
     "Dieser Termin gehört zu einer wiederkehrenden Serie.": "This event is part of a recurring series.",
     "Serientermine bestimmst du beim Erstellen. Später geht das nicht mehr.": "You set recurring dates when you create the event, not afterwards.",
     ":time Uhr": ":time",
-    ":from - :to Uhr": ":from - :to"
+    ":from - :to Uhr": ":from - :to",
+    "Besucher sehen an dieser Stelle dasselbe.": "Visitors see the same thing here."
 }

--- a/lang/es.json
+++ b/lang/es.json
@@ -879,5 +879,6 @@
     "Dieser Termin gehört zu einer wiederkehrenden Serie.": "Este evento forma parte de una serie recurrente.",
     "Serientermine bestimmst du beim Erstellen. Später geht das nicht mehr.": "Defines las fechas periódicas al crear el evento, no después.",
     ":time Uhr": ":time h",
-    ":from - :to Uhr": ":from - :to h"
+    ":from - :to Uhr": ":from - :to h",
+    "Besucher sehen an dieser Stelle dasselbe.": "Los visitantes ven aquí lo mismo."
 }

--- a/lang/hu.json
+++ b/lang/hu.json
@@ -879,5 +879,6 @@
     "Dieser Termin gehört zu einer wiederkehrenden Serie.": "Ez az esemény egy ismétlődő sorozat része.",
     "Serientermine bestimmst du beim Erstellen. Später geht das nicht mehr.": "Az ismétlődést a létrehozáskor állítod be, utólag már nem.",
     ":time Uhr": ":time",
-    ":from - :to Uhr": ":from - :to"
+    ":from - :to Uhr": ":from - :to",
+    "Besucher sehen an dieser Stelle dasselbe.": "A látogatók ugyanezt látják itt."
 }

--- a/lang/lv.json
+++ b/lang/lv.json
@@ -879,5 +879,6 @@
     "Dieser Termin gehört zu einer wiederkehrenden Serie.": "Šis pasākums ir daļa no atkārtojošās sērijas.",
     "Serientermine bestimmst du beim Erstellen. Später geht das nicht mehr.": "Atkārtošanos iestati, veidojot pasākumu, vēlāk vairs ne.",
     ":time Uhr": ":time",
-    ":from - :to Uhr": ":from - :to"
+    ":from - :to Uhr": ":from - :to",
+    "Besucher sehen an dieser Stelle dasselbe.": "Apmeklētāji šeit redz to pašu."
 }

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -879,5 +879,6 @@
     "Dieser Termin gehört zu einer wiederkehrenden Serie.": "Dit evenement maakt deel uit van een terugkerende reeks.",
     "Serientermine bestimmst du beim Erstellen. Später geht das nicht mehr.": "Je stelt de reeks in bij het aanmaken, later niet meer.",
     ":time Uhr": ":time uur",
-    ":from - :to Uhr": ":from - :to uur"
+    ":from - :to Uhr": ":from - :to uur",
+    "Besucher sehen an dieser Stelle dasselbe.": "Bezoekers zien hier hetzelfde."
 }

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -879,5 +879,6 @@
     "Dieser Termin gehört zu einer wiederkehrenden Serie.": "To wydarzenie jest częścią serii cyklicznej.",
     "Serientermine bestimmst du beim Erstellen. Später geht das nicht mehr.": "Cykliczność ustawiasz przy tworzeniu wydarzenia, później już nie.",
     ":time Uhr": ":time",
-    ":from - :to Uhr": ":from - :to"
+    ":from - :to Uhr": ":from - :to",
+    "Besucher sehen an dieser Stelle dasselbe.": "Odwiedzający widzą tutaj to samo."
 }

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -879,5 +879,6 @@
     "Dieser Termin gehört zu einer wiederkehrenden Serie.": "Este evento faz parte de uma série recorrente.",
     "Serientermine bestimmst du beim Erstellen. Später geht das nicht mehr.": "Defines a recorrência ao criar o evento, não depois.",
     ":time Uhr": ":time",
-    ":from - :to Uhr": ":from - :to"
+    ":from - :to Uhr": ":from - :to",
+    "Besucher sehen an dieser Stelle dasselbe.": "Os visitantes veem aqui o mesmo."
 }

--- a/resources/views/livewire/meetups/landingpage.blade.php
+++ b/resources/views/livewire/meetups/landingpage.blade.php
@@ -56,37 +56,247 @@ class extends Component
 @endsection
 
 <div class="container mx-auto px-4 py-8">
-    <div class="grid grid-cols-1 lg:grid-cols-2 gap-8">
-        <!-- Left Column: Meetup Details -->
-        <div class="space-y-6">
-            <div class="flex flex-col sm:flex-row items-center space-x-0 sm:space-x-4 space-y-4 sm:space-y-0">
-                <flux:avatar class="[:where(&)]:size-32 [:where(&)]:text-base" size="xl"
-                             src="{{ $meetup->getFirstMediaUrl('logo') }}"/>
-                <div class="space-y-2">
-                    <flux:heading size="xl" class="mb-4">{{ $meetup->name }}</flux:heading>
-                    <flux:subheading class="text-gray-600 dark:text-gray-400">
-                        {{ $meetup->city->name }}, {{ $meetup->city->country->name }}
-                    </flux:subheading>
-                    <x-calendar-stream-picker :meetup-id="$meetup->id"/>
-                    @if(auth()->check())
-                        {{-- Identical condition to the list view's edit action
-                             (index.blade.php, "Bearbeiten"): the update ability —
-                             leader, creator, super-admin, meetup steward. Without
-                             this, editing a meetup was reachable only by going back
-                             to the list view. --}}
-                        @if($meetup->leadByMe || auth()->user()->can('update', $meetup))
-                            <div>
-                                <flux:button
-                                    :href="route_with_country('meetups.edit', ['meetup' => $meetup])"
-                                    size="sm" variant="filled" icon="pencil">
-                                    {{ __('Meetup bearbeiten') }}
-                                </flux:button>
+    {{-- Identity row: who and where, in one band. Everything a visitor needs to
+         confirm they are on the right page, and nothing that delays the list. --}}
+    <div class="flex flex-col sm:flex-row items-center space-x-0 sm:space-x-4 space-y-4 sm:space-y-0">
+        <flux:avatar class="[:where(&)]:size-32 [:where(&)]:text-base" size="xl"
+                     src="{{ $meetup->getFirstMediaUrl('logo') }}"/>
+        <div class="space-y-2">
+            <flux:heading size="xl" class="mb-4">{{ $meetup->name }}</flux:heading>
+            <flux:subheading class="text-gray-600 dark:text-gray-400">
+                {{ $meetup->city->name }}, {{ $meetup->city->country->name }}
+            </flux:subheading>
+            <x-calendar-stream-picker :meetup-id="$meetup->id"/>
+            @if(auth()->check())
+                {{-- Identical condition to the list view's edit action
+                     (index.blade.php, "Bearbeiten"): the update ability —
+                     leader, creator, super-admin, meetup steward. Without
+                     this, editing a meetup was reachable only by going back
+                     to the list view. --}}
+                @if($meetup->leadByMe || auth()->user()->can('update', $meetup))
+                    <div>
+                        <flux:button
+                            :href="route_with_country('meetups.edit', ['meetup' => $meetup])"
+                            size="sm" variant="filled" icon="pencil">
+                            {{ __('Meetup bearbeiten') }}
+                        </flux:button>
+                    </div>
+                @endif
+            @endif
+        </div>
+    </div>
+
+    {{-- Upcoming events, full width and directly under the identity row (issue #45).
+
+         Measured on a FULL meetup — long intro, all six contact links, nostr and
+         community — with this section still sitting below both grid columns:
+
+             viewport     details col   map col   events heading   first card
+             1920x1080      892px        435px       y=1026          y=1088
+             1440x900       964px        374px       y=1098          y=1160
+
+         The map was never the binding constraint. A grid takes the height of its
+         TALLER column, and that is the details column by 457px at 1920 and 590px at
+         1440 — so shrinking or even deleting the map could not have moved the list up
+         by a single pixel. Only lifting the list out from behind both columns does,
+         which is the "reposition" the issue asks for. The map stays at full size
+         rather than collapsing: a collapsed map costs every visitor a click in order
+         to save scrolling for some.
+
+         This also fixes the mobile order for free. At grid-cols-1 the DOM order is the
+         visual order, so phone users previously scrolled the intro, six contact
+         buttons and the entire map before reaching the first date.
+
+         The heading row is shared by both branches on purpose: before, the empty case
+         rendered neither heading nor calendar action, which is half of why an empty
+         meetup looked broken. --}}
+    <div class="mt-8" data-testid="upcoming-events">
+        <div class="flex flex-col sm:flex-row items-center sm:space-x-4 space-y-4 sm:space-y-0 mb-6">
+            <flux:heading size="xl">{{ __('Kommende Veranstaltungen') }}</flux:heading>
+            @if($meetup->leadByMe)
+                <flux:button :href="route_with_country('meetups.events.create', ['meetup' => $meetup])"
+                             variant="primary" icon="calendar">
+                    {{ __('Neues Event erstellen') }}
+                </flux:button>
+            @endif
+            <x-calendar-stream-picker :meetup-id="$meetup->id"/>
+        </div>
+
+        @if($events->isNotEmpty())
+
+            {{-- Einmalig statt pro Karte: attendeesVisibleTo() löst sonst je Event
+                 den update-Policy-Check (is_leader-Pivot-Query) neu aus.
+
+                 Deliberately the block form, and this is load-bearing.
+
+                 Blade collects raw PHP blocks before anything else, with
+                 /(?<!@)@php(.*?)@endphp/s. The single-line parenthesised form still
+                 matches the opening @php of that pattern, so it pairs with the NEXT
+                 real @endphp further down the file and swallows everything in between.
+                 Once this section moved above the details grid, that next @endphp
+                 became the map column's $attribution block near the end of the file —
+                 so the whole card grid vanished from the compiled template: output fell
+                 from 100KB to 35KB and left a conditional unclosed, and the page died
+                 with "unexpected end of file, expecting endif".
+
+                 Verified rather than assumed: with the single-line form restored and
+                 only that later @php ... @endphp block deleted, the file compiles again
+                 at 100KB. It compiled before this change only because the single-line
+                 form then sat AFTER the map block, with no later @endphp left to pair
+                 with. Paired block form has no opening token to steal and is safe in
+                 either position. --}}
+            @php
+                $canSeeAttendees = $meetup->attendeesVisibleTo(auth()->user());
+            @endphp
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                @foreach($events as $event)
+                    <flux:card size="sm" class="h-full flex flex-col">
+                        <flux:heading class="flex items-center gap-2">
+                            {{ $event->start->asDate() }}
+                            {{-- Series marker (issue #43). `recurrence_group` is the only
+                                 reliable series identity: the 2026_08_25_194948 migration
+                                 backfilled that column alone, so events of pre-P5 series
+                                 carry `recurrence_type = null` and would be missed by it.
+
+                                 `inset="top bottom"` is Flux's own mechanism for an inline
+                                 badge: it cancels the badge's py-1 out of the layout box, so
+                                 a series card's heading stays exactly as tall as a
+                                 badge-free neighbour's and the grid row does not grow.
+                                 `shrink-0` keeps the badge from being squeezed by the date
+                                 beside it, since flux:badge is whitespace-nowrap. --}}
+                            @if($event->recurrence_group !== null)
+                                <flux:badge size="sm" color="zinc" icon="arrow-path"
+                                            inset="top bottom" class="shrink-0"
+                                            data-testid="series-badge">{{ __('Serie') }}</flux:badge>
+                            @endif
+                        </flux:heading>
+
+                        <flux:text class="mt-2 text-sm text-zinc-600 dark:text-zinc-400">
+                            <flux:icon.clock class="inline w-4 h-4"/>
+                            {{ __(':time Uhr', ['time' => $event->start->asTime()]) }}
+                        </flux:text>
+
+                        {{-- Einzeilig: die Kachel beantwortet "welcher Termin", der Ortsname
+                             schaerft das. Die Adresse gehoert auf die Detailseite, nicht in
+                             fuenf Kacheln nebeneinander. --}}
+                        @if($event->osm_name || $event->location)
+                            <div class="mt-1 flex items-start gap-1.5">
+                                <flux:icon.map-pin class="mt-0.5 size-4 shrink-0 text-zinc-600 dark:text-zinc-300"
+                                                   aria-hidden="true"/>
+                                <x-osm-place :place="$event"/>
                             </div>
                         @endif
+
+                        @if($event->description)
+                            <flux:text class="mt-2">{{ Str::limit($event->description, 100) }}</flux:text>
+                        @endif
+
+                        @if($canSeeAttendees)
+                            <flux:text class="mt-2 text-sm text-zinc-600 dark:text-zinc-400">
+                                <div class="text-xs text-zinc-500 flex items-center gap-2">
+                                    <span>{{ trans_choice(':count Zusage|:count Zusagen', count($event->attendees ?? [])) }}</span>
+                                    <flux:separator vertical/>
+                                    <span>{{ trans_choice(':count Vielleicht|:count Vielleicht', count($event->might_attendees ?? [])) }}</span>
+                                </div>
+                            </flux:text>
+                        @endif
+
+                        {{-- `flex-wrap` alone would not have fixed the leader row: with
+                             `flex-1` the primary button has flex-basis 0, so it counts as
+                             zero when the browser decides where to break the line, all
+                             three buttons stay on one line, and `min-width: auto` then
+                             floors them back to 312px of content in a 254px box —
+                             "Entfernen" spilling into the neighbouring card. `basis-full`
+                             gives the primary a real basis so it claims the first line and
+                             the two leader actions wrap below it. The visitor view is
+                             unchanged: with a single child, basis-full renders exactly as
+                             flex-1 did. `gap-2` already supplies the 8px row gap. --}}
+                        <div class="mt-auto pt-4 flex flex-wrap gap-2">
+                            <flux:button
+                                :href="route('meetups.landingpage-event', ['meetup' => $meetup->slug, 'event' => $event->id, 'country' => $country])"
+                                size="xs"
+                                variant="primary"
+                                class="basis-full"
+                            >
+                                {{ __('Öffnen/RSVP') }}
+                            </flux:button>
+                            @if($meetup->leadByMe)
+                                <flux:button
+                                    :href="route_with_country('meetups.events.edit', ['meetup' => $meetup, 'event' => $event])"
+                                    size="xs"
+                                    variant="ghost"
+                                    icon="pencil"
+                                >
+                                    {{ __('Bearbeiten') }}
+                                </flux:button>
+                                <flux:modal.trigger name="delete-event-{{ $event->id }}">
+                                    <flux:button
+                                        class="cursor-pointer"
+                                        size="xs"
+                                        variant="danger"
+                                        icon="trash"
+                                    >
+                                        {{ __('Entfernen') }}
+                                    </flux:button>
+                                </flux:modal.trigger>
+
+                                <flux:modal name="delete-event-{{ $event->id }}" variant="flyout">
+                                    <form wire:submit="deleteEvent({{ $event->id }})" class="space-y-6">
+                                        <div>
+                                            <flux:heading size="lg">{{ __('Event löschen?') }}</flux:heading>
+                                            <flux:subheading>
+                                                {{ __('Möchtest du das Event vom') }} {{ $event->start->asDate() }} {{ __('wirklich löschen?') }}
+                                            </flux:subheading>
+                                            <flux:subheading class="mt-2">
+                                                {{ __('Diese Aktion kann nicht rückgängig gemacht werden.') }}
+                                            </flux:subheading>
+                                        </div>
+                                        <div class="flex gap-2">
+                                            <flux:spacer/>
+                                            <flux:modal.close>
+                                                <flux:button class="cursor-pointer"
+                                                             variant="ghost">{{ __('Abbrechen') }}</flux:button>
+                                            </flux:modal.close>
+                                            <flux:button type="submit" class="cursor-pointer"
+                                                         variant="danger">{{ __('Entfernen') }}</flux:button>
+                                        </div>
+                                    </form>
+                                </flux:modal>
+                            @endif
+                        </div>
+                    </flux:card>
+                @endforeach
+            </div>
+        @else
+            {{-- Before this, the empty case rendered a bare box: no heading, no text,
+                 nothing — so a visitor could not tell "nothing is scheduled" from
+                 "this page is broken". A measured finding from the #45 audit.
+
+                 The wording is the dashboard's existing key rather than a new one: the
+                 same fact should read the same everywhere in the product, and that key
+                 is already translated into all nine languages with each one's own noun
+                 for an occurrence (cs "termíny", nl "afspraken", lv "pasākumu", hu
+                 "időpontok"). The leader gets one extra line, and it deliberately does
+                 not repeat the button next to it — it says the thing the button cannot:
+                 that this is exactly what visitors are seeing. --}}
+            <div class="flex items-start gap-2 text-sm text-zinc-600 dark:text-zinc-400"
+                 data-testid="no-upcoming-events">
+                <flux:icon.calendar class="mt-0.5 size-4 shrink-0" aria-hidden="true"/>
+                <div>
+                    <p>{{ __('Keine bevorstehenden Termine') }}</p>
+                    @if($meetup->leadByMe)
+                        <p class="mt-1">{{ __('Besucher sehen an dieser Stelle dasselbe.') }}</p>
                     @endif
                 </div>
             </div>
+        @endif
+    </div>
 
+    {{-- Everything below the list is reference material: read once, then not again.
+         It keeps the two-column shape it always had, one rank down. --}}
+    <div class="mt-16 grid grid-cols-1 lg:grid-cols-2 gap-8">
+        <!-- Left Column: Meetup Details -->
+        <div class="space-y-6">
             @if($meetup->intro)
                 <div>
                     <flux:heading size="lg" class="mb-2">{{ __('Über uns') }}</flux:heading>
@@ -250,153 +460,4 @@ class extends Component
         </div>
     </div>
 
-    {{-- Events Section --}}
-    @if($events->isNotEmpty())
-        <div class="mt-16">
-            <div class="flex flex-col sm:flex-row items-center sm:space-x-4 space-y-4 sm:space-y-0 mb-6">
-                <flux:heading size="xl">{{ __('Kommende Veranstaltungen') }}</flux:heading>
-                @if($meetup->leadByMe)
-                    <flux:button :href="route_with_country('meetups.events.create', ['meetup' => $meetup])"
-                                 variant="primary" icon="calendar">
-                        {{ __('Neues Event erstellen') }}
-                    </flux:button>
-                @endif
-                <x-calendar-stream-picker :meetup-id="$meetup->id"/>
-            </div>
-
-            {{-- Einmalig statt pro Karte: attendeesVisibleTo() löst sonst je Event
-                 den update-Policy-Check (is_leader-Pivot-Query) neu aus. --}}
-            @php($canSeeAttendees = $meetup->attendeesVisibleTo(auth()->user()))
-            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-                @foreach($events as $event)
-                    <flux:card size="sm" class="h-full flex flex-col">
-                        <flux:heading class="flex items-center gap-2">
-                            {{ $event->start->asDate() }}
-                            {{-- Series marker (issue #43). `recurrence_group` is the only
-                                 reliable series identity: the 2026_08_25_194948 migration
-                                 backfilled that column alone, so events of pre-P5 series
-                                 carry `recurrence_type = null` and would be missed by it.
-
-                                 `inset="top bottom"` is Flux's own mechanism for an inline
-                                 badge: it cancels the badge's py-1 out of the layout box, so
-                                 a series card's heading stays exactly as tall as a
-                                 badge-free neighbour's and the grid row does not grow.
-                                 `shrink-0` keeps the badge from being squeezed by the date
-                                 beside it, since flux:badge is whitespace-nowrap. --}}
-                            @if($event->recurrence_group !== null)
-                                <flux:badge size="sm" color="zinc" icon="arrow-path"
-                                            inset="top bottom" class="shrink-0"
-                                            data-testid="series-badge">{{ __('Serie') }}</flux:badge>
-                            @endif
-                        </flux:heading>
-
-                        <flux:text class="mt-2 text-sm text-zinc-600 dark:text-zinc-400">
-                            <flux:icon.clock class="inline w-4 h-4"/>
-                            {{ __(':time Uhr', ['time' => $event->start->asTime()]) }}
-                        </flux:text>
-
-                        {{-- Einzeilig: die Kachel beantwortet "welcher Termin", der Ortsname
-                             schaerft das. Die Adresse gehoert auf die Detailseite, nicht in
-                             fuenf Kacheln nebeneinander. --}}
-                        @if($event->osm_name || $event->location)
-                            <div class="mt-1 flex items-start gap-1.5">
-                                <flux:icon.map-pin class="mt-0.5 size-4 shrink-0 text-zinc-600 dark:text-zinc-300"
-                                                   aria-hidden="true"/>
-                                <x-osm-place :place="$event"/>
-                            </div>
-                        @endif
-
-                        @if($event->description)
-                            <flux:text class="mt-2">{{ Str::limit($event->description, 100) }}</flux:text>
-                        @endif
-
-                        @if($canSeeAttendees)
-                            <flux:text class="mt-2 text-sm text-zinc-600 dark:text-zinc-400">
-                                <div class="text-xs text-zinc-500 flex items-center gap-2">
-                                    <span>{{ trans_choice(':count Zusage|:count Zusagen', count($event->attendees ?? [])) }}</span>
-                                    <flux:separator vertical/>
-                                    <span>{{ trans_choice(':count Vielleicht|:count Vielleicht', count($event->might_attendees ?? [])) }}</span>
-                                </div>
-                            </flux:text>
-                        @endif
-
-                        {{-- `flex-wrap` alone would not have fixed the leader row: with
-                             `flex-1` the primary button has flex-basis 0, so it counts as
-                             zero when the browser decides where to break the line, all
-                             three buttons stay on one line, and `min-width: auto` then
-                             floors them back to 312px of content in a 254px box —
-                             "Entfernen" spilling into the neighbouring card. `basis-full`
-                             gives the primary a real basis so it claims the first line and
-                             the two leader actions wrap below it. The visitor view is
-                             unchanged: with a single child, basis-full renders exactly as
-                             flex-1 did. `gap-2` already supplies the 8px row gap. --}}
-                        <div class="mt-auto pt-4 flex flex-wrap gap-2">
-                            <flux:button
-                                :href="route('meetups.landingpage-event', ['meetup' => $meetup->slug, 'event' => $event->id, 'country' => $country])"
-                                size="xs"
-                                variant="primary"
-                                class="basis-full"
-                            >
-                                {{ __('Öffnen/RSVP') }}
-                            </flux:button>
-                            @if($meetup->leadByMe)
-                                <flux:button
-                                    :href="route_with_country('meetups.events.edit', ['meetup' => $meetup, 'event' => $event])"
-                                    size="xs"
-                                    variant="ghost"
-                                    icon="pencil"
-                                >
-                                    {{ __('Bearbeiten') }}
-                                </flux:button>
-                                <flux:modal.trigger name="delete-event-{{ $event->id }}">
-                                    <flux:button
-                                        class="cursor-pointer"
-                                        size="xs"
-                                        variant="danger"
-                                        icon="trash"
-                                    >
-                                        {{ __('Entfernen') }}
-                                    </flux:button>
-                                </flux:modal.trigger>
-
-                                <flux:modal name="delete-event-{{ $event->id }}" variant="flyout">
-                                    <form wire:submit="deleteEvent({{ $event->id }})" class="space-y-6">
-                                        <div>
-                                            <flux:heading size="lg">{{ __('Event löschen?') }}</flux:heading>
-                                            <flux:subheading>
-                                                {{ __('Möchtest du das Event vom') }} {{ $event->start->asDate() }} {{ __('wirklich löschen?') }}
-                                            </flux:subheading>
-                                            <flux:subheading class="mt-2">
-                                                {{ __('Diese Aktion kann nicht rückgängig gemacht werden.') }}
-                                            </flux:subheading>
-                                        </div>
-                                        <div class="flex gap-2">
-                                            <flux:spacer/>
-                                            <flux:modal.close>
-                                                <flux:button class="cursor-pointer"
-                                                             variant="ghost">{{ __('Abbrechen') }}</flux:button>
-                                            </flux:modal.close>
-                                            <flux:button type="submit" class="cursor-pointer"
-                                                         variant="danger">{{ __('Entfernen') }}</flux:button>
-                                        </div>
-                                    </form>
-                                </flux:modal>
-                            @endif
-                        </div>
-                    </flux:card>
-                @endforeach
-            </div>
-        </div>
-    @else
-        <div class="mt-16">
-            <div class="flex items-center space-x-4 mb-6">
-                @if($meetup->leadByMe)
-                    <flux:button :href="route_with_country('meetups.events.create', ['meetup' => $meetup])"
-                                 variant="primary" icon="calendar">
-                        {{ __('Neues Event erstellen') }}
-                    </flux:button>
-                @endif
-            </div>
-        </div>
-    @endif
 </div>

--- a/tests/Feature/Meetups/LandingpageEventSectionTest.php
+++ b/tests/Feature/Meetups/LandingpageEventSectionTest.php
@@ -1,0 +1,291 @@
+<?php
+
+use App\Models\Meetup;
+use App\Models\MeetupEvent;
+use App\Models\User;
+use Dom\HTMLDocument;
+use Illuminate\Support\Carbon;
+use Livewire\Livewire;
+
+/*
+|--------------------------------------------------------------------------
+| #45 — the upcoming-events section leads the meetup detail page
+|--------------------------------------------------------------------------
+|
+| Two hooks the markup owes this file:
+|
+|   data-testid="upcoming-events"     the events section itself
+|   data-testid="no-upcoming-events"  the empty state shown to a meetup that
+|                                     has no upcoming event
+|
+| Both are asserted on the attribute, never on the German copy — and here
+| that is not a matter of taste. "Kommende Veranstaltungen" also occurs
+| inside the CSS comment that landingpage.blade.php ships in its <style>
+| block for the map height, and that comment sits in the RIGHT column, i.e.
+| before the section it talks about. Measured on ea91f59 with one upcoming
+| event: the first occurrence of that string is at offset 614770 (the
+| comment), the section heading only at 620616. A DOM-order test anchored on
+| the heading would have measured a comment and reported an order that the
+| page does not have.
+|
+| The whole point of #45 is ORDER, not presence: before the restructuring the
+| section rendered after the two-column header block, below the fold. A test
+| that only asserts the section exists stays green while it slides back down.
+*/
+
+/**
+ * A meetup that renders both header blocks the events section has to beat.
+ *
+ * `intro` is pinned rather than left to the factory's faker paragraph: the
+ * "Über uns" block is gated on it, and it is one of the two anchors below.
+ */
+function meetupWithHeaderBlocks(?User $leader = null): Meetup
+{
+    return Meetup::factory()->create([
+        'intro' => 'Wir treffen uns jeden zweiten Donnerstag im Vereinsheim.',
+        'created_by' => ($leader ?? User::factory()->create())->id,
+    ]);
+}
+
+/**
+ * The rendered landing page for whoever is acting in the current test.
+ */
+function landingpageMarkup(Meetup $meetup): string
+{
+    return Livewire::test('meetups.landingpage', ['meetup' => $meetup])
+        ->assertStatus(200)
+        ->html();
+}
+
+/**
+ * The markup of the element carrying `data-testid="upcoming-events"`, or null
+ * when no element carries it.
+ *
+ * Parsed rather than sliced: "inside the section" is a containment question,
+ * and a string search cannot answer it — the section has no closing marker a
+ * test could find, and the page carries ~600 KB of Flux markup between the
+ * section heading and the first event card.
+ */
+function upcomingEventsSectionMarkup(string $html): ?string
+{
+    $document = HTMLDocument::createFromString($html, LIBXML_NOERROR);
+    $section = $document->querySelector('[data-testid="upcoming-events"]');
+
+    return $section === null ? null : $document->saveHtml($section);
+}
+
+/**
+ * The URL the "Neues Event erstellen" action points at, built through the same
+ * helper the view uses so the country segment is resolved identically.
+ */
+function createEventUrl(Meetup $meetup): string
+{
+    return route_with_country('meetups.events.create', ['meetup' => $meetup]);
+}
+
+/*
+|--------------------------------------------------------------------------
+| 1. DOM order
+|--------------------------------------------------------------------------
+|
+| Every offset is guarded with ->not->toBeFalse() BEFORE it is compared, and
+| that guard is load-bearing: mb_strpos() returns false when the needle is
+| missing, and PHP compares false against an int by casting the int to bool,
+| so `false < 620616` is true. Without the guards, a page that lost the
+| section altogether would satisfy every ordering assertion in this block.
+*/
+
+it('renders the upcoming events section before the about and contact blocks', function () {
+    $meetup = meetupWithHeaderBlocks();
+    MeetupEvent::factory()->for($meetup)->create(['start' => now()->addWeek()]);
+
+    $html = landingpageMarkup($meetup);
+
+    $section = mb_strpos($html, 'data-testid="upcoming-events"');
+    // "Kontakt & Links" reaches the markup as "Kontakt &amp; Links" — the
+    // heading goes through Blade's escaping, so the raw key never matches.
+    $aboutUs = mb_strpos($html, __('Über uns'));
+    $contact = mb_strpos($html, e(__('Kontakt & Links')));
+
+    expect($section)->not->toBeFalse('no element carries data-testid="upcoming-events"')
+        ->and($aboutUs)->not->toBeFalse('the "Über uns" block did not render')
+        ->and($contact)->not->toBeFalse('the "Kontakt & Links" block did not render')
+        ->and($section)->toBeLessThan($aboutUs)
+        ->and($section)->toBeLessThan($contact);
+});
+
+it('renders the empty state before the about and contact blocks', function () {
+    // Same claim for a meetup without events. Anchored on the empty state
+    // rather than on the section, so it holds whether the empty state sits
+    // inside `data-testid="upcoming-events"` or takes its place.
+    $meetup = meetupWithHeaderBlocks();
+
+    $html = landingpageMarkup($meetup);
+
+    $emptyState = mb_strpos($html, 'data-testid="no-upcoming-events"');
+    $aboutUs = mb_strpos($html, __('Über uns'));
+    $contact = mb_strpos($html, e(__('Kontakt & Links')));
+
+    expect($emptyState)->not->toBeFalse('no element carries data-testid="no-upcoming-events"')
+        ->and($aboutUs)->not->toBeFalse('the "Über uns" block did not render')
+        ->and($contact)->not->toBeFalse('the "Kontakt & Links" block did not render')
+        ->and($emptyState)->toBeLessThan($aboutUs)
+        ->and($emptyState)->toBeLessThan($contact);
+});
+
+/*
+|--------------------------------------------------------------------------
+| 2. The empty state, in both directions
+|--------------------------------------------------------------------------
+*/
+
+it('shows the empty state for a meetup that has no event at all', function () {
+    $meetup = meetupWithHeaderBlocks();
+
+    Livewire::test('meetups.landingpage', ['meetup' => $meetup])
+        ->assertStatus(200)
+        ->assertSeeHtml('data-testid="no-upcoming-events"');
+});
+
+it('shows no empty state for a meetup with an upcoming event', function () {
+    $meetup = meetupWithHeaderBlocks();
+    $event = MeetupEvent::factory()->for($meetup)->create(['start' => now()->addWeek()]);
+
+    $html = landingpageMarkup($meetup);
+
+    // The card is there AND the empty state is not. Asserting only the absence
+    // would also pass on a page that renders neither.
+    expect($html)
+        ->toContain(route('meetups.landingpage-event', [
+            'meetup' => $meetup->slug,
+            'event' => $event->id,
+            'country' => defaultCountrySegment(),
+        ]))
+        ->not->toContain('data-testid="no-upcoming-events"');
+});
+
+/*
+|--------------------------------------------------------------------------
+| 3. A past-only meetup counts as empty
+|--------------------------------------------------------------------------
+|
+| The section filters on `start >= now()`. The two tests below pin both sides
+| of that comparison, because the plausible ways to break it pull in opposite
+| directions: dropping the filter lists yesterday's event again, and
+| coarsening it to a whereDate()/today() comparison drops an event that starts
+| later on the same day.
+*/
+
+it('counts a meetup whose only event lies in the past as having no upcoming event', function () {
+    $meetup = meetupWithHeaderBlocks();
+    $past = MeetupEvent::factory()->for($meetup)->create(['start' => now()->subWeek()]);
+
+    $html = landingpageMarkup($meetup);
+
+    expect($html)
+        ->toContain('data-testid="no-upcoming-events"')
+        // And the past event is not quietly listed above that empty state.
+        ->not->toContain(route('meetups.landingpage-event', [
+            'meetup' => $meetup->slug,
+            'event' => $past->id,
+            'country' => defaultCountrySegment(),
+        ]));
+});
+
+it('still lists an event that starts later on the same day', function () {
+    // The clock is frozen so "later today" stays "later today": at 09:00 an
+    // event at 20:00 is upcoming, and a run started at 22:00 would otherwise
+    // have pushed it into tomorrow and measured something else.
+    $this->travelTo(Carbon::parse('2027-03-11 09:00:00'));
+
+    $meetup = meetupWithHeaderBlocks();
+    $event = MeetupEvent::factory()->for($meetup)->create([
+        'start' => Carbon::parse('2027-03-11 20:00:00'),
+    ]);
+
+    $html = landingpageMarkup($meetup);
+
+    expect($html)
+        ->toContain(route('meetups.landingpage-event', [
+            'meetup' => $meetup->slug,
+            'event' => $event->id,
+            'country' => defaultCountrySegment(),
+        ]))
+        ->not->toContain('data-testid="no-upcoming-events"');
+});
+
+/*
+|--------------------------------------------------------------------------
+| 4. The create-event action lives in the events section
+|--------------------------------------------------------------------------
+|
+| Placement, not presence: the action used to sit in a header row of its own,
+| and an assertSee() on its URL would not notice it going back there. So the
+| number of create links inside the section is compared against the number on
+| the whole page — that is what makes "and nowhere else" an assertion instead
+| of a wish, and it stays honest about HOW MANY the section holds: the empty
+| state may legitimately repeat the action next to its own copy.
+*/
+
+it('places the create-event action inside the upcoming events section for a leader', function () {
+    $leader = actingAsUser();
+    $meetup = meetupWithHeaderBlocks($leader);
+    MeetupEvent::factory()->for($meetup)->create(['start' => now()->addWeek()]);
+
+    $html = landingpageMarkup($meetup);
+    $section = upcomingEventsSectionMarkup($html);
+    $createUrl = createEventUrl($meetup);
+
+    expect($section)->not->toBeNull('no element carries data-testid="upcoming-events"')
+        ->and(substr_count($html, $createUrl))->toBeGreaterThan(0)
+        ->and(substr_count((string) $section, $createUrl))->toBe(substr_count($html, $createUrl));
+});
+
+it('places the create-event action inside the events area for a leader of a meetup without events', function () {
+    // A leader arriving at an empty meetup is the case #45 is really about:
+    // the action has to be where the missing events are, not in a header row.
+    $leader = actingAsUser();
+    $meetup = meetupWithHeaderBlocks($leader);
+
+    $html = landingpageMarkup($meetup);
+    $section = upcomingEventsSectionMarkup($html);
+    $createUrl = createEventUrl($meetup);
+
+    $emptyState = mb_strpos($html, 'data-testid="no-upcoming-events"');
+    $createAction = mb_strpos($html, $createUrl);
+    $aboutUs = mb_strpos($html, __('Über uns'));
+
+    expect($section)->not->toBeNull('no element carries data-testid="upcoming-events"')
+        ->and($emptyState)->not->toBeFalse('no element carries data-testid="no-upcoming-events"')
+        ->and($createAction)->not->toBeFalse('the create-event action did not render for the leader')
+        ->and(substr_count((string) $section, $createUrl))->toBe(substr_count($html, $createUrl))
+        ->and($aboutUs)->not->toBeFalse('the "Über uns" block did not render')
+        ->and($createAction)->toBeLessThan($aboutUs);
+});
+
+it('shows no create-event action to a signed-in visitor who does not lead the meetup', function () {
+    $meetup = meetupWithHeaderBlocks();
+    MeetupEvent::factory()->for($meetup)->create(['start' => now()->addWeek()]);
+
+    // Acting AFTER the meetup exists: its creator is made leader by a model
+    // hook, so a user created first would be the one leading it.
+    actingAsUser();
+
+    $html = landingpageMarkup($meetup);
+
+    // The section is still there — a visitor reads the event list, they just
+    // get no action on it. Asserting only the absence of the URL would pass on
+    // a page that failed to render the section at all.
+    expect(upcomingEventsSectionMarkup($html))->not->toBeNull('no element carries data-testid="upcoming-events"')
+        ->and(substr_count($html, createEventUrl($meetup)))->toBe(0);
+});
+
+it('shows no create-event action to a guest', function () {
+    $meetup = meetupWithHeaderBlocks();
+    MeetupEvent::factory()->for($meetup)->create(['start' => now()->addWeek()]);
+
+    $html = landingpageMarkup($meetup);
+
+    expect(upcomingEventsSectionMarkup($html))->not->toBeNull('no element carries data-testid="upcoming-events"')
+        ->and(substr_count($html, createEventUrl($meetup)))->toBe(0);
+});


### PR DESCRIPTION
Closes #45.

The last open acceptance criterion of #45: *"The event list and Create event action are visible without scrolling past a large map on a typical desktop viewport."* #52 shrank the map and closed this as only partly reached, because it measured a sparse meetup.

On a full one it failed at both viewports — at 1920×1080 the first card began 8px past the fold with no card visible. **And the map was never the binding constraint:** the details column is the taller column of the grid (892px against 435px at 1920), the events section began after both, and deleting the map column outright was measured to move the list up by zero pixels. Resizing could not close this criterion; repositioning can.

The page is now identity row → events section full width with its Create event action → About us / Contact & Links / Community alongside the map. First event card 1088 → 316 (1920) and 1160 → 316 (1440), all three elements fully inside the first viewport.

Also: a meetup with no upcoming event rendered an empty block, so a visitor could not tell "no events" from "page broken". Named now, in all nine languages.

Ten feature tests. Order is asserted on string offsets rather than presence — a presence check would stay green if the section slid back below the fold, which is the regression this issue is about. Full non-Browser suite: 1790 passed, 6532 assertions.

One note left in the file for whoever moves a block here next: Blade pairs a single-line `@php(...)` with the next real `@endphp` further down and swallows everything between. That line was harmless only while no such block followed it; moving the events section put one behind it and the compiled template lost the entire card grid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A4BKf2zxFNSRKBoMUB8EUW