### PR TITLE
Record that an .env edit needs a config:cache to take effect

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,24 @@
+# ---------------------------------------------------------------------------
+# Changing a value in production does NOT take effect on its own.
+#
+# The deploy script runs `php artisan optimize`, which compiles this file's
+# values into bootstrap/cache/config.php. While that cache exists Laravel does
+# not read .env at all, so an edit made in Forge WITHOUT a deploy is invisible
+# to the running app — silently, with no error anywhere.
+#
+# Measured on 2026-09-04: NOSTR_PUBLISHER_NSEC was set at 01:24 against a cache
+# compiled at 01:17. The scheduler kept running every five minutes and failing
+# every time, and `nostr:whoami` kept reporting "Key configured: no", which is
+# indistinguishable from the value never having been saved.
+#
+# After editing an environment variable in Forge, either deploy the site, or:
+#
+#   cd <release>/current && php artisan config:cache
+#
+# If that ever fails and leaves a half-written cache, `php artisan config:clear`
+# is the recovery — the app then reads this file directly, slower but correct.
+# ---------------------------------------------------------------------------
+
 APP_NAME=Laravel
 APP_ENV=local
 APP_KEY=
@@ -77,6 +98,12 @@ PASSPORT_PUBLIC_KEY=
 # `nostr:publish-calendar`). nsec- oder Hex-Format. Ohne diesen Wert bricht der
 # Command mit einer Fehlermeldung ab, statt unsigniert zu publizieren.
 # Niemals einen echten Schlüssel committen.
+#
+# `php artisan nostr:whoami` reads this back: it derives and prints only the
+# PUBLIC half (npub and hex pubkey) plus the relays and whether the publish
+# command is scheduled, so its output is safe to paste into an issue. Run it
+# after changing either value — and mind the config cache noted at the top of
+# this file, or it will report the previous state.
 NOSTR_PUBLISHER_NSEC=
 NOSTR_RELAYS=wss://nos.lol,wss://relay.damus.io
 


### PR DESCRIPTION
Documentation only, no code.

While closing #49 an environment value was set in Forge and stayed invisible to the app: the deploy script's `php artisan optimize` had compiled `.env` into `bootstrap/cache/config.php`, and Laravel does not read `.env` while that cache exists. The scheduler ran every five minutes and failed every time; the diagnostic command reported the key as unset, which looks exactly like the value never having been saved.

The note sits at the top of `.env.example` because it applies to every value there. It also records the check that settled it — an mtime comparison rather than grepping the compiled cache, because `config/services.php` reads the key through `env()` and the cache therefore holds the nsec in plaintext.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A4BKf2zxFNSRKBoMUB8EUW