### PR TITLE
Render dates as ISO 8601 everywhere, and name the fields the reporter tripped over

### DIFF
--- a/app/Http/Controllers/Api/MeetupEventController.php
+++ b/app/Http/Controllers/Api/MeetupEventController.php
@@ -69,6 +69,18 @@ class MeetupEventController extends Controller
         return $events->map(fn ($event) => [
             'id' => $event->id,
             'title' => $event->title,
+            /*
+             * Deliberately NOT switched to the App\Support\Carbon formatters by the ISO
+             * 8601 work (issue #48): this is a published API contract with a live mobile
+             * consumer, and it is already ISO-shaped. `Y-m-d H:i` in UTC, with no zone
+             * marker and no seconds — a raw ->format() that skips the user-timezone
+             * conversion on purpose, because an API has no "current user's timezone".
+             *
+             * Changing it (adding a zone suffix, going full ISO 8601 with T and offset,
+             * or rendering in a requested zone) is a breaking change for that consumer
+             * and needs its own decision — not a side effect of a display-layer fix.
+             * MobileMeetupListController::__invoke() mirrors this format on purpose.
+             */
             'start' => $event->start->format('Y-m-d H:i'),
             'end' => $event->end?->format('Y-m-d H:i'),
             /*

--- a/app/Http/Controllers/Api/MobileMeetupListController.php
+++ b/app/Http/Controllers/Api/MobileMeetupListController.php
@@ -75,7 +75,14 @@ class MobileMeetupListController extends Controller
                 // a fallback URL (country placeholder). Without a real logo the
                 // app should show the initials avatar, so null instead of a placeholder URL.
                 'logo' => $meetup->getFirstMedia('logo')?->getUrl(),
-                // Same format as GET /api/meetup-events (see MeetupEventController).
+                /*
+                 * Same format as GET /api/meetup-events (see MeetupEventController),
+                 * and deliberately left alone by the ISO 8601 work (issue #48):
+                 * `Y-m-d H:i` in UTC, no zone marker, no user-timezone conversion.
+                 * A published API contract with a live mobile consumer — changing its
+                 * shape is a breaking change that needs its own decision, and it has to
+                 * be taken for both endpoints at once.
+                 */
                 'next_event_start' => $meetup->next_event_start
                     ? Carbon::parse($meetup->next_event_start)->format('Y-m-d H:i')
                     : null,

--- a/app/Support/Carbon.php
+++ b/app/Support/Carbon.php
@@ -4,42 +4,43 @@ namespace App\Support;
 
 use Carbon\CarbonImmutable;
 
+/**
+ * Application date implementation, bound via Date::use() in AppServiceProvider.
+ *
+ * All formatters render ISO 8601 with 24-hour time, in the timezone resolved by
+ * the SetTimezone middleware into config('app.user-timezone'). ISO output is
+ * deliberately locale-independent: the portal serves nine locales, so no month
+ * or day name may leak into a numeric date.
+ *
+ * The explicit ->timezone(config('app.user-timezone')) is what does the converting,
+ * and it is not redundant: date_default_timezone_set() runs at bootstrap, long
+ * before SetTimezone, so PHP's default zone stays UTC for the whole request
+ * (measured after a real request with a New York user: date_default_timezone_get()
+ * = 'UTC'). Note that config('app.timezone') is NOT UTC at that point — SetTimezone
+ * overwrites it with the user's zone too — but nothing reads it here, and a
+ * console or queue context never runs that middleware at all. Drop the explicit
+ * ->timezone() call and every timestamp falls back to UTC.
+ */
 class Carbon extends CarbonImmutable
 {
     public function asDate(): string
     {
-        $dt = $this->timezone(config('app.user-timezone'))->locale('de');
-
-        return str($dt->day)->padLeft(2, '0').'. '.$dt->monthName.' '.$dt->year;
+        return $this->timezone(config('app.user-timezone'))
+            ->format('Y-m-d');
     }
 
     public function asTime(): string
     {
-        return $this->timezone(config('app.user-timezone'))->locale('de')
+        return $this->timezone(config('app.user-timezone'))
             ->format('H:i');
-    }
-
-    public function asDayNameAndMonthName(): string
-    {
-        $dt = $this->timezone(config('app.user-timezone'))->locale('de');
-
-        return sprintf('%s, %s. week of %s [%s]',
-            $dt->dayName,
-            $dt->weekNumberInMonth,
-            $dt->monthName,
-            $dt->timezoneAbbreviatedName
-        );
     }
 
     public function asDateTime(): string
     {
-        $dt = $this->timezone(config('app.user-timezone'))->locale('de');
+        $dt = $this->timezone(config('app.user-timezone'));
 
-        return sprintf('%s.%s.%s %s (%s)',
-            str($dt->day)->padLeft(2, '0'),
-            str($dt->month)->padLeft(2, '0'),
-            $dt->year,
-            $dt->format('H:i'),
+        return sprintf('%s (%s)',
+            $dt->format('Y-m-d H:i'),
             $dt->timezoneAbbreviatedName
         );
     }

--- a/app/Traits/NostrTrait.php
+++ b/app/Traits/NostrTrait.php
@@ -50,6 +50,19 @@ trait NostrTrait
             ]),
             $model instanceof MeetupEvent => __('nostr.meetup_event_text', [
                 'from' => $this->getFrom($model),
+                /*
+                 * asDateTime() feeds the text of a published kind:1 note, not a page.
+                 * The ISO 8601 switch (issue #48) therefore changed the shape of every
+                 * note this trait publishes from now on — "08.10.2026 19:00 (CEST)"
+                 * became "2026-10-08 19:00 (CEST)". Notes already on the relays keep
+                 * the old shape; a Nostr event is immutable, so the two forms coexist
+                 * in the wild forever and any consumer parsing this string sees both.
+                 *
+                 * Recorded because nothing guards it: `grep -rn
+                 * 'meetup_event_text\|publishOnNostr' tests/` finds no coverage at all,
+                 * so a future change to the formatters will alter published note text
+                 * again with no test going red.
+                 */
                 'start' => $model->start->asDateTime(),
                 'location' => $model->location,
                 'url' => $this->getUrl($model, $countryCode),

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -880,5 +880,8 @@
     "Serientermine bestimmst du beim Erstellen. Später geht das nicht mehr.": "Opakování nastavuješ při vytváření události, později už ne.",
     ":time Uhr": ":time",
     ":from - :to Uhr": ":from - :to",
-    "Besucher sehen an dieser Stelle dasselbe.": "Návštěvníci zde vidí totéž."
+    "Besucher sehen an dieser Stelle dasselbe.": "Návštěvníci zde vidí totéž.",
+    "Ort als Text": "Místo jako text",
+    "z.B. Hinterzimmer im Café Mustermann": "např. zadní místnost v Café Mustermann",
+    "Freitext für Besucher. Auch Details, die ein Kartenpunkt nicht zeigt.": "Volný text pro návštěvníky. I detaily, které bod na mapě neukáže."
 }

--- a/lang/de.json
+++ b/lang/de.json
@@ -880,5 +880,8 @@
     "Serientermine bestimmst du beim Erstellen. Später geht das nicht mehr.": "",
     ":time Uhr": "",
     ":from - :to Uhr": "",
-    "Besucher sehen an dieser Stelle dasselbe.": ""
+    "Besucher sehen an dieser Stelle dasselbe.": "",
+    "Ort als Text": "",
+    "z.B. Hinterzimmer im Café Mustermann": "",
+    "Freitext für Besucher. Auch Details, die ein Kartenpunkt nicht zeigt.": ""
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -880,5 +880,8 @@
     "Serientermine bestimmst du beim Erstellen. Später geht das nicht mehr.": "You set recurring dates when you create the event, not afterwards.",
     ":time Uhr": ":time",
     ":from - :to Uhr": ":from - :to",
-    "Besucher sehen an dieser Stelle dasselbe.": "Visitors see the same thing here."
+    "Besucher sehen an dieser Stelle dasselbe.": "Visitors see the same thing here.",
+    "Ort als Text": "Location as text",
+    "z.B. Hinterzimmer im Café Mustermann": "e.g. back room at Cafe Mustermann",
+    "Freitext für Besucher. Auch Details, die ein Kartenpunkt nicht zeigt.": "Free text for visitors. Also details a map pin cannot show."
 }

--- a/lang/es.json
+++ b/lang/es.json
@@ -880,5 +880,8 @@
     "Serientermine bestimmst du beim Erstellen. Später geht das nicht mehr.": "Defines las fechas periódicas al crear el evento, no después.",
     ":time Uhr": ":time h",
     ":from - :to Uhr": ":from - :to h",
-    "Besucher sehen an dieser Stelle dasselbe.": "Los visitantes ven aquí lo mismo."
+    "Besucher sehen an dieser Stelle dasselbe.": "Los visitantes ven aquí lo mismo.",
+    "Ort als Text": "Ubicación como texto",
+    "z.B. Hinterzimmer im Café Mustermann": "p. ej. sala trasera del Café Mustermann",
+    "Freitext für Besucher. Auch Details, die ein Kartenpunkt nicht zeigt.": "Texto libre para los visitantes. También detalles que un punto en el mapa no muestra."
 }

--- a/lang/hu.json
+++ b/lang/hu.json
@@ -880,5 +880,8 @@
     "Serientermine bestimmst du beim Erstellen. Später geht das nicht mehr.": "Az ismétlődést a létrehozáskor állítod be, utólag már nem.",
     ":time Uhr": ":time",
     ":from - :to Uhr": ":from - :to",
-    "Besucher sehen an dieser Stelle dasselbe.": "A látogatók ugyanezt látják itt."
+    "Besucher sehen an dieser Stelle dasselbe.": "A látogatók ugyanezt látják itt.",
+    "Ort als Text": "Helyszín szövegként",
+    "z.B. Hinterzimmer im Café Mustermann": "pl. hátsó terem a Café Mustermannban",
+    "Freitext für Besucher. Auch Details, die ein Kartenpunkt nicht zeigt.": "Szabad szöveg a látogatóknak. Olyan részletek is, amelyeket a térképpont nem mutat."
 }

--- a/lang/lv.json
+++ b/lang/lv.json
@@ -880,5 +880,8 @@
     "Serientermine bestimmst du beim Erstellen. Später geht das nicht mehr.": "Atkārtošanos iestati, veidojot pasākumu, vēlāk vairs ne.",
     ":time Uhr": ":time",
     ":from - :to Uhr": ":from - :to",
-    "Besucher sehen an dieser Stelle dasselbe.": "Apmeklētāji šeit redz to pašu."
+    "Besucher sehen an dieser Stelle dasselbe.": "Apmeklētāji šeit redz to pašu.",
+    "Ort als Text": "Vieta kā teksts",
+    "z.B. Hinterzimmer im Café Mustermann": "piem., aizmugurējā telpa Café Mustermann",
+    "Freitext für Besucher. Auch Details, die ein Kartenpunkt nicht zeigt.": "Brīvs teksts apmeklētājiem. Arī detaļas, ko kartes punkts neparāda."
 }

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -880,5 +880,8 @@
     "Serientermine bestimmst du beim Erstellen. Später geht das nicht mehr.": "Je stelt de reeks in bij het aanmaken, later niet meer.",
     ":time Uhr": ":time uur",
     ":from - :to Uhr": ":from - :to uur",
-    "Besucher sehen an dieser Stelle dasselbe.": "Bezoekers zien hier hetzelfde."
+    "Besucher sehen an dieser Stelle dasselbe.": "Bezoekers zien hier hetzelfde.",
+    "Ort als Text": "Locatie als tekst",
+    "z.B. Hinterzimmer im Café Mustermann": "bijv. achterzaal in Café Mustermann",
+    "Freitext für Besucher. Auch Details, die ein Kartenpunkt nicht zeigt.": "Vrije tekst voor bezoekers. Ook details die een kaartpunt niet toont."
 }

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -880,5 +880,8 @@
     "Serientermine bestimmst du beim Erstellen. Später geht das nicht mehr.": "Cykliczność ustawiasz przy tworzeniu wydarzenia, później już nie.",
     ":time Uhr": ":time",
     ":from - :to Uhr": ":from - :to",
-    "Besucher sehen an dieser Stelle dasselbe.": "Odwiedzający widzą tutaj to samo."
+    "Besucher sehen an dieser Stelle dasselbe.": "Odwiedzający widzą tutaj to samo.",
+    "Ort als Text": "Lokalizacja jako tekst",
+    "z.B. Hinterzimmer im Café Mustermann": "np. zaplecze w Café Mustermann",
+    "Freitext für Besucher. Auch Details, die ein Kartenpunkt nicht zeigt.": "Wolny tekst dla odwiedzających. Także szczegóły, których nie pokaże punkt na mapie."
 }

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -880,5 +880,8 @@
     "Serientermine bestimmst du beim Erstellen. Später geht das nicht mehr.": "Defines a recorrência ao criar o evento, não depois.",
     ":time Uhr": ":time",
     ":from - :to Uhr": ":from - :to",
-    "Besucher sehen an dieser Stelle dasselbe.": "Os visitantes veem aqui o mesmo."
+    "Besucher sehen an dieser Stelle dasselbe.": "Os visitantes veem aqui o mesmo.",
+    "Ort als Text": "Local como texto",
+    "z.B. Hinterzimmer im Café Mustermann": "p. ex. sala dos fundos no Café Mustermann",
+    "Freitext für Besucher. Auch Details, die ein Kartenpunkt nicht zeigt.": "Texto livre para os visitantes. Também detalhes que um ponto no mapa não mostra."
 }

--- a/resources/views/livewire/admin/webhooks.blade.php
+++ b/resources/views/livewire/admin/webhooks.blade.php
@@ -176,7 +176,7 @@ new class extends Component
                                 {{ implode(', ', $subscription->resources) }}
                             </p>
                             <p class="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
-                                {{ __('Angefragt am :date', ['date' => $subscription->created_at?->format('d.m.Y H:i')]) }}
+                                {{ __('Angefragt am :date', ['date' => $subscription->created_at?->asDateTime()]) }}
                             </p>
                         </div>
 

--- a/resources/views/livewire/courses/create-edit-events.blade.php
+++ b/resources/views/livewire/courses/create-edit-events.blade.php
@@ -5,8 +5,10 @@ use App\Models\City;
 use App\Models\Country;
 use App\Models\Course;
 use App\Models\CourseEvent;
+use App\Models\Tag;
 use App\Services\Osm\NominatimClient;
 use App\Traits\SeoTrait;
+use Carbon\Carbon;
 use Flux\Flux;
 use Livewire\Attributes\Locked;
 use Livewire\Attributes\Validate;
@@ -14,18 +16,23 @@ use Livewire\Component;
 
 new
 #[SeoDataAttribute(key: 'courses_edit_events')]
-class extends Component {
+class extends Component
+{
     use SeoTrait;
 
     public Course $course;
+
     public ?CourseEvent $event = null;
 
     #[Locked]
     public $country = 'de';
 
     public ?string $fromDate = null;
+
     public ?string $fromTime = null;
+
     public ?string $toDate = null;
+
     public ?string $toTime = null;
 
     /**
@@ -227,10 +234,10 @@ class extends Component {
         $timezone = auth()->user()->timezone ?? 'Europe/Berlin';
 
         // Combine date and time in user's timezone, then convert to UTC
-        $localFrom = \Carbon\Carbon::createFromFormat('Y-m-d H:i', $this->fromDate.' '.$this->fromTime, $timezone);
+        $localFrom = Carbon::createFromFormat('Y-m-d H:i', $this->fromDate.' '.$this->fromTime, $timezone);
         $utcFrom = $localFrom->setTimezone('UTC');
 
-        $localTo = \Carbon\Carbon::createFromFormat('Y-m-d H:i', $this->toDate.' '.$this->toTime, $timezone);
+        $localTo = Carbon::createFromFormat('Y-m-d H:i', $this->toDate.' '.$this->toTime, $timezone);
         $utcTo = $localTo->setTimezone('UTC');
 
         // Additional validation: to must be after from
@@ -303,7 +310,7 @@ class extends Component {
      */
     private function syncTags(CourseEvent $event): void
     {
-        $allowed = \App\Models\Tag::query()
+        $allowed = Tag::query()
             ->where('type', 'meetup_event')
             ->selectableBy(auth()->user())
             ->whereIn('id', $this->tagIds)
@@ -434,17 +441,33 @@ class extends Component {
         <flux:fieldset class="space-y-6">
             <flux:legend>{{ __('Event Details') }}</flux:legend>
 
+            {{-- The `locale` attribute is not decoration: without it Flux falls back to
+                 navigator.language, so these four pickers followed the BROWSER instead of
+                 the language the user picked in the portal — a German organiser on an
+                 English-language laptop got an English calendar here while the meetup form
+                 next door showed a German one. session('lang_country') is the portal's own
+                 selection and what meetups/create-edit-events.blade.php has always passed.
+
+                 Deliberately NOT pinned to an ISO locale. Issue #48 put the portal on ISO
+                 8601, but that rule governs data display, not an input widget — the picker
+                 is a control the organiser operates and its calendar may speak their
+                 language. The measurement behind that decision, and the one locale that
+                 would have produced an ISO date, are recorded at the matching block in
+                 meetups/create-edit-events.blade.php.
+
+                 Display only: wire:model carries Y-m-d and H:i, and save() converts those
+                 from the user's timezone to UTC. --}}
             <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
                 <flux:field>
                     <flux:label>{{ __('Startdatum') }} <span class="text-red-500">*</span></flux:label>
-                    <flux:date-picker wire:model="fromDate" required/>
+                    <flux:date-picker wire:model="fromDate" required locale="{{ session('lang_country', 'de-DE') }}"/>
                     <flux:description>{{ __('An welchem Tag beginnt das Event?') }}</flux:description>
                     <flux:error name="fromDate"/>
                 </flux:field>
 
                 <flux:field>
                     <flux:label>{{ __('Startzeit') }} <span class="text-red-500">*</span></flux:label>
-                    <flux:time-picker wire:model="fromTime" required/>
+                    <flux:time-picker wire:model="fromTime" required locale="{{ session('lang_country', 'de-DE') }}"/>
                     <flux:description>{{ __('Um wie viel Uhr beginnt das Event?') }} ({{ auth()->user()->timezone ?? 'Europe/Berlin' }})</flux:description>
                     <flux:error name="fromTime"/>
                 </flux:field>
@@ -453,14 +476,14 @@ class extends Component {
             <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
                 <flux:field>
                     <flux:label>{{ __('Enddatum') }} <span class="text-red-500">*</span></flux:label>
-                    <flux:date-picker wire:model="toDate" required/>
+                    <flux:date-picker wire:model="toDate" required locale="{{ session('lang_country', 'de-DE') }}"/>
                     <flux:description>{{ __('An welchem Tag endet das Event?') }}</flux:description>
                     <flux:error name="toDate"/>
                 </flux:field>
 
                 <flux:field>
                     <flux:label>{{ __('Endzeit') }} <span class="text-red-500">*</span></flux:label>
-                    <flux:time-picker wire:model="toTime" required/>
+                    <flux:time-picker wire:model="toTime" required locale="{{ session('lang_country', 'de-DE') }}"/>
                     <flux:description>{{ __('Um wie viel Uhr endet das Event?') }} ({{ auth()->user()->timezone ?? 'Europe/Berlin' }})</flux:description>
                     <flux:error name="toTime"/>
                 </flux:field>
@@ -510,11 +533,14 @@ class extends Component {
                 wire:key="osm-picker-{{ $this->osmCountry ?? 'any' }}"
             />
 
+            {{-- Same pair, same fix as the meetup event form (issue #48). The reporter
+                 only saw that form, but leaving its twin with the old "Ort" next to an
+                 identically-hinted "Ort auf der Karte" would have been half a fix. --}}
             <flux:field>
-                <flux:label>{{ __('Ort') }} <span class="text-red-500">*</span></flux:label>
-                <flux:input wire:model="location" placeholder="{{ __('z.B. Café Mustermann, Hauptstr. 1') }}"
+                <flux:label>{{ __('Ort als Text') }} <span class="text-red-500">*</span></flux:label>
+                <flux:input wire:model="location" placeholder="{{ __('z.B. Hinterzimmer im Café Mustermann') }}"
                             required/>
-                <flux:description>{{ __('Wo findet das Event statt?') }}</flux:description>
+                <flux:description>{{ __('Freitext für Besucher. Auch Details, die ein Kartenpunkt nicht zeigt.') }}</flux:description>
                 <flux:error name="location"/>
             </flux:field>
 

--- a/resources/views/livewire/courses/edit.blade.php
+++ b/resources/views/livewire/courses/edit.blade.php
@@ -63,8 +63,8 @@ class extends Component {
 
         // System fields
         $this->created_by = $this->course->created_by;
-        $this->created_at = $this->course->created_at?->format('Y-m-d H:i:s');
-        $this->updated_at = $this->course->updated_at?->format('Y-m-d H:i:s');
+        $this->created_at = $this->course->created_at?->asDateTime();
+        $this->updated_at = $this->course->updated_at?->asDateTime();
     }
 
     public function updateCourse(): void

--- a/resources/views/livewire/courses/index.blade.php
+++ b/resources/views/livewire/courses/index.blade.php
@@ -109,7 +109,7 @@ class extends Component {
                         @endphp
                         @if($nextEvent)
                             <flux:badge color="green" size="sm">
-                                {{ $nextEvent->from->format('d.m.Y H:i') }}
+                                {{ $nextEvent->from->asDateTime() }}
                             </flux:badge>
                         @endif
                     </flux:table.cell>

--- a/resources/views/livewire/courses/landingpage.blade.php
+++ b/resources/views/livewire/courses/landingpage.blade.php
@@ -141,12 +141,12 @@ class extends Component {
                 @foreach($events as $event)
                     <flux:card size="sm" class="h-full flex flex-col">
                         <flux:heading class="flex items-center gap-2">
-                            {{ $event->from->format('d.m.Y') }}
+                            {{ $event->from->asDate() }}
                         </flux:heading>
 
                         <flux:text class="mt-2 text-sm text-zinc-600 dark:text-zinc-300">
                             <flux:icon.clock class="inline w-4 h-4"/>
-                            {{ __(':from - :to Uhr', ['from' => $event->from->format('H:i'), 'to' => $event->to->format('H:i')]) }}
+                            {{ __(':from - :to Uhr', ['from' => $event->from->asTime(), 'to' => $event->to->asTime()]) }}
                         </flux:text>
 
                         {{-- Die Whitelist fuer osm_type, das 24px-Ziel und der Pfeil stehen

--- a/resources/views/livewire/lecturers/edit.blade.php
+++ b/resources/views/livewire/lecturers/edit.blade.php
@@ -79,8 +79,8 @@ class extends Component {
         $this->paynym = $this->lecturer->paynym;
 
         $this->created_by = $this->lecturer->created_by;
-        $this->created_at = $this->lecturer->created_at?->format('Y-m-d H:i:s');
-        $this->updated_at = $this->lecturer->updated_at?->format('Y-m-d H:i:s');
+        $this->created_at = $this->lecturer->created_at?->asDateTime();
+        $this->updated_at = $this->lecturer->updated_at?->asDateTime();
     }
 
     public function updateLecturer(): void

--- a/resources/views/livewire/lecturers/index.blade.php
+++ b/resources/views/livewire/lecturers/index.blade.php
@@ -105,7 +105,7 @@ class extends Component {
                             <div class="flex flex-col gap-1">
                                 <a href="{{ route('courses.landingpage', ['course' => $nextEvent->course, 'country' => $country]) }}">
                                     <flux:badge color="green" size="sm">
-                                        {{ $nextEvent->from->format('d.m.Y H:i') }}
+                                        {{ $nextEvent->from->asDateTime() }}
                                     </flux:badge>
                                 </a>
                                 @if($lecturer->future_events_count > 1)

--- a/resources/views/livewire/meetups/create-edit-events.blade.php
+++ b/resources/views/livewire/meetups/create-edit-events.blade.php
@@ -63,7 +63,12 @@ class extends Component
 
             return array_map(fn (Carbon $date): array => [
                 'date' => $date,
-                'formatted' => $date->translatedFormat('l, d.m.Y'),
+                // ISO 8601, like every other date the portal renders. The instances
+                // ExpandRecurrenceSeries returns keep the timezone they were built with
+                // ($timezone above), so no conversion belongs here — same as 'time' below.
+                // translatedFormat('l, d.m.Y') used to sit here and was the last display
+                // site that carried both a day name and a d.m.Y date (issue #48).
+                'formatted' => $date->format('Y-m-d'),
                 'time' => $date->format('H:i'),
             ], $this->generateEventDates($startDate, $endDate));
         } catch (Exception $e) {
@@ -530,7 +535,61 @@ class extends Component
         <flux:fieldset class="space-y-6">
             <flux:legend>{{ __('Event Details') }}</flux:legend>
 
-            <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+            {{-- When the event happens is ONE fact, so it is one row (issue #48). The end
+                 time used to sit further down, after the title and a callout, labelled
+                 just "Ende" — which does not say end of what, in a form that also creates
+                 series and therefore has a genuine end DATE elsewhere. Start and end now
+                 sit side by side, where the only way to read them is against each other.
+
+                 "Startzeit"/"Endzeit" are not new words: the courses form next door has
+                 used them all along, so this aligns the two forms instead of inventing a
+                 third vocabulary — and both keys already exist in all nine locales.
+
+                 Three columns collapse to one below lg, the same breakpoint every other
+                 row in this form uses. That is deliberate: two time pickers side by side
+                 on a phone is the obvious way for this to go wrong.
+
+                 Known and measured: the End time control sits 6.66px higher than its two
+                 neighbours (control top 185.5 vs 192.16 at 1280px, wrapper height 40 vs
+                 46.67). Flux renders a required, non-clearable picker taller than an
+                 optional clearable one, and the gap between label and control is a
+                 correct 8px in all three. Not patched here: neither equalising the label
+                 boxes (h-6 on all three) nor a shared min-height on the controls reaches
+                 the element that differs, and End time must stay clearable, so
+                 :clearable="false" is not an option. Left visible and reported rather
+                 than papered over with a class that does not explain itself.
+
+                 These pickers follow the portal's own language selection, and that is
+                 SETTLED — do not pin them to an ISO locale. Issue #48 put the portal on
+                 ISO 8601 in every locale, but that rule governs DATA DISPLAY, not an input
+                 widget: a date picker is a control the organiser operates, and its calendar
+                 may speak their language. What must be ISO is what the form renders as data
+                 (the series preview above) and what it stores.
+
+                 Written down because someone will try the ISO pinning again, and the
+                 measurement is worth more than the code was. Flux hardcodes
+                 {day:"numeric", month:"short", year:"numeric"} for the selected-date
+                 display (vendor/livewire/flux-pro/dist/flux.js:8383) and offers no `format`
+                 attribute, so `locale` is the only lever over it. Across 74 language tags
+                 measured in Chromium, exactly one answers that option set with a plain
+                 YYYY-MM-DD: lt-*. Not sv-SE, the usual ISO candidate — it renders
+                 "7 sep. 2026"; de-DE gives "7. Sept. 2026", en-US "Sep 7, 2026".
+
+                 A locale="lt-LT" pinning was built, measured and then REJECTED by the owner
+                 on 2026-09-04: the same attribute also drives the popover, so it turned the
+                 month heading ("2026 m. rugsėjis"), the weekday initials and every day
+                 cell's aria-label Lithuanian — the last of those is what a US organiser's
+                 screen reader announces ("2026 m. rugsėjo 7 d., pirmadienis"). Trading an
+                 accessible calendar for an ISO string in one input field is the wrong way
+                 round.
+
+                 What actually matters here is storage, and it is independent of this
+                 attribute: `locale` touches display only, wire:model carries Y-m-d and H:i,
+                 and createOrUpdateSingleEvent() converts those from the user's timezone to
+                 UTC. Measured through the real widget on 2026-09-04 for an
+                 America/Indiana/Indianapolis organiser — en-US and lt-LT store the
+                 identical instant, which is what makes the choice of locale here free. --}}
+            <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
                 <flux:field>
                     <flux:label>{{ $seriesMode && !$event ? __('Startdatum') : __('Datum') }} <span class="text-red-500">*</span></flux:label>
                     <flux:date-picker :clearable="false" min="today" wire:model.live="startDate" required locale="{{ session('lang_country', 'de-DE') }}"/>
@@ -539,10 +598,17 @@ class extends Component
                 </flux:field>
 
                 <flux:field>
-                    <flux:label>{{ __('Uhrzeit') }} <span class="text-red-500">*</span></flux:label>
+                    <flux:label>{{ __('Startzeit') }} <span class="text-red-500">*</span></flux:label>
                     <flux:time-picker :clearable="false" wire:model="startTime" required locale="{{ session('lang_country', 'de-DE') }}"/>
                     <flux:description>{{ __('Um wie viel Uhr startet das Event?') }} ({{ $this->userTimezone }})</flux:description>
                     <flux:error name="startTime"/>
+                </flux:field>
+
+                <flux:field>
+                    <flux:label>{{ __('Endzeit') }}</flux:label>
+                    <flux:time-picker wire:model="endTime" locale="{{ session('lang_country', 'de-DE') }}"/>
+                    <flux:description>{{ __('Optional. Eine Zeit vor dem Beginn bedeutet: das Event endet nach Mitternacht.') }}</flux:description>
+                    <flux:error name="endTime"/>
                 </flux:field>
             </div>
 
@@ -656,13 +722,6 @@ class extends Component
                 <flux:error name="title"/>
             </flux:field>
 
-            <flux:field>
-                <flux:label>{{ __('Ende') }}</flux:label>
-                <flux:time-picker wire:model="endTime" locale="{{ session('lang_country', 'de-DE') }}"/>
-                <flux:description>{{ __('Optional. Eine Zeit vor dem Beginn bedeutet: das Event endet nach Mitternacht.') }}</flux:description>
-                <flux:error name="endTime"/>
-            </flux:field>
-
             @if ($this->needsOsmHint)
                 <flux:callout icon="map-pin" data-testid="osm-missing-hint">
                     <flux:callout.heading>{{ __('Dieses Event hat noch keinen Kartenort') }}</flux:callout.heading>
@@ -677,10 +736,20 @@ class extends Component
                 :country-code="$this->osmCountry"
             />
 
+            {{-- Issue #48: this field and the map picker above it were called "Ort" and
+                 "Ort auf der Karte" and carried the SAME placeholder, so nothing told the
+                 user which to use. The names are now a contrastive pair — auf der Karte
+                 vs als Text — where only the distinguishing word changes, and the
+                 placeholder shows the job a map pin cannot do rather than repeating an
+                 address the picker above already asks for.
+
+                 The picker's own copy is deliberately untouched: its placeholder IS an
+                 address because it feeds an OSM search, which is correct. The field at
+                 fault was this one, imitating a search box while being free text. --}}
             <flux:field>
-                <flux:label>{{ __('Ort') }}</flux:label>
-                <flux:input wire:model="location" placeholder="{{ __('z.B. Café Mustermann, Hauptstr. 1') }}"/>
-                <flux:description>{{ __('Wo findet das Event statt?') }}</flux:description>
+                <flux:label>{{ __('Ort als Text') }}</flux:label>
+                <flux:input wire:model="location" placeholder="{{ __('z.B. Hinterzimmer im Café Mustermann') }}"/>
+                <flux:description>{{ __('Freitext für Besucher. Auch Details, die ein Kartenpunkt nicht zeigt.') }}</flux:description>
                 <flux:error name="location"/>
             </flux:field>
 

--- a/resources/views/livewire/meetups/edit.blade.php
+++ b/resources/views/livewire/meetups/edit.blade.php
@@ -295,8 +295,8 @@ class extends Component
 
         // System fields
         $this->created_by = $this->meetup->created_by;
-        $this->created_at = $this->meetup->created_at?->format('Y-m-d H:i:s');
-        $this->updated_at = $this->meetup->updated_at?->format('Y-m-d H:i:s');
+        $this->created_at = $this->meetup->created_at?->asDateTime();
+        $this->updated_at = $this->meetup->updated_at?->asDateTime();
     }
 
     public function updateMeetup(): void

--- a/resources/views/livewire/meetups/landingpage-event.blade.php
+++ b/resources/views/livewire/meetups/landingpage-event.blade.php
@@ -184,7 +184,7 @@ class extends Component {
                 {{ $event->meetup->name }}
             </a>
             <span class="mx-2">/</span>
-            <span>{{ $event->start->format('d.m.Y') }}</span>
+            <span>{{ $event->start->asDate() }}</span>
         </flux:text>
     </div>
 

--- a/resources/views/livewire/services/index.blade.php
+++ b/resources/views/livewire/services/index.blade.php
@@ -175,7 +175,7 @@ class extends Component {
                                 <div class="flex items-center gap-1">
                                     <flux:icon.plus variant="micro" class="text-green-600 dark:text-green-400"/>
                                     <span
-                                        class="text-gray-600 dark:text-gray-400">{{ $service->created_at->format('d.m.Y') }}</span>
+                                        class="text-gray-600 dark:text-gray-400">{{ $service->created_at->asDateTime() }}</span>
                                 </div>
                             </flux:tooltip>
                             @if($service->created_at->ne($service->updated_at))
@@ -183,7 +183,7 @@ class extends Component {
                                     <div class="flex items-center gap-1">
                                         <flux:icon.pencil variant="micro" class="text-blue-600 dark:text-blue-400"/>
                                         <span
-                                            class="text-gray-600 dark:text-gray-400">{{ $service->updated_at->format('d.m.Y') }}</span>
+                                            class="text-gray-600 dark:text-gray-400">{{ $service->updated_at->asDateTime() }}</span>
                                     </div>
                                 </flux:tooltip>
                             @endif

--- a/resources/views/livewire/services/landingpage.blade.php
+++ b/resources/views/livewire/services/landingpage.blade.php
@@ -224,7 +224,7 @@ class extends Component {
                         <div class="text-gray-500 dark:text-gray-400 mb-1">{{ __('Erstellt am') }}</div>
                         <div class="flex items-center gap-1">
                             <flux:icon.plus variant="micro" class="text-green-600 dark:text-green-400"/>
-                            <span>{{ $service->created_at->format('d.m.Y H:i') }}</span>
+                            <span>{{ $service->created_at->asDateTime() }}</span>
                         </div>
                     </div>
 
@@ -234,7 +234,7 @@ class extends Component {
                             <div class="text-gray-500 dark:text-gray-400 mb-1">{{ __('Zuletzt aktualisiert') }}</div>
                             <div class="flex items-center gap-1">
                                 <flux:icon.pencil variant="micro" class="text-blue-600 dark:text-blue-400"/>
-                                <span>{{ $service->updated_at->format('d.m.Y H:i') }}</span>
+                                <span>{{ $service->updated_at->asDateTime() }}</span>
                             </div>
                         </div>
                     @endif

--- a/resources/views/livewire/settings/api-tokens.blade.php
+++ b/resources/views/livewire/settings/api-tokens.blade.php
@@ -143,7 +143,7 @@ class extends Component {
                                             <flux:badge size="sm" color="zinc">{{ __('Nie') }}</flux:badge>
                                         @endif
                                     </flux:table.cell>
-                                    <flux:table.cell>{{ $token->created_at->format('d.m.Y') }}</flux:table.cell>
+                                    <flux:table.cell>{{ $token->created_at->asDateTime() }}</flux:table.cell>
                                     <flux:table.cell align="end">
                                         <flux:tooltip :content="__('Widerrufen')">
                                             <flux:button variant="danger" size="sm" icon="trash"

--- a/resources/views/livewire/settings/link-identity.blade.php
+++ b/resources/views/livewire/settings/link-identity.blade.php
@@ -198,7 +198,7 @@ class extends Component {
             'name' => $u->name,
             'photo' => $u->profile_photo_url,
             'has_photo' => $u->profile_photo_path !== null,
-            'created_at' => optional($u->created_at)->format('d.m.Y'),
+            'created_at' => optional($u->created_at)->asDateTime(),
             'reputation' => (int) $u->reputation,
             /*
              * Nur noch `public_key` (P6). `lightning_address` und `lnurl` sind hier

--- a/tests/Feature/Lang/IsoDateFormatTest.php
+++ b/tests/Feature/Lang/IsoDateFormatTest.php
@@ -1,0 +1,849 @@
+<?php
+
+use App\Models\City;
+use App\Models\Country;
+use App\Models\Meetup;
+use App\Models\MeetupEvent;
+use App\Models\User;
+use App\Support\Carbon as PortalCarbon;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Facades\Date;
+
+/*
+|--------------------------------------------------------------------------
+| Dates are ISO 8601 in every locale, and in the visitor's own timezone
+|--------------------------------------------------------------------------
+|
+| Issue #48 (external usability report): App\Support\Carbon hardcoded
+| ->locale('de') in all four formatters, and AppServiceProvider binds that
+| class as the application's date implementation (Date::use()). Every date in
+| a nine-locale portal therefore rendered German — an English (US) visitor was
+| shown "16.09.2026 19:00 (EDT)" and "19. August 2026".
+|
+| The owner's decision: ISO 8601 in every locale, 24-hour time everywhere.
+|
+|   asDate()                  2026-10-08
+|   asTime()                  19:00                      (unchanged)
+|   asDateTime()              2026-10-08 19:00 (CEST)    (zone suffix kept)
+|
+| A fourth formatter, asDayNameAndMonthName(), was deleted rather than fixed —
+| see the note above the third section for why, and why no test replaces it.
+|
+| Two things this file does deliberately:
+|
+|   1. It asserts a PATTERN, never nine hardcoded per-locale strings. Nine
+|      hardcoded expectations are nine chances to write a bug down as an
+|      expectation. The single exception is the contract example from the
+|      issue itself, on one fixed instant in one fixed zone — that literal is
+|      the contract, and it is deterministic.
+|   2. It asserts on RENDERED responses as well as on the class. A unit test
+|      on App\Support\Carbon stays green while a Blade file bypasses it with
+|      its own ->format(), which is the second defect in this issue.
+|
+| Sibling file RenderedLocaleTest.php watches German *literals* on rendered
+| pages and explicitly excluded the date formatters ("separate defect,
+| separate owner"). This file is that separate owner.
+*/
+
+/**
+ * The formatters as they stood BEFORE issue #48 was fixed — copied verbatim
+ * from app/Support/Carbon.php at commit 336ccec, hardcoded ->locale('de') and
+ * all.
+ *
+ * This class is the calibration fixture. Every guard in this file has to be
+ * shown failing against the behaviour it was written to catch, and once the
+ * fix is in the tree there is nothing left in the repo to fail against — the
+ * old code is only in git history, which no test can reach. Keeping the old
+ * shape here, and binding it through Date::use() in the negative controls at
+ * the bottom, makes the proof permanent instead of a one-off run somebody has
+ * to remember.
+ *
+ * It is a fixture, never the app: production code is not touched, not even
+ * temporarily. Date::use() is re-applied by AppServiceProvider::register() on
+ * every test's app boot, so the binding does not leak past the test that sets
+ * it.
+ */
+class LegacyGermanCarbon extends CarbonImmutable
+{
+    public function asDate(): string
+    {
+        $dt = $this->timezone(config('app.user-timezone'))->locale('de');
+
+        return str($dt->day)->padLeft(2, '0').'. '.$dt->monthName.' '.$dt->year;
+    }
+
+    public function asTime(): string
+    {
+        return $this->timezone(config('app.user-timezone'))->locale('de')
+            ->format('H:i');
+    }
+
+    public function asDateTime(): string
+    {
+        $dt = $this->timezone(config('app.user-timezone'))->locale('de');
+
+        return sprintf('%s.%s.%s %s (%s)',
+            str($dt->day)->padLeft(2, '0'),
+            str($dt->month)->padLeft(2, '0'),
+            $dt->year,
+            $dt->format('H:i'),
+            $dt->timezoneAbbreviatedName
+        );
+    }
+}
+
+/**
+ * A formatter that emits perfect ISO 8601 but ignores
+ * config('app.user-timezone') and always renders the application default zone.
+ *
+ * This is the second calibration fixture, and it is the mutation the ISO
+ * pattern checks are blind to by construction: "2026-10-03 03:30 (CEST)"
+ * satisfies every shape assertion in this file while being the wrong instant
+ * for the visitor who reported the issue.
+ */
+class AppDefaultZoneCarbon extends CarbonImmutable
+{
+    private const APP_DEFAULT_ZONE = 'Europe/Berlin';
+
+    public function asDate(): string
+    {
+        return $this->timezone(self::APP_DEFAULT_ZONE)->format('Y-m-d');
+    }
+
+    public function asTime(): string
+    {
+        return $this->timezone(self::APP_DEFAULT_ZONE)->format('H:i');
+    }
+
+    public function asDateTime(): string
+    {
+        $dt = $this->timezone(self::APP_DEFAULT_ZONE);
+
+        return sprintf('%s (%s)', $dt->format('Y-m-d H:i'), $dt->timezoneAbbreviatedName);
+    }
+}
+
+/**
+ * asDate() — nothing but a numeric ISO 8601 calendar date.
+ */
+const ISO_DATE_PATTERN = '/^\d{4}-\d{2}-\d{2}$/';
+
+/**
+ * asDateTime() — the ISO date, 24-hour time, and the timezone label in
+ * parentheses. The label is kept on purpose (issue #48): a bare local time
+ * without its zone is what made the reporter mis-plan his evening.
+ */
+const ISO_DATE_TIME_PATTERN = '/^\d{4}-\d{2}-\d{2} \d{2}:\d{2} \([^()]+\)$/';
+
+/**
+ * asTime() — 24 hours, no am/pm, in every locale.
+ */
+const ISO_TIME_PATTERN = '/^\d{2}:\d{2}$/';
+
+/**
+ * A fixed instant, so the contract literals below need no "now".
+ *
+ * 2026-10-08 17:00 UTC is 19:00 in Europe/Berlin and 13:00 in
+ * America/Indiana/Indianapolis. Both zones are unambiguously on summer time
+ * that day (CEST runs to 2026-10-25, EDT to 2026-11-01), so neither literal
+ * depends on when this suite runs.
+ */
+const CONTRACT_INSTANT_UTC = '2026-10-08 17:00:00';
+
+/**
+ * The reporter's own timezone (issue #48).
+ *
+ * Chosen over a one-hour neighbour on purpose: six hours from Europe/Berlin
+ * means an implementation that silently skips the conversion cannot hide
+ * behind an off-by-one hour.
+ */
+const REPORTER_TIMEZONE = 'America/Indiana/Indianapolis';
+
+/**
+ * Every locale the portal ships, read from lang/*.json rather than from a
+ * list written down here — a locale added tomorrow is covered without anyone
+ * remembering this file.
+ *
+ * @return list<string>
+ */
+function portalLocales(): array
+{
+    $locales = array_map(
+        static fn (string $path): string => basename($path, '.json'),
+        glob(lang_path('*.json')) ?: []
+    );
+
+    sort($locales);
+
+    return $locales;
+}
+
+/**
+ * Full month and weekday names of $locale, in that locale's own spelling.
+ *
+ * Full forms only, no abbreviations: an abbreviation such as "Est" could
+ * collide with a timezone label and turn this into a matcher nobody trusts.
+ *
+ * @return list<string>
+ */
+function localizedDateNames(string $locale): array
+{
+    $names = [];
+
+    foreach (range(1, 12) as $month) {
+        $names[] = CarbonImmutable::create(2026, $month, 1, 0, 0, 0, 'UTC')->locale($locale)->monthName;
+    }
+
+    // 2026-03-01 is a Sunday, so seven consecutive days cover every weekday.
+    $week = CarbonImmutable::create(2026, 3, 1, 0, 0, 0, 'UTC');
+
+    foreach (range(0, 6) as $offset) {
+        $names[] = $week->addDays($offset)->locale($locale)->dayName;
+    }
+
+    return array_values(array_unique(array_filter($names)));
+}
+
+/**
+ * Month and weekday names of EVERY portal locale, in one list.
+ *
+ * The union is the point. Checking a date only against the names of the
+ * locale that produced it would miss precisely the reported defect: a German
+ * month name on an English page.
+ *
+ * @return list<string>
+ */
+function allLocalizedDateNames(): array
+{
+    $names = [];
+
+    foreach (portalLocales() as $locale) {
+        $names = array_merge($names, localizedDateNames($locale));
+    }
+
+    return array_values(array_unique($names));
+}
+
+/**
+ * Which of $names occur in $value, case-insensitively.
+ *
+ * @param  list<string>  $names
+ * @return list<string>
+ */
+function dateNameLeaks(string $value, array $names): array
+{
+    return array_values(array_filter(
+        $names,
+        static fn (string $name): bool => $name !== '' && mb_stripos($value, $name) !== false
+    ));
+}
+
+/**
+ * The part of an asDateTime() string in front of the timezone label.
+ *
+ * The label is not localized and is asserted separately; stripping it keeps
+ * the name check below free of false positives.
+ */
+function withoutZoneLabel(string $value): string
+{
+    return trim((string) preg_replace('/\s*\([^()]*\)\s*$/', '', $value));
+}
+
+/**
+ * The expected ISO date of $instant in $timezone, computed WITHOUT the code
+ * under test — plain PHP, so a wrong conversion in App\Support\Carbon cannot
+ * reproduce itself in the expectation.
+ */
+function zonedIsoDate(DateTimeInterface $instant, string $timezone): string
+{
+    return DateTimeImmutable::createFromInterface($instant)
+        ->setTimezone(new DateTimeZone($timezone))
+        ->format('Y-m-d');
+}
+
+/**
+ * As zonedIsoDate(), plus 24-hour time and the timezone label.
+ */
+function zonedIsoDateTime(DateTimeInterface $instant, string $timezone): string
+{
+    return DateTimeImmutable::createFromInterface($instant)
+        ->setTimezone(new DateTimeZone($timezone))
+        ->format('Y-m-d H:i (T)');
+}
+
+/**
+ * The shape a date had BEFORE this change: "08. Oktober 2026".
+ */
+function germanLongDate(DateTimeInterface $instant, string $timezone): string
+{
+    $local = CarbonImmutable::instance(
+        DateTimeImmutable::createFromInterface($instant)
+    )->timezone($timezone)->locale('de');
+
+    return $local->format('d').'. '.$local->monthName.' '.$local->format('Y');
+}
+
+/**
+ * expect($haystack)->toContain($needle, 'why it matters') does NOT attach a
+ * message: Pest's toContain() is variadic, so the second argument becomes a
+ * SECOND needle and the assertion quietly demands the message text be in the
+ * haystack as well. Measured while writing this file — four assertions failed
+ * with "To contain: The event page did not carry …" on pages that carried the
+ * date perfectly well. These two helpers keep the diagnostic message and the
+ * needle apart.
+ */
+function expectHtmlToContain(string $haystack, string $needle, string $message): void
+{
+    expect(str_contains($haystack, $needle))->toBeTrue($message);
+}
+
+function expectHtmlNotToContain(string $haystack, string $needle, string $message): void
+{
+    expect(str_contains($haystack, $needle))->toBeFalse($message);
+}
+
+/**
+ * Requests $url as a visitor of $locale and returns the body.
+ *
+ * Same mechanism as RenderedLocaleTest: the locale arrives through
+ * Accept-Language, which is the path DomainMiddleware takes for a first-time
+ * visitor and the path the reporter came in on. Tests\TestCase blanks
+ * Symfony's synthetic Accept-Language default, so this header is the only
+ * thing speaking. The getLocale() check is a positive control — without it a
+ * request that quietly stayed German would satisfy an "is ISO" assertion for
+ * the wrong reason.
+ */
+function renderForVisitor(object $case, string $url, string $locale): string
+{
+    $header = match ($locale) {
+        'en' => 'en-US,en;q=0.9',
+        'de' => 'de-DE,de;q=0.9',
+    };
+
+    $response = $case->withHeaders(['Accept-Language' => $header])->get($url);
+
+    $response->assertSuccessful();
+
+    expect(app()->getLocale())->toBe($locale, "Request to {$url} did not run under the '{$locale}' locale.");
+
+    return (string) $response->getContent();
+}
+
+beforeEach(function () {
+    $this->country = Country::factory()->create(['code' => 'de']);
+    $this->city = City::factory()->create(['country_id' => $this->country->id]);
+
+    $this->meetup = Meetup::factory()->create([
+        'city_id' => $this->city->id,
+        'name' => 'Bitcoin Meetup Testhausen',
+        'slug' => 'bitcoin-meetup-testhausen',
+        'intro' => 'A regular gathering for bitcoiners.',
+        'visible_on_map' => true,
+    ]);
+
+    /*
+     * 01:30 UTC, a month out. Two properties are load-bearing:
+     *
+     *   - it is in the future, so meetups.landingpage lists it at all
+     *     (the component filters on `start >= now()`);
+     *   - at 01:30 UTC the local CALENDAR DAY differs between Europe/Berlin
+     *     (03:30, same day) and the reporter's zone (21:30, day before). A
+     *     rendered date that ignores the visitor's timezone therefore fails
+     *     on the day, not only on the hour.
+     *
+     * The instant is fixed relative to now() rather than to a calendar date,
+     * so the test does not rot; every expectation is computed from it with
+     * plain PHP.
+     */
+    $this->eventStart = CarbonImmutable::now('UTC')->addDays(30)->setTime(1, 30);
+
+    $this->event = MeetupEvent::factory()->create([
+        'meetup_id' => $this->meetup->id,
+        'start' => $this->eventStart,
+        'location' => 'Main Street 1',
+        'description' => 'An evening about bitcoin.',
+        'recurrence_type' => null,
+    ]);
+
+    $this->meetupUrl = route('meetups.landingpage', ['country' => 'de', 'meetup' => $this->meetup->slug]);
+    $this->eventUrl = route('meetups.landingpage-event', [
+        'country' => 'de',
+        'meetup' => $this->meetup->slug,
+        'event' => $this->event->id,
+    ]);
+});
+
+/*
+|--------------------------------------------------------------------------
+| 1. The formatters emit ISO in every locale
+|--------------------------------------------------------------------------
+*/
+
+it('formats a date as ISO 8601 in every portal locale', function () {
+    config(['app.user-timezone' => 'Europe/Berlin']);
+
+    $locales = portalLocales();
+
+    // The floor belongs in an assertion, not in a comment: a glob that
+    // silently returns two files would make the loop below pass for free.
+    expect(count($locales))->toBeGreaterThanOrEqual(9, 'Fewer locale files than the nine the portal ships: '.implode(', ', $locales));
+    expect($locales)->toContain('de')->toContain('en');
+
+    $offenders = [];
+
+    foreach ($locales as $locale) {
+        app()->setLocale($locale);
+
+        $formatted = PortalCarbon::parse(CONTRACT_INSTANT_UTC, 'UTC')->asDate();
+
+        if (preg_match(ISO_DATE_PATTERN, $formatted) !== 1) {
+            $offenders[$locale] = $formatted;
+        }
+    }
+
+    expect($offenders)->toBe([], 'asDate() did not return YYYY-MM-DD in these locales.');
+});
+
+it('formats a date and time as ISO 8601 with a zone label in every portal locale', function () {
+    config(['app.user-timezone' => 'Europe/Berlin']);
+
+    $offenders = [];
+
+    foreach (portalLocales() as $locale) {
+        app()->setLocale($locale);
+
+        $formatted = PortalCarbon::parse(CONTRACT_INSTANT_UTC, 'UTC')->asDateTime();
+
+        if (preg_match(ISO_DATE_TIME_PATTERN, $formatted) !== 1) {
+            $offenders[$locale] = $formatted;
+        }
+    }
+
+    expect($offenders)->toBe([], 'asDateTime() did not return "YYYY-MM-DD HH:MM (ZONE)" in these locales.');
+});
+
+it('keeps time at 24 hours in every portal locale', function () {
+    config(['app.user-timezone' => 'Europe/Berlin']);
+
+    $offenders = [];
+
+    foreach (portalLocales() as $locale) {
+        app()->setLocale($locale);
+
+        $formatted = PortalCarbon::parse(CONTRACT_INSTANT_UTC, 'UTC')->asTime();
+
+        if (preg_match(ISO_TIME_PATTERN, $formatted) !== 1 || $formatted !== '19:00') {
+            $offenders[$locale] = $formatted;
+        }
+    }
+
+    expect($offenders)->toBe([], 'asTime() is no longer 24-hour "19:00" in these locales.');
+});
+
+/*
+|--------------------------------------------------------------------------
+| 2. No month or day name leaks into a numeric date, in any locale
+|--------------------------------------------------------------------------
+|
+| This is the actual regression class. It runs in both directions: a German
+| month name must not reach an English visitor (what was reported), and a
+| German visitor must not get "Oktober" back from asDate() either — ISO means
+| ISO for everyone.
+*/
+
+it('leaks no month or day name of any portal locale into a numeric date', function () {
+    config(['app.user-timezone' => 'Europe/Berlin']);
+
+    $names = allLocalizedDateNames();
+
+    // Positive control on the name list itself. If Carbon ever stops
+    // resolving these locales, $names would be empty and every check below
+    // would pass without looking at anything.
+    expect($names)->toContain('Oktober')->toContain('October')->toContain('Donnerstag');
+
+    $offenders = [];
+
+    foreach (portalLocales() as $locale) {
+        app()->setLocale($locale);
+
+        $instant = PortalCarbon::parse(CONTRACT_INSTANT_UTC, 'UTC');
+
+        $date = $instant->asDate();
+        $dateTime = withoutZoneLabel($instant->asDateTime());
+
+        foreach (['asDate' => $date, 'asDateTime' => $dateTime] as $method => $value) {
+            $leaks = dateNameLeaks($value, $names);
+
+            if ($leaks !== []) {
+                $offenders["{$locale}/{$method}"] = $value.' → '.implode(', ', $leaks);
+            }
+
+            // Belt to the braces: the numeric part of a date carries no
+            // letters at all, so even a name Carbon does not know is caught.
+            if (preg_match('/\p{L}/u', $value) === 1 && ! isset($offenders["{$locale}/{$method}"])) {
+                $offenders["{$locale}/{$method}"] = $value.' → contains letters';
+            }
+        }
+    }
+
+    expect($offenders)->toBe([], 'Month or day names reached a numeric date.');
+});
+
+it('emits the exact shapes the issue #48 contract names', function () {
+    config(['app.user-timezone' => 'Europe/Berlin']);
+    app()->setLocale('en');
+
+    $instant = PortalCarbon::parse(CONTRACT_INSTANT_UTC, 'UTC');
+
+    // One fixed instant, one fixed zone, both on summer time that day. These
+    // three literals ARE the contract from the issue, not a per-locale guess.
+    expect($instant->asDate())->toBe('2026-10-08');
+    expect($instant->asTime())->toBe('19:00');
+    expect($instant->asDateTime())->toBe('2026-10-08 19:00 (CEST)');
+});
+
+/*
+|--------------------------------------------------------------------------
+| 3. There is no fourth formatter
+|--------------------------------------------------------------------------
+|
+| asDayNameAndMonthName() was the one formatter that kept day and month names,
+| and the contract handed to this file described it as following the active
+| locale. It does not exist any more, by a decision confirmed on 2026-09-03:
+| a repo-wide grep found exactly one hit, its own definition — no blade, no
+| controller, no test, no dynamic call. It was also bilingual by construction,
+| interpolating a German dayName and monthName into the literal English frame
+| '%s, %s. week of %s [%s]', which could not be repaired without a new
+| lang/*.json key. Deleting dead code beat translating it for zero callers.
+|
+| Nothing is asserted here on purpose. This note exists so the gap between the
+| four-method contract and the three methods below reads as a decision rather
+| than as an omission.
+*/
+
+/*
+|--------------------------------------------------------------------------
+| 4. Rendered, not just unit-level
+|--------------------------------------------------------------------------
+|
+| A unit test on App\Support\Carbon passes even when a view bypasses it with
+| its own ->format(). Both assertions below run against a real response.
+*/
+
+it('renders an ISO date on the meetup landing page', function (string $locale) {
+    $html = renderForVisitor($this, $this->meetupUrl, $locale);
+
+    $expected = zonedIsoDate($this->eventStart, 'Europe/Berlin');
+
+    // Positive: the page really did render the date region.
+    expectHtmlToContain($html, $expected, "The meetup landing page did not carry the ISO date {$expected} for a '{$locale}' visitor.");
+
+    // Negative: the shape it carried before this change is gone. Both forms,
+    // because the pre-change asDate() produced the long one and asDateTime()
+    // the dotted one.
+    expect($html)->not->toContain(germanLongDate($this->eventStart, 'Europe/Berlin'));
+    expect($html)->not->toContain(
+        DateTimeImmutable::createFromInterface($this->eventStart)
+            ->setTimezone(new DateTimeZone('Europe/Berlin'))->format('d.m.Y')
+    );
+})->with(['en', 'de']);
+
+it('renders an ISO date and time on the meetup event page', function (string $locale) {
+    $html = renderForVisitor($this, $this->eventUrl, $locale);
+
+    $expectedDateTime = zonedIsoDateTime($this->eventStart, 'Europe/Berlin');
+    $expectedDate = zonedIsoDate($this->eventStart, 'Europe/Berlin');
+
+    expectHtmlToContain($html, $expectedDateTime, "The event page did not carry \"{$expectedDateTime}\" for a '{$locale}' visitor.");
+    expectHtmlToContain($html, $expectedDate, "The event page did not carry the ISO date {$expectedDate} for a '{$locale}' visitor.");
+
+    expect($html)->not->toContain(germanLongDate($this->eventStart, 'Europe/Berlin'));
+    expect($html)->not->toContain(
+        DateTimeImmutable::createFromInterface($this->eventStart)
+            ->setTimezone(new DateTimeZone('Europe/Berlin'))->format('d.m.Y')
+    );
+})->with(['en', 'de']);
+
+/*
+|--------------------------------------------------------------------------
+| 5. The visitor's own timezone is visible, and named
+|--------------------------------------------------------------------------
+*/
+
+it('converts to the configured user timezone and names it', function () {
+    app()->setLocale('en');
+
+    config(['app.user-timezone' => 'Europe/Berlin']);
+    $berlin = PortalCarbon::parse(CONTRACT_INSTANT_UTC, 'UTC')->asDateTime();
+
+    config(['app.user-timezone' => REPORTER_TIMEZONE]);
+    $indianapolis = PortalCarbon::parse(CONTRACT_INSTANT_UTC, 'UTC')->asDateTime();
+
+    expect($berlin)->toBe('2026-10-08 19:00 (CEST)');
+    expect($indianapolis)->toBe('2026-10-08 13:00 (EDT)');
+
+    // The two must not be the same string. Without this, an implementation
+    // that dropped the conversion entirely could still satisfy one of the
+    // literals above if the fixture zones ever converged.
+    expect($indianapolis)->not->toBe($berlin);
+
+    config(['app.user-timezone' => REPORTER_TIMEZONE]);
+    expect(PortalCarbon::parse(CONTRACT_INSTANT_UTC, 'UTC')->asTime())->toBe('13:00');
+});
+
+it('renders the event page in the timezone each visitor configured, not the app default', function () {
+    /*
+     * One stored instant, one page, two visitors who differ in nothing but
+     * their users.timezone column. That is what makes this a measurement of
+     * the conversion rather than of a constant: a page that ignored the column
+     * would hand both of them the same string, and the two visitors' own
+     * strings are asserted absent from each other's response.
+     *
+     * config('app.user-timezone') is the authoritative source, written by
+     * SetTimezone from users.timezone. PHP's own default zone stays UTC
+     * throughout — date_default_timezone_set() ran at bootstrap, long before
+     * any middleware — so ->timezone(config('app.user-timezone')) is the only
+     * thing that converts anything.
+     *
+     * Measured after a real request with an Indianapolis user, rather than
+     * assumed: date_default_timezone_get() = 'UTC', while config('app.timezone')
+     * = 'America/Indiana/Indianapolis'. SetTimezone.php:20 writes that key too;
+     * it is simply not what the formatters read, and not what keeps PHP on UTC.
+     *
+     * Auckland sits on the other side of the app default from Indianapolis, so
+     * "the visitor's date is one day behind" cannot be satisfied by a fixed
+     * offset in the wrong direction.
+     */
+    $visitors = [
+        // At 01:30 UTC the reporter's zone (UTC-4/-5) is on the PREVIOUS
+        // calendar day, so his date fails on the day and not merely on the
+        // hour. Auckland (UTC+12/+13) is on the same day as Berlin; it is here
+        // for the opposite direction of the offset, and its date is therefore
+        // asserted to match the app default's while its time does not.
+        REPORTER_TIMEZONE => ['user' => null, 'sameCalendarDayAsAppDefault' => false],
+        'Pacific/Auckland' => ['user' => null, 'sameCalendarDayAsAppDefault' => true],
+    ];
+
+    $appDefault = zonedIsoDateTime($this->eventStart, 'Europe/Berlin');
+    $rendered = [];
+
+    foreach ($visitors as $timezone => $expectation) {
+        $visitor = User::factory()->create(['timezone' => $timezone]);
+        $expected = zonedIsoDateTime($this->eventStart, $timezone);
+
+        expect($expected)->not->toBe($appDefault);
+        expect(zonedIsoDate($this->eventStart, $timezone) === zonedIsoDate($this->eventStart, 'Europe/Berlin'))
+            ->toBe($expectation['sameCalendarDayAsAppDefault'], "The fixture instant no longer places {$timezone} where beforeEach() says it does.");
+
+        $html = (string) $this->actingAs($visitor)
+            ->withHeaders(['Accept-Language' => 'en-US,en;q=0.9'])
+            ->get($this->eventUrl)
+            ->assertSuccessful()
+            ->getContent();
+
+        expectHtmlToContain($html, $expected, "The event page did not show the {$timezone} visitor their own time \"{$expected}\".");
+        expectHtmlNotToContain($html, $appDefault, "The event page showed the app default zone (\"{$appDefault}\") to a visitor who configured {$timezone}.");
+
+        $rendered[$timezone] = $html;
+    }
+
+    // Cross-check: neither visitor was served the other one's time.
+    expectHtmlNotToContain(
+        $rendered[REPORTER_TIMEZONE],
+        zonedIsoDateTime($this->eventStart, 'Pacific/Auckland'),
+        'The Indianapolis visitor was served the Auckland time — the output does not track users.timezone.'
+    );
+    expectHtmlNotToContain(
+        $rendered['Pacific/Auckland'],
+        zonedIsoDateTime($this->eventStart, REPORTER_TIMEZONE),
+        'The Auckland visitor was served the Indianapolis time — the output does not track users.timezone.'
+    );
+});
+
+it('shows the created and updated timestamps of the admin form in the visitor timezone, with the zone named', function () {
+    $editor = User::factory()->create(['timezone' => REPORTER_TIMEZONE]);
+
+    // promoteLeader(), not created_by: `created_by` is not fillable on Meetup,
+    // so an update() of it no-ops and the page answers 403. MeetupPolicy@update
+    // accepts a leader on the meetup_user pivot.
+    $this->meetup->promoteLeader($editor);
+
+    $this->actingAs($editor);
+
+    // A real request, not Livewire::test(): the component test runs without
+    // middleware, so SetTimezone would never fire and app.user-timezone would
+    // stay on the config default. That would prove nothing about a visitor.
+    $response = $this->get(route('meetups.edit', ['country' => 'de', 'meetup' => $this->meetup->id]));
+    $response->assertSuccessful();
+
+    $html = (string) $response->getContent();
+
+    $createdAt = $this->meetup->fresh()->created_at;
+    $expected = zonedIsoDateTime($createdAt, REPORTER_TIMEZONE);
+    $appDefault = zonedIsoDateTime($createdAt, 'Europe/Berlin');
+
+    // Positive control: a fixture created "just now" would render the same
+    // string in both zones if the two happened to agree on minute and label.
+    expect($expected)->not->toBe($appDefault);
+
+    expectHtmlToContain($html, $expected, "The edit form did not show created_at as \"{$expected}\".");
+    expectHtmlNotToContain($html, $appDefault, "The edit form showed created_at in the app default zone (\"{$appDefault}\").");
+});
+
+/*
+|--------------------------------------------------------------------------
+| 6. Calibration — the assertions above must be able to fail
+|--------------------------------------------------------------------------
+|
+| Written against fixtures rather than against the app, so it survives the
+| fix. Once App\Support\Carbon emits ISO, every other test in this file goes
+| green and nothing left in the repo would show that they ever caught
+| anything. This one keeps the old shapes on file and proves the matchers
+| still reject them.
+|
+| The strings are the ones issue #48 reported verbatim.
+*/
+
+it('rejects the German shapes this suite was written against', function () {
+    $names = allLocalizedDateNames();
+
+    // "19. August 2026" — the pre-change asDate().
+    expect(preg_match(ISO_DATE_PATTERN, '19. August 2026'))->toBe(0);
+    expect(dateNameLeaks('19. August 2026', $names))->toContain('August');
+
+    // "08. Oktober 2026" — same shape, a month whose German spelling differs
+    // from the English one.
+    expect(preg_match(ISO_DATE_PATTERN, '08. Oktober 2026'))->toBe(0);
+    expect(dateNameLeaks('08. Oktober 2026', $names))->toContain('Oktober');
+
+    // "16.09.2026 19:00 (EDT)" — the pre-change asDateTime(), quoted from the
+    // report. Numeric, so the name check is blind to it; the pattern is not.
+    expect(preg_match(ISO_DATE_TIME_PATTERN, '16.09.2026 19:00 (EDT)'))->toBe(0);
+    expect(dateNameLeaks(withoutZoneLabel('16.09.2026 19:00 (EDT)'), $names))->toBe([]);
+
+    // A correct ISO date and time must pass all of it, or the matchers above
+    // are simply rejecting everything.
+    expect(preg_match(ISO_DATE_PATTERN, '2026-10-08'))->toBe(1);
+    expect(preg_match(ISO_DATE_TIME_PATTERN, '2026-10-08 19:00 (CEST)'))->toBe(1);
+    expect(preg_match(ISO_TIME_PATTERN, '19:00'))->toBe(1);
+    expect(dateNameLeaks(withoutZoneLabel('2026-10-08 19:00 (CEST)'), $names))->toBe([]);
+
+    // Both a day and a month name in one string are reported, in order, so a
+    // failure names every leak rather than the first one.
+    expect(dateNameLeaks('Donnerstag, 08. Oktober 2026', ['Donnerstag', 'Oktober']))
+        ->toBe(['Donnerstag', 'Oktober']);
+
+    // 12-hour time must not pass for 24-hour time.
+    expect(preg_match(ISO_TIME_PATTERN, '7:00 PM'))->toBe(0);
+});
+
+it('fails its own locale checks against the pre-issue-48 formatter', function () {
+    config(['app.user-timezone' => 'Europe/Berlin']);
+
+    $names = allLocalizedDateNames();
+    $survivors = [];
+
+    foreach (portalLocales() as $locale) {
+        app()->setLocale($locale);
+
+        $legacy = LegacyGermanCarbon::parse(CONTRACT_INSTANT_UTC, 'UTC');
+
+        // Every locale must fail, and fail for the reported reason: the shape
+        // is not ISO, and a German month name sits inside a numeric date.
+        if (preg_match(ISO_DATE_PATTERN, $legacy->asDate()) !== 0) {
+            $survivors["{$locale}/asDate/pattern"] = $legacy->asDate();
+        }
+
+        if (dateNameLeaks($legacy->asDate(), $names) === []) {
+            $survivors["{$locale}/asDate/names"] = $legacy->asDate();
+        }
+
+        if (preg_match(ISO_DATE_TIME_PATTERN, $legacy->asDateTime()) !== 0) {
+            $survivors["{$locale}/asDateTime/pattern"] = $legacy->asDateTime();
+        }
+
+        if (dateNameLeaks(withoutZoneLabel($legacy->asDateTime()), $names) !== []) {
+            // The old asDateTime() was numeric ("16.09.2026 19:00 (EDT)"), so
+            // the NAME check is blind to it by design and only the pattern
+            // catches it. Recorded as an expectation, not left to chance: if a
+            // name ever did appear here, the two checks would no longer be
+            // testing what this file says they test.
+            $survivors["{$locale}/asDateTime/names"] = $legacy->asDateTime();
+        }
+    }
+
+    expect($survivors)->toBe([], 'These checks stayed silent on the old German formatter — they cannot be catching the regression they were written for.');
+
+    // asTime() is the one formatter issue #48 leaves unchanged. Stated here so
+    // the absence of a legacy check above is a decision on the record and not
+    // an omission.
+    app()->setLocale('en');
+    expect(LegacyGermanCarbon::parse(CONTRACT_INSTANT_UTC, 'UTC')->asTime())
+        ->toBe(PortalCarbon::parse(CONTRACT_INSTANT_UTC, 'UTC')->asTime());
+});
+
+it('fails its own page checks against the pre-issue-48 formatter', function (string $url) {
+    /*
+     * The rendered guards are the ones that could pass for the wrong reason —
+     * a page that never printed a date satisfies "no German date" for free.
+     * Binding the old formatter puts the German shape back on the real page
+     * and shows both directions of the assertion moving.
+     */
+    Date::use(LegacyGermanCarbon::class);
+
+    $html = renderForVisitor($this, $this->{$url}, 'en');
+
+    $isoDate = zonedIsoDate($this->eventStart, 'Europe/Berlin');
+    $germanLong = germanLongDate($this->eventStart, 'Europe/Berlin');
+
+    expectHtmlNotToContain($html, $isoDate, "The old formatter still rendered the ISO date {$isoDate} — the positive assertion in the real test is not what makes it pass.");
+    expectHtmlToContain($html, $germanLong, "The old formatter did not put \"{$germanLong}\" on the page — the negative assertion in the real test watches for a shape this page never had.");
+
+    /*
+     * The same run is the proof for the sibling guard: with ->locale('de')
+     * back, a German MONTH NAME reaches the page as a whole word, which is
+     * what RenderedLocaleTest's RENDERED_GERMAN_MONTH_NAMES entries watch for.
+     * That list carries only the months English spells differently, so the
+     * name asserted here is not always one of them — but a month name on the
+     * page is the condition all of them share.
+     */
+    $germanMonth = CarbonImmutable::instance(DateTimeImmutable::createFromInterface($this->eventStart))
+        ->timezone('Europe/Berlin')->locale('de')->monthName;
+
+    expectHtmlToContain($html, $germanMonth, "A German month name did not reach the page under the old formatter, so the month-name guard in RenderedLocaleTest watches for something this page cannot produce ({$germanMonth}).");
+})->with([
+    'meetup landing page' => 'meetupUrl',
+    'meetup event page' => 'eventUrl',
+]);
+
+it('fails its own timezone checks against a formatter that skips the conversion', function () {
+    /*
+     * The ISO shape assertions cannot see this mutation — AppDefaultZoneCarbon
+     * emits flawless ISO. Only the two timezone tests can, so they are the ones
+     * that have to be shown falling.
+     */
+    $reporter = User::factory()->create(['timezone' => REPORTER_TIMEZONE]);
+    $this->meetup->promoteLeader($reporter);
+    $this->actingAs($reporter);
+
+    Date::use(AppDefaultZoneCarbon::class);
+
+    $reporterTime = zonedIsoDateTime($this->eventStart, REPORTER_TIMEZONE);
+    $appDefault = zonedIsoDateTime($this->eventStart, 'Europe/Berlin');
+
+    $eventHtml = (string) $this->withHeaders(['Accept-Language' => 'en-US,en;q=0.9'])
+        ->get($this->eventUrl)->assertSuccessful()->getContent();
+
+    expectHtmlNotToContain($eventHtml, $reporterTime, "A formatter that ignores the visitor timezone still produced \"{$reporterTime}\" — the event-page timezone test cannot be measuring the conversion.");
+    expectHtmlToContain($eventHtml, $appDefault, "The page did not fall back to the app default zone (\"{$appDefault}\"), so the negative half of the event-page timezone test watches for something unreachable.");
+
+    // Same mutation, the admin form — a second rendering path with its own
+    // assertion, so it needs its own proof.
+    $createdAt = $this->meetup->fresh()->created_at;
+
+    $editHtml = (string) $this->get(route('meetups.edit', ['country' => 'de', 'meetup' => $this->meetup->id]))
+        ->assertSuccessful()->getContent();
+
+    expectHtmlNotToContain($editHtml, zonedIsoDateTime($createdAt, REPORTER_TIMEZONE), 'The edit form still showed created_at in the visitor timezone under a formatter that ignores it.');
+    expectHtmlToContain($editHtml, zonedIsoDateTime($createdAt, 'Europe/Berlin'), 'The edit form did not show created_at in the app default zone under a formatter that ignores the visitor timezone.');
+});

--- a/tests/Feature/Lang/RenderedLocaleTest.php
+++ b/tests/Feature/Lang/RenderedLocaleTest.php
@@ -7,7 +7,9 @@ use App\Models\CourseEvent;
 use App\Models\Lecturer;
 use App\Models\Meetup;
 use App\Models\MeetupEvent;
+use Carbon\CarbonImmutable;
 use Illuminate\Support\Facades\Blade;
+use Illuminate\Support\Facades\Date;
 
 /*
 |--------------------------------------------------------------------------
@@ -33,19 +35,100 @@ use Illuminate\Support\Facades\Blade;
 | in this file that can pass without a page having been rendered is the wrong
 | test.
 |
-| Known and deliberately NOT asserted: App\Support\Carbon::asDate() and its
-| siblings hardcode ->locale('de'), so month and weekday names render in
-| German for every visitor ("05. Januar 2027"). Separate defect, separate
-| owner; putting it in the list below would leave this guard permanently red,
-| and a permanently red guard gets switched off.
+| Dates USED to be excluded here: App\Support\Carbon::asDate() and its
+| siblings hardcoded ->locale('de'), so month and weekday names rendered in
+| German for every visitor ("05. Januar 2027"). Listing them would have left
+| this guard permanently red, and a permanently red guard gets switched off.
+|
+| That justification expired on 2026-09-03 with issue #48: every formatter now
+| emits ISO 8601 ("2027-01-05") in every locale, so no month name may appear
+| in a date on any page, in any language. The German month names are therefore
+| in the watch list below — a reintroduced ->locale('de') puts "Oktober"
+| straight onto an English page and this guard fires.
+|
+| The SHAPE of a date is not this file's business; tests/Feature/Lang/
+| IsoDateFormatTest.php owns that, including the timezone conversion and the
+| per-locale pattern. This file only watches for German words on an English
+| page, and a month name is one.
 */
 
 /**
- * The German literals that were found in English screenshots on 2026-09-03.
+ * German month names that cannot also be read as English.
+ *
+ * April, August, September and November are deliberately absent: they are
+ * spelled identically in English, so watching for them would fire on
+ * legitimate English output and the guard would be deleted rather than fixed.
+ *
+ * Weekday names are absent for a different reason — "Montag" and its siblings
+ * turn up in ordinary German prose (recurrence wording, opening hours) far
+ * more readily than a month name does, and the negative control below asserts
+ * an EXACT word list per page, which such a word would have to be carried in
+ * forever.
+ *
+ * Under ISO 8601 (issue #48) no date carries a month name in any locale, so
+ * while the fix holds, none of these can appear on any page and the four
+ * guards below pass them for free. That is precisely how this list was
+ * decoration for one round: it needs the page-level negative control at the
+ * bottom of this file, which binds the pre-#48 formatter and requires the
+ * matcher to find the month again, plus the pinned fixture date that keeps a
+ * WATCHED month on the page whatever day the suite runs.
  *
  * @var list<string>
  */
-const RENDERED_GERMAN_LITERALS = ['Uhr', 'Webseite'];
+const RENDERED_GERMAN_MONTH_NAMES = ['Januar', 'Februar', 'März', 'Mai', 'Juni', 'Juli', 'Oktober', 'Dezember'];
+
+/**
+ * The German literals that were found in English screenshots on 2026-09-03,
+ * plus the month names that issue #48 made watchable (see above).
+ *
+ * @var list<string>
+ */
+const RENDERED_GERMAN_LITERALS = ['Uhr', 'Webseite', ...RENDERED_GERMAN_MONTH_NAMES];
+
+/**
+ * The date formatter as it stood before issue #48 — hardcoded ->locale('de'),
+ * copied from app/Support/Carbon.php at commit 336ccec.
+ *
+ * Bound through Date::use() in the negative control at the bottom, it puts a
+ * German month name back onto the real pages, which is the only honest way to
+ * show that the month names above are watched rather than merely listed. The
+ * app is never touched, not even briefly: app/ and resources/ belong to
+ * another author this round.
+ *
+ * IsoDateFormatTest carries the same fixture under its own name. Duplicated on
+ * purpose rather than shared: a test file that is run alone
+ * (`pest tests/Feature/Lang/RenderedLocaleTest.php`) does not have the other
+ * file's declarations, and a guard that fatals depending on how the suite was
+ * invoked is worse than twenty duplicated lines.
+ */
+class PreIsoGermanDate extends CarbonImmutable
+{
+    public function asDate(): string
+    {
+        $dt = $this->timezone(config('app.user-timezone'))->locale('de');
+
+        return str($dt->day)->padLeft(2, '0').'. '.$dt->monthName.' '.$dt->year;
+    }
+
+    public function asTime(): string
+    {
+        return $this->timezone(config('app.user-timezone'))->locale('de')
+            ->format('H:i');
+    }
+
+    public function asDateTime(): string
+    {
+        $dt = $this->timezone(config('app.user-timezone'))->locale('de');
+
+        return sprintf('%s.%s.%s %s (%s)',
+            str($dt->day)->padLeft(2, '0'),
+            str($dt->month)->padLeft(2, '0'),
+            $dt->year,
+            $dt->format('H:i'),
+            $dt->timezoneAbbreviatedName
+        );
+    }
+}
 
 /**
  * Returns those of $words that occur in $html as WHOLE words.
@@ -74,6 +157,43 @@ function renderedGermanWords(string $html, array $words): array
             $html
         ) === 1
     ));
+}
+
+/**
+ * The date these fixtures use, pinned to a month this guard actually watches.
+ *
+ * `now()->addDays(7)` was here until 2026-09-04 and made the month-name half
+ * of the guard calendar-dependent: on 2026-09-03 the fixture fell on
+ * 2026-09-10, whose German month name is "September" — one of the four names
+ * excluded for being spelled the same in English. Measured by the reviewer
+ * with App\Support\Carbon genuinely reverted: all seven tests in this file
+ * passed, and the same page with the event forced into October failed. A guard
+ * that is silent for four months of the year, including the day it was
+ * written, is decoration.
+ *
+ * So the month is chosen, not inherited: the 15th of the next month whose
+ * German name is in RENDERED_GERMAN_MONTH_NAMES, always in the future — the
+ * meetup landing page lists only `start >= now()`, and an event that dropped
+ * out of the list would take the guard with it.
+ *
+ * The horizon is at most 98 days, measured over a thousand consecutive days
+ * rather than reasoned about; the worst case is 9–14 July, where the search
+ * starts at 15 August and has to step over both excluded summer names. The
+ * test at the bottom of this file holds all three properties for every
+ * calendar day, so this paragraph cannot quietly go stale.
+ */
+function watchedMonthFixtureDate(): CarbonImmutable
+{
+    $candidate = CarbonImmutable::now()->addDays(7);
+
+    // Past the 15th, the 15th of THIS month would be in the past.
+    $candidate = $candidate->day > 15 ? $candidate->addMonth()->day(15) : $candidate->day(15);
+
+    while (! in_array($candidate->locale('de')->monthName, RENDERED_GERMAN_MONTH_NAMES, true)) {
+        $candidate = $candidate->addMonth();
+    }
+
+    return $candidate->startOfDay();
 }
 
 /**
@@ -109,6 +229,8 @@ beforeEach(function () {
     $this->country = Country::factory()->create(['code' => 'de']);
     $this->city = City::factory()->create(['country_id' => $this->country->id]);
 
+    $this->fixtureDate = watchedMonthFixtureDate();
+
     // Every free-text field these pages echo is set explicitly. The factories
     // fill them from fake(), and a random German paragraph is exactly the kind
     // of input that makes a text-matching guard flap.
@@ -123,7 +245,7 @@ beforeEach(function () {
 
     $this->event = MeetupEvent::factory()->create([
         'meetup_id' => $this->meetup->id,
-        'start' => now()->addDays(7)->setTime(19, 30),
+        'start' => $this->fixtureDate->setTime(19, 30),
         'location' => 'Main Street 1',
         'description' => 'An evening about bitcoin.',
         'link' => 'https://example.com/event',
@@ -139,8 +261,8 @@ beforeEach(function () {
     CourseEvent::factory()->create([
         'course_id' => $this->course->id,
         'city_id' => $this->city->id,
-        'from' => now()->addDays(7)->setTime(18, 0),
-        'to' => now()->addDays(7)->setTime(20, 0),
+        'from' => $this->fixtureDate->setTime(18, 0),
+        'to' => $this->fixtureDate->setTime(20, 0),
         'location' => 'Main Street 1',
         'link' => 'https://example.com/course-event',
     ]);
@@ -232,4 +354,100 @@ it('flags a whole German word in rendered output and spares English words that c
     );
 
     expect(renderedGermanWords($html, ['Uhr', 'Webseite', 'Serie']))->toBe(['Uhr']);
+});
+
+/*
+|--------------------------------------------------------------------------
+| Negative control for the month names — on a REAL page, not on a fixture
+|--------------------------------------------------------------------------
+|
+| The four guards above cannot demonstrate the month half of the list: while
+| dates are ISO, no page carries a month name, so those eight entries pass for
+| free on every run. The reviewer's measurement of 2026-09-04 showed what that
+| is worth — with App\Support\Carbon reverted for real, this whole file stayed
+| green, because the fixture happened to fall in September.
+|
+| So the regression is reproduced here instead: the pre-#48 formatter is bound
+| over the same page and the same matcher must now find the month.
+*/
+it('pins the fixture into a watched month and into the future, on every calendar day', function () {
+    /*
+     * The defect this replaced was a fixture that happened to be fine on the
+     * day it was written. Asserting the pinning for TODAY only would repeat
+     * exactly that mistake, so every day of a leap year and the two years
+     * after it is walked. Three properties, all of them load-bearing:
+     * the month must be one the guard watches, the date must stay in the
+     * future (the landing page lists `start >= now()` and would otherwise drop
+     * the event, taking the guard with it), and the horizon must stay short
+     * enough that the fixture is not silently a year away.
+     */
+    $offenders = [];
+    $longestHorizonDays = 0;
+
+    try {
+        $firstDay = CarbonImmutable::create(2024, 1, 1, 12, 0, 0);
+
+        for ($offset = 0; $offset < 1000; $offset++) {
+            $today = $firstDay->addDays($offset);
+            CarbonImmutable::setTestNow($today);
+
+            $fixture = watchedMonthFixtureDate();
+            $germanMonth = $fixture->locale('de')->monthName;
+            $horizonDays = (int) $today->startOfDay()->diffInDays($fixture);
+            $longestHorizonDays = max($longestHorizonDays, $horizonDays);
+
+            $offenders[$today->toDateString()] = match (true) {
+                ! in_array($germanMonth, RENDERED_GERMAN_MONTH_NAMES, true) => "excluded month {$germanMonth}",
+                $fixture->lessThanOrEqualTo($today) => "not in the future: {$fixture->toDateString()}",
+                default => null,
+            };
+        }
+    } finally {
+        CarbonImmutable::setTestNow();
+    }
+
+    expect(array_filter($offenders))->toBe([], 'watchedMonthFixtureDate() does not hold on these days.');
+
+    /*
+     * The horizon is asserted rather than described, because the first version
+     * of the docblock above got it wrong: it claimed "at most two months",
+     * and this loop measured 98 days. The worst case is the 9th to the 14th of
+     * July — past the 15th of July, so the search starts at 15 August, and
+     * August and September are both excluded names.
+     */
+    expect($longestHorizonDays)->toBe(98, 'The fixture horizon moved; the docblock above states 98 days.');
+});
+
+it('finds a German month name on the English page once the pre-issue-48 formatter is bound', function () {
+    Date::use(PreIsoGermanDate::class);
+
+    $watchedMonth = $this->fixtureDate->locale('de')->monthName;
+
+    // Positive control on the pinning, not on the page: if the fixture date
+    // ever slid back into an excluded month, the assertion below would be
+    // unreachable and this control would go quiet along with the guard.
+    expect(RENDERED_GERMAN_MONTH_NAMES)->toContain($watchedMonth);
+
+    $html = renderAsVisitor($this, $this->meetupUrl, 'en');
+
+    expect(renderedGermanWords($html, RENDERED_GERMAN_LITERALS))
+        ->toContain($watchedMonth);
+});
+
+/*
+ * Matcher-level calibration for the month names, kept alongside the page-level
+ * control above because it pins down the boundary behaviour the page cannot
+ * exercise: the reason April, August, September and November are absent from
+ * the list is that an English page legitimately printing "August" must not
+ * trip a German-word guard.
+ */
+it('flags a German month name in a date and spares the months English spells the same way', function () {
+    $germanDate = Blade::render('<p>08. Oktober 2026</p><p>05. Januar 2027</p><p>01. März 2026</p>');
+
+    expect(renderedGermanWords($germanDate, RENDERED_GERMAN_LITERALS))
+        ->toBe(['Januar', 'März', 'Oktober']);
+
+    $englishDate = Blade::render('<p>August 8, 2026</p><p>September 5</p><p>2026-10-08</p>');
+
+    expect(renderedGermanWords($englishDate, RENDERED_GERMAN_LITERALS))->toBe([]);
 });

--- a/tests/Feature/Livewire/Forms/EventDateTimeFormTest.php
+++ b/tests/Feature/Livewire/Forms/EventDateTimeFormTest.php
@@ -1,0 +1,453 @@
+<?php
+
+use App\Enums\RecurrenceType;
+use App\Models\City;
+use App\Models\Course;
+use App\Models\CourseEvent;
+use App\Models\Meetup;
+use App\Models\MeetupEvent;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Facades\DB;
+use Livewire\Livewire;
+
+/*
+|--------------------------------------------------------------------------
+| What the date pickers STORE, and what the series preview DISPLAYS
+|--------------------------------------------------------------------------
+|
+| Two behaviours from the issue #48 fix, both proven by hand and neither
+| guarded until now.
+|
+| The owner's acceptance condition is the first one, in his words:
+| "hauptsache der datepicker speichert richtig in die DB (welche UTC ist)".
+| The rule he settled on afterwards draws the line this file is organised
+| around: a picker is an INPUT CONTROL, ISO applies to DATA DISPLAY. So
+| nothing here asserts what a picker shows — only what it stores, and what
+| the preview renders. That is also why the brief experiment of pinning the
+| Flux pickers to lt-LT (to force an ISO display) could be reverted without
+| loss: the stored instant never depended on it, and the test below pins that
+| independence so the question stays permanently harmless.
+|
+| Placed here rather than in tests/Feature/Meetups or tests/Feature/Courses
+| because it covers BOTH create-edit-events components, which live in those
+| two different directories; and because storage and preview belong in one
+| file — they are the two halves of the same control, and the input/display
+| rule above is only legible when they sit side by side.
+|
+| Every storage assertion reads the RAW column through the query builder, not
+| a re-parsed Carbon. A model attribute comes back through the same cast that
+| wrote it, so a conversion that is wrong in both directions would agree with
+| itself; the column does not.
+*/
+
+/**
+ * The organiser whose report started issue #48.
+ *
+ * Indianapolis is EDT (UTC-4) in September, so 21:30 local moves BOTH the hour
+ * and the calendar date when it becomes UTC. That is the property to keep when
+ * touching these fixtures — it is what stops an off-by-one from hiding.
+ */
+const ORGANISER_TIMEZONE = 'America/Indiana/Indianapolis';
+
+/**
+ * The owner's own measurement: entered 2026-09-14 / 21:30, stored
+ * 2026-09-15 01:30:00.
+ */
+const ENTERED_DATE = '2026-09-14';
+
+const ENTERED_TIME = '21:30';
+
+const EXPECTED_UTC = '2026-09-15 01:30:00';
+
+/**
+ * The nine locales the portal ships, plus lt-LT — the locale the pickers were
+ * briefly pinned to and which was reverted. It is in the list precisely
+ * because no picker names it any more (it remains selectable via
+ * config/lang-country.php): the point of the test is that the display locale
+ * cannot reach the stored value at all.
+ *
+ * @return list<string>
+ */
+function displayLocales(): array
+{
+    $locales = array_map(
+        static fn (string $path): string => basename($path, '.json'),
+        glob(langDirectory().'/*.json') ?: []
+    );
+
+    sort($locales);
+
+    return [...$locales, 'lt'];
+}
+
+/**
+ * The lang directory, reached without the framework.
+ *
+ * lang_path() cannot be used here: this function feeds a with() dataset, and
+ * Pest resolves datasets while collecting the suite — before the application
+ * is booted, so the helper is not available yet (measured: "DatasetMissing",
+ * because the glob silently produced nothing). The path is checked against
+ * lang_path() in its own test below, so moving this file cannot make the
+ * dataset quietly shrink to one entry.
+ */
+function langDirectory(): string
+{
+    return dirname(__DIR__, 4).'/lang';
+}
+
+/**
+ * The raw column value, straight from the database.
+ */
+function rawColumn(string $table, int $id, string $column): ?string
+{
+    return DB::table($table)->where('id', $id)->value($column);
+}
+
+/**
+ * Weekday names of every portal locale, in that locale's own spelling.
+ *
+ * The union, not just the active locale's: translatedFormat('l') followed the
+ * app locale, so the leak this guards against appears in whichever language
+ * the visitor happens to be reading.
+ *
+ * @return list<string>
+ */
+function everyLocaleDayNames(): array
+{
+    $names = [];
+
+    // 2026-03-01 is a Sunday, so seven consecutive days cover every weekday.
+    $week = CarbonImmutable::create(2026, 3, 1, 0, 0, 0, 'UTC');
+
+    foreach (displayLocales() as $locale) {
+        foreach (range(0, 6) as $offset) {
+            $names[] = $week->addDays($offset)->locale($locale)->dayName;
+        }
+    }
+
+    return array_values(array_unique(array_filter($names)));
+}
+
+/**
+ * Which of $names occur in $value as whole words, case-insensitively.
+ *
+ * Whole words matter here for the same reason as in RenderedLocaleTest: the
+ * Czech "út" or the Latvian "otrdiena" inside a longer token would otherwise
+ * report a leak that is not there.
+ *
+ * @param  list<string>  $names
+ * @return list<string>
+ */
+function dayNameLeaks(string $value, array $names): array
+{
+    return array_values(array_filter(
+        $names,
+        static fn (string $name): bool => preg_match(
+            '/(?<![\p{L}\p{N}])'.preg_quote($name, '/').'(?![\p{L}\p{N}])/ui',
+            $value
+        ) === 1
+    ));
+}
+
+/**
+ * The markup around every occurrence of $needle in $html.
+ *
+ * The preview cards are the only place the formatted date appears, so a window
+ * around the date is the preview region — and it is locale-independent, unlike
+ * anchoring on the translated heading. The window has to be tight: the form
+ * also renders a weekday SELECT (Montag, Dienstag, …), which is correct German
+ * UI and must not be mistaken for a date leak.
+ */
+function markupAround(string $html, string $needle, int $radius = 160): string
+{
+    $windows = [];
+    $offset = 0;
+
+    while (($position = mb_strpos($html, $needle, $offset)) !== false) {
+        $windows[] = mb_substr($html, max(0, $position - $radius), $radius * 2);
+        $offset = $position + 1;
+    }
+
+    return implode("\n", $windows);
+}
+
+beforeEach(function () {
+    $this->organiser = actingAsUser(['timezone' => ORGANISER_TIMEZONE]);
+    $this->meetup = Meetup::factory()->create(['created_by' => $this->organiser->id]);
+});
+
+/*
+|--------------------------------------------------------------------------
+| 1. The picker stores the correct UTC instant
+|--------------------------------------------------------------------------
+*/
+
+it('reaches the real lang directory without the framework', function () {
+    // The dataset below is only as wide as this path is right. If the file
+    // moves, dirname(__DIR__, 4) points somewhere else, the glob returns
+    // nothing, and the per-locale test would silently run for 'lt' alone.
+    expect(realpath(langDirectory()))->toBe(realpath(lang_path()));
+    expect(displayLocales())->toContain('de')->toContain('en')->toContain('lt');
+    expect(count(displayLocales()))->toBeGreaterThanOrEqual(10);
+});
+
+it('stores the organiser wall-clock entry as the correct UTC instant', function () {
+    Livewire::test('meetups.create-edit-events', ['meetup' => $this->meetup])
+        ->set('startDate', ENTERED_DATE)
+        ->set('startTime', ENTERED_TIME)
+        ->set('location', 'Main Street 1')
+        ->set('description', 'An evening about bitcoin.')
+        ->call('save')
+        ->assertHasNoErrors();
+
+    $event = MeetupEvent::query()->sole();
+    $stored = rawColumn('meetup_events', $event->id, 'start');
+
+    expect($stored)->toBe(EXPECTED_UTC);
+
+    /*
+     * The three ways this has been got wrong, named rather than merely
+     * excluded by the line above. Each is a value the column would carry
+     * under a plausible implementation:
+     *
+     *   - the wall clock written through as if it were already UTC;
+     *   - the offset applied in the wrong direction;
+     *   - the date left alone because only the hour was converted.
+     */
+    expect($stored)->not->toBe('2026-09-14 21:30:00');
+    expect($stored)->not->toBe('2026-09-14 17:30:00');
+    expect(substr($stored, 0, 10))->not->toBe(ENTERED_DATE);
+});
+
+it('stores the same UTC instant whatever locale the form is displayed in', function () {
+    $storedPerLocale = [];
+
+    foreach (displayLocales() as $locale) {
+        app()->setLocale($locale);
+
+        MeetupEvent::query()->delete();
+
+        Livewire::test('meetups.create-edit-events', ['meetup' => $this->meetup])
+            ->set('startDate', ENTERED_DATE)
+            ->set('startTime', ENTERED_TIME)
+            ->set('location', 'Main Street 1')
+            ->set('description', 'An evening about bitcoin.')
+            ->call('save')
+            ->assertHasNoErrors();
+
+        $event = MeetupEvent::query()->sole();
+        $storedPerLocale[$locale] = rawColumn('meetup_events', $event->id, 'start');
+    }
+
+    // The floor is asserted, not assumed: an empty glob would make the
+    // "identical everywhere" claim below true over nothing.
+    expect(count($storedPerLocale))->toBeGreaterThanOrEqual(10);
+    expect(array_keys($storedPerLocale))->toContain('de')->toContain('en')->toContain('lt');
+
+    expect(array_unique(array_values($storedPerLocale)))->toBe([EXPECTED_UTC]);
+});
+
+it('stores both ends of a course event as UTC', function () {
+    $course = Course::factory()->create(['created_by' => $this->organiser->id]);
+    $city = City::factory()->create();
+
+    Livewire::test('courses.create-edit-events', ['course' => $course])
+        ->set('fromDate', ENTERED_DATE)
+        ->set('fromTime', ENTERED_TIME)
+        ->set('toDate', '2026-09-14')
+        ->set('toTime', '23:00')
+        ->set('city_id', $city->id)
+        ->set('location', 'Main Street 1')
+        ->set('link', 'https://example.com/course-event')
+        ->call('save')
+        ->assertHasNoErrors();
+
+    $event = CourseEvent::query()->sole();
+
+    expect(rawColumn('course_events', $event->id, 'from'))->toBe(EXPECTED_UTC);
+    expect(rawColumn('course_events', $event->id, 'to'))->toBe('2026-09-15 03:00:00');
+});
+
+/*
+|--------------------------------------------------------------------------
+| 2. A series keeps the organiser's wall clock across a DST change
+|--------------------------------------------------------------------------
+|
+| createEventSeries() expands the dates itself and converts afterwards, which
+| is a different code path from the single event above and was never measured.
+|
+| The property is wall-clock stability in the organiser's zone, NOT equal
+| spacing in UTC. US zones leave DST on 2026-11-01, so a weekly 19:00 series
+| that crosses it must store 23:00 UTC before the switch and 00:00 UTC after
+| it. An implementation that advances the UTC instant by seven days produces
+| 23:00 UTC throughout — 18:00 local, an hour early, silently, for every
+| occurrence after the switch.
+*/
+
+it('keeps every occurrence of a series on the organiser wall clock across the DST change', function () {
+    Livewire::test('meetups.create-edit-events', ['meetup' => $this->meetup])
+        ->set('seriesMode', true)
+        ->set('startDate', '2026-10-28')
+        ->set('startTime', '19:00')
+        ->set('endDate', '2026-11-11')
+        ->set('recurrenceType', RecurrenceType::Weekly)
+        ->set('location', 'Main Street 1')
+        ->set('description', 'A weekly evening about bitcoin.')
+        ->call('save')
+        ->assertHasNoErrors();
+
+    $stored = MeetupEvent::query()
+        ->orderBy('start')
+        ->pluck('id')
+        ->map(fn (int $id): string => rawColumn('meetup_events', $id, 'start'))
+        ->all();
+
+    // Three Wednesdays: 28 October (EDT), 4 and 11 November (EST).
+    expect($stored)->toBe([
+        '2026-10-28 23:00:00',
+        '2026-11-05 00:00:00',
+        '2026-11-12 00:00:00',
+    ]);
+
+    // The same claim expressed as the property, so a future fixture change
+    // cannot quietly turn the list above into three numbers nobody checks.
+    $wallClocks = array_map(
+        static fn (string $utc): string => CarbonImmutable::createFromFormat('Y-m-d H:i:s', $utc, 'UTC')
+            ->setTimezone(ORGANISER_TIMEZONE)
+            ->format('H:i'),
+        $stored
+    );
+
+    expect($wallClocks)->toBe(['19:00', '19:00', '19:00']);
+
+    /*
+     * The discriminator. A naive implementation that adds seven days to the
+     * UTC instant satisfies "three occurrences, a week apart" perfectly and
+     * fails only here: correct output is deliberately NOT equally spaced,
+     * because one of the gaps swallows the extra hour.
+     */
+    $gaps = [
+        CarbonImmutable::parse($stored[0], 'UTC')->diffInHours(CarbonImmutable::parse($stored[1], 'UTC')),
+        CarbonImmutable::parse($stored[1], 'UTC')->diffInHours(CarbonImmutable::parse($stored[2], 'UTC')),
+    ];
+
+    expect($gaps)->toBe([169.0, 168.0], 'Equal UTC spacing across a DST change means the wall clock moved.');
+});
+
+/*
+|--------------------------------------------------------------------------
+| 3. Reopening the edit form does not move the instant
+|--------------------------------------------------------------------------
+|
+| mount() reads start->setTimezone($timezone) back into the pickers, save()
+| converts the other way. The two are only symmetrical if they agree, and
+| nobody had run the round trip.
+*/
+
+it('does not move a stored instant when the edit form is reopened and saved unchanged', function () {
+    Livewire::test('meetups.create-edit-events', ['meetup' => $this->meetup])
+        ->set('startDate', ENTERED_DATE)
+        ->set('startTime', ENTERED_TIME)
+        ->set('location', 'Main Street 1')
+        ->set('description', 'An evening about bitcoin.')
+        ->call('save')
+        ->assertHasNoErrors();
+
+    $event = MeetupEvent::query()->sole();
+
+    expect(rawColumn('meetup_events', $event->id, 'start'))->toBe(EXPECTED_UTC);
+
+    Livewire::test('meetups.create-edit-events', ['meetup' => $this->meetup, 'event' => $event])
+        // The pickers must come back carrying the organiser's own wall clock,
+        // not UTC — otherwise the round trip below would be trivially stable
+        // while the form showed the wrong time.
+        ->assertSet('startDate', ENTERED_DATE)
+        ->assertSet('startTime', ENTERED_TIME)
+        ->call('save')
+        ->assertHasNoErrors();
+
+    expect(rawColumn('meetup_events', $event->id, 'start'))->toBe(EXPECTED_UTC);
+});
+
+/*
+|--------------------------------------------------------------------------
+| 4. The series preview is data display, so it is ISO and carries no day name
+|--------------------------------------------------------------------------
+|
+| create-edit-events.blade.php:66 used translatedFormat('l, d.m.Y') and put
+| "Monday, 05.10.2026" on the reporter's own page — the thirteenth display
+| site, and the one the original sweep's grep patterns could not match. The
+| day name is what made it a locale leak rather than a mere format
+| inconsistency, so that is the half asserted per locale.
+*/
+
+it('renders the series preview as ISO with no day name, in every portal locale', function (string $locale) {
+    app()->setLocale($locale);
+
+    $html = Livewire::test('meetups.create-edit-events', ['meetup' => $this->meetup])
+        ->set('seriesMode', true)
+        ->set('startDate', '2026-10-05')
+        ->set('startTime', '19:00')
+        ->set('endDate', '2026-10-19')
+        ->set('recurrenceType', RecurrenceType::Weekly)
+        ->html();
+
+    $expectedDates = ['2026-10-05', '2026-10-12', '2026-10-19'];
+
+    foreach ($expectedDates as $date) {
+        // Positive control first: without it, "no day name near the date"
+        // would be satisfied by a preview that never rendered.
+        expect(str_contains($html, $date))->toBeTrue("The preview did not render {$date} under locale '{$locale}'.");
+
+        expect(dayNameLeaks(markupAround($html, $date), everyLocaleDayNames()))
+            ->toBe([], "A weekday name is rendered next to {$date} under locale '{$locale}'.");
+    }
+
+    // The other half of the old shape. Asserted over the WHOLE form, not just
+    // the preview: d.m.Y has no legitimate place anywhere on this page.
+    expect(preg_match('/\d{2}\.\d{2}\.\d{4}/', $html))
+        ->toBe(0, "A d.m.Y date is rendered somewhere in the event form under locale '{$locale}'.");
+})->with(displayLocales());
+
+/*
+|--------------------------------------------------------------------------
+| 5. Calibration — the day-name matcher must be able to fail
+|--------------------------------------------------------------------------
+|
+| The preview cannot produce the old shape any more, so nothing on a rendered
+| page can exercise the matcher. It is calibrated on the string the reporter
+| actually saw instead, which keeps the proof in the repo after the fix.
+*/
+
+it('flags the pre-issue-48 preview shape and spares the corrected one', function () {
+    $names = everyLocaleDayNames();
+
+    // Positive control on the name list itself: empty, and everything below
+    // would pass without looking at anything.
+    expect($names)->toContain('Monday')->toContain('Montag')->toContain('pirmadienis');
+
+    // What translatedFormat('l, d.m.Y') rendered, in the two locales the
+    // reporter and the owner were reading.
+    expect(dayNameLeaks('Monday, 05.10.2026', $names))->toBe(['Monday']);
+    expect(dayNameLeaks('Montag, 05.10.2026', $names))->toBe(['Montag']);
+    expect(preg_match('/\d{2}\.\d{2}\.\d{4}/', 'Monday, 05.10.2026'))->toBe(1);
+
+    // What it renders now.
+    expect(dayNameLeaks('2026-10-05', $names))->toBe([]);
+    expect(preg_match('/\d{2}\.\d{2}\.\d{4}/', '2026-10-05'))->toBe(0);
+
+    /*
+     * Why the assertion above looks at a window around the date instead of at
+     * the whole page. This one line of the very same form scores TWO hits: the
+     * visible "Montag" of the weekday select, which is correct German UI, and
+     * the machine value="monday" in the attribute, which is not text at all.
+     * Neither is a date leak, and a whole-page day-name check would report
+     * both on every render — the guard would be red permanently and switched
+     * off within a day. Measured while writing this test; the second hit was
+     * not anticipated.
+     */
+    $weekdaySelect = '<option value="monday">Montag</option>';
+
+    expect(dayNameLeaks($weekdaySelect, $names))->toBe(['Montag', 'Monday']);
+    expect(markupAround($weekdaySelect, '2026-10-05'))->toBe('');
+});


### PR DESCRIPTION
Closes #48.

An external usability report from a US organiser. Its first three items shared one root cause: `App\Support\Carbon` hardcoded `->locale('de')` in all four formatters, and that class is bound as the application's date implementation — so in a nine-locale portal the language selector could not reach a single date.

The owner decided ISO 8601 for every locale with 24-hour time, as the reporter recommended. Thirteen hand-written display sites now go through the formatters; the thirteenth only surfaced on review, because the first sweep's grep patterns could not match `translatedFormat('l, d.m.Y')`. A grep pattern is a measurement boundary, not a search.

The reporter's "Created on … (unknown timezone)" was a second defect. The mechanism is counter-intuitive enough to record: `date_default_timezone_get()` stays UTC for the whole request because `date_default_timezone_set()` runs at bootstrap before `SetTimezone` middleware; `config('app.timezone')` is *not* UTC — the middleware writes the user's zone into it — but the formatters do not read that key.

**A picker is an input control; ISO governs data display.** Forcing the Flux date picker to ISO is possible and was rejected: Flux hardcodes `{day:"numeric", month:"short", year:"numeric"}` with no format attribute, exactly one language tag of 103 answers that with `YYYY-MM-DD`, and pinning it makes every day cell's `aria-label` Lithuanian. The courses form did get a real fix — its pickers carried no locale at all and followed `navigator.language` instead of the portal's own language selection.

Also: start and end time are named and grouped (they were "Uhrzeit" and "Ende", 335px apart), and the two location fields no longer carry the identical hint that made them indistinguishable.

The storage path is guarded where it matters. A date entered through the real widget in `America/Indiana/Indianapolis` stores `2026-09-15 01:30:00` for a local `2026-09-14 21:30` — hour and calendar date both move — and ten display locales produce the identical stored instant. A weekly series crossing the 2026-11-01 DST change keeps every occurrence at 19:00 local, so its stored UTC gaps are 169 and 168 hours: unequal on purpose, and the only thing separating a correct implementation from one that adds seven days to a UTC instant.

Full non-Browser suite: 1827 passed, 6746 assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A4BKf2zxFNSRKBoMUB8EUW