### PR TITLE
Compare country codes case-insensitively, everywhere

### DIFF
--- a/app/Http/Controllers/DownloadMeetupCalendar.php
+++ b/app/Http/Controllers/DownloadMeetupCalendar.php
@@ -102,7 +102,7 @@ class DownloadMeetupCalendar extends Controller
 
     private function scopeToCountry(Builder $query, string $countryCode): Builder
     {
-        return $query->whereHas('meetup.city.country', fn ($query) => $query->where('countries.code', $countryCode));
+        return $query->whereHas('meetup.city.country', fn ($query) => $query->matchingCode($countryCode));
     }
 
     /**
@@ -126,7 +126,16 @@ class DownloadMeetupCalendar extends Controller
             return null;
         }
 
-        return Country::query()->where('code', $requested)->exists() ? $requested : null;
+        /*
+         * Dieser Vergleich ist das Tor, nicht scopeToCountry(): faellt er durch, wird
+         * `null` zurueckgegeben und der Filter unten gar nicht erst gesetzt. Er war
+         * case-sensitiv, waehrend `$requested` immer kleingeschrieben ankommt — mit
+         * gross gespeicherten Codes lieferte `?country=de` deshalb NICHT einen leeren
+         * Kalender, sondern den ganzen weltweiten Feed (gemessen: 5 statt 2 Termine).
+         * Von den beiden moeglichen Richtungen war das die falsche: ein Abo, das still
+         * mehr ausliefert als bestellt, faellt niemandem auf.
+         */
+        return Country::query()->matchingCode($requested)->exists() ? $requested : null;
     }
 
     /**

--- a/app/Models/Country.php
+++ b/app/Models/Country.php
@@ -2,7 +2,9 @@
 
 namespace App\Models;
 
+use App\Console\Commands\ImportRegions;
 use App\Models\Concerns\HasOsmReference;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -31,6 +33,35 @@ class Country extends Model
         'osm_lat' => 'float',
         'osm_lon' => 'float',
     ];
+
+    /**
+     * Vergleicht `countries.code` gegen ein URL-Segment — case-insensitiv.
+     *
+     * `countries.code` ist gross oder klein geschrieben, je nach Bestand: lokal steht
+     * "DE" neben "us", und der Regions-Import hat denselben Unterschied schon in der
+     * Produktion angetroffen ({@see ImportRegions}). Die URLs des
+     * Portals sind dagegen immer klein. Ein `where('code', 'de')` haengt damit an der
+     * Kollation: MySQL vergleicht mit utf8mb4_*_ci zufaellig richtig, SQLite exakt — die
+     * Abfrage ist eine Wette auf den Bestand, keine Aussage ueber ihn. Genau daran
+     * zeigten die landesbezogenen Badges der Sidebar durchgaengig 0 (Issue #58).
+     *
+     * Dieselbe Form benutzt {@see Region::findByCountryCodeAndCode()} seit dem
+     * Regions-Import; sie steht hier, damit nicht jede Aufrufstelle sie neu formuliert.
+     *
+     * Fail-closed: ein leerer oder fehlender Code trifft KEINE Zeile (kein Land hat
+     * einen leeren Code) statt still alle — eine Route ohne `country` darf nicht
+     * aussehen wie "alle Laender".
+     *
+     * Der Spaltenname wird qualifiziert, weil `regions` ebenfalls eine Spalte `code`
+     * hat: in einer verjointen Abfrage waere `LOWER(code)` mehrdeutig.
+     */
+    public function scopeMatchingCode(Builder $query, ?string $code): Builder
+    {
+        return $query->whereRaw(
+            'LOWER('.$query->qualifyColumn('code').') = ?',
+            [mb_strtolower((string) $code)],
+        );
+    }
 
     public function cities(): HasMany
     {

--- a/resources/views/components/layouts/app/sidebar.blade.php
+++ b/resources/views/components/layouts/app/sidebar.blade.php
@@ -43,6 +43,25 @@
             ->value('id');
 
         /*
+         * Die beiden Meetup-Zahlen — je EINMAL gezaehlt, obwohl vier Eintraege sie tragen.
+         *
+         * Liste und Karte dieses Landes zeigen dieselbe Menge: `meetups.index` und
+         * `meetups.map` filtern beide ausschliesslich ueber Land und Region
+         * (meetups/index.blade.php:54, meetups/map.blade.php:64). "Alle Meetups" und die
+         * Welt-Karte ebenso — beide ganz ohne Filter. Vier eigene count()-Abfragen waeren
+         * also viermal dieselbe Zahl; so kostet die neue Karten-Badge keine zusaetzliche.
+         *
+         * Bekommt eine der vier Seiten einmal einen eigenen Filter, gehoert die betroffene
+         * Zahl wieder getrennt — sonst verspricht die Badge etwas, das hinter dem Link
+         * nicht steht.
+         */
+        $navCountryMeetupCount = \App\Models\Meetup::query()
+            ->whereHas('city.country', fn ($query) => $query->matchingCode($navCountry))
+            ->when($navRegionId, fn ($query) => $query->whereHas('city', fn ($q) => $q->where('cities.region_id', $navRegionId)))
+            ->count();
+        $navAllMeetupCount = \App\Models\Meetup::query()->count();
+
+        /*
          * Die Meetups, die der angemeldete Nutzer als Leader fuehrt (Issue #45): ohne sie
          * kommt ein Organisator nur ueber die Laenderliste an sein eigenes Meetup.
          * Weil diese Sidebar auch die mobile Navigation ist (flux:sidebar.toggle unten),
@@ -95,10 +114,7 @@
             <flux:navlist.item icon="user-group" :href="country_or_region_route('meetups.index')"
                                :current="request()->routeIs('meetups.index', 'meetups.index-region')"
                                wire:navigate
-                               badge="{{ \App\Models\Meetup::query()
-                                   ->whereHas('city.country', fn($query) => $query->where('countries.code', $navCountry))
-                                   ->when($navRegionId, fn($query) => $query->whereHas('city', fn($q) => $q->where('cities.region_id', $navRegionId)))
-                                   ->count() }}">
+                               badge="{{ $navCountryMeetupCount }}">
                 <div class="flex items-center space-x-2">
                     <span>{{ __('Meetups') }}</span>
                     <img alt="{{ request()->route('country') }}"
@@ -109,15 +125,20 @@
             <flux:navlist.item icon="user-group" :href="route_with_country('meetups.index-all')"
                                :current="request()->routeIs('meetups.index-all')"
                                wire:navigate
-                               badge="{{ \App\Models\Meetup::query()->count() }}">
+                               badge="{{ $navAllMeetupCount }}">
                 <div class="flex items-center space-x-2">
                     <span>{{ __('Alle Meetups') }}</span>
                     <flux:icon name="globe-europe-africa"/>
                 </div>
             </flux:navlist.item>
+            {{-- Die Zahl ist hier die ganze Erklaerung (Issue #51): "Karte 🇨🇿 0" neben
+                 "Welt-Karte 🌐 307" beantwortet vor dem Klick, warum diese Karte leer ist.
+                 Beide Zahlen zaehlen dieselbe Sache — die Meetups, die die jeweilige Karte
+                 als Marker setzt — und unterscheiden sich nur im Zuschnitt. --}}
             <flux:navlist.item icon="map" :href="country_or_region_route('meetups.map')"
                                :current="request()->routeIs('meetups.map', 'meetups.map-region')"
-                               wire:navigate>
+                               wire:navigate
+                               badge="{{ $navCountryMeetupCount }}">
                 <div class="flex items-center space-x-2">
                     <span>{{ __('Karte') }}</span>
                     <img alt="{{ request()->route('country') }}"
@@ -127,7 +148,7 @@
             </flux:navlist.item>
             <flux:navlist.item icon="map" :href="route_with_country('meetups.map-world')"
                                :current="request()->routeIs('meetups.map-world')"
-                               wire:navigate badge="{{ \App\Models\Meetup::query()->count() }}">
+                               wire:navigate badge="{{ $navAllMeetupCount }}">
                 <div class="flex items-center space-x-2">
                     <span>{{ __('Welt-Karte') }}</span>
                     <flux:icon name="globe-europe-africa"/>
@@ -160,7 +181,7 @@
             <flux:navlist.item icon="academic-cap" :href="route_with_country('courses.index')"
                                :current="request()->routeIs('courses.index')"
                                wire:navigate
-                               badge="{{ \App\Models\Course::query()->whereHas('courseEvents.city.country', fn($query) => $query->where('countries.code', request()->route('country')))->count() }}">
+                               badge="{{ \App\Models\Course::query()->whereHas('courseEvents.city.country', fn($query) => $query->matchingCode($navCountry))->count() }}">
                 <div class="flex items-center space-x-2">
                     <span>{{ __('Kurse') }}</span>
                     <img alt="{{ request()->route('country') }}"
@@ -171,7 +192,7 @@
             <flux:navlist.item icon="user" :href="route_with_country('lecturers.index')"
                                :current="request()->routeIs('lecturers.index')"
                                wire:navigate
-                               badge="{{ \App\Models\Lecturer::query()->whereHas('coursesEvents.city.country', fn($query) => $query->where('countries.code', request()->route('country')))->count() }}">
+                               badge="{{ \App\Models\Lecturer::query()->whereHas('coursesEvents.city.country', fn($query) => $query->matchingCode($navCountry))->count() }}">
                 <div class="flex items-center space-x-2">
                     <span>{{ __('Dozenten') }}</span>
                     <img alt="{{ request()->route('country') }}"
@@ -188,7 +209,7 @@
                                :current="request()->routeIs('cities.index', 'cities.index-region')"
                                wire:navigate
                                badge="{{ \App\Models\City::query()
-                                   ->whereHas('country', fn($query) => $query->where('countries.code', $navCountry))
+                                   ->whereHas('country', fn($query) => $query->matchingCode($navCountry))
                                    ->when($navRegionId, fn($query) => $query->where('cities.region_id', $navRegionId))
                                    ->count() }}">
                 {{ __('Städte/Gebiete') }}

--- a/resources/views/livewire/cities/create.blade.php
+++ b/resources/views/livewire/cities/create.blade.php
@@ -10,12 +10,16 @@ use Livewire\Component;
 
 new
 #[SeoDataAttribute(key: 'cities_create')]
-class extends Component {
+class extends Component
+{
     use SeoTrait;
 
     public $country = 'de';
+
     public string $name = '';
+
     public ?int $country_id = null;
+
     public ?int $region_id = null;
 
     /**
@@ -28,9 +32,13 @@ class extends Component {
      * @var array<string, mixed>
      */
     public array $osmPlace = [];
+
     public ?float $latitude = null;
+
     public ?float $longitude = null;
+
     public ?int $population = null;
+
     public ?string $population_date = null;
 
     /**
@@ -60,7 +68,7 @@ class extends Component {
     {
         $this->country = request()->route('country', config('app.domain_country'));
         $this->country_id = Country::query()
-            ->where('code', $this->country)
+            ->matchingCode($this->country)
             ->value('id');
     }
 
@@ -174,7 +182,6 @@ class extends Component {
             navigate: true,
         );
     }
-
 
     /**
      * Die OSM-Spalten aus dem gewaehlten Ort, immer alle acht.

--- a/resources/views/livewire/cities/index.blade.php
+++ b/resources/views/livewire/cities/index.blade.php
@@ -9,11 +9,13 @@ use Livewire\WithPagination;
 
 new
 #[SeoDataAttribute(key: 'cities_index')]
-class extends Component {
-    use WithPagination;
+class extends Component
+{
     use SeoTrait;
+    use WithPagination;
 
     public $country = 'de';
+
     public $search = '';
 
     /**
@@ -37,11 +39,10 @@ class extends Component {
         return [
             'cities' => City::query()
                 ->with(['country', 'createdBy', 'region'])
-                ->when($this->search, fn($query)
-                    => $query->whereLike('name', '%'.$this->search.'%'),
+                ->when($this->search, fn ($query) => $query->whereLike('name', '%'.$this->search.'%'),
                 )
-                ->whereHas('country', fn($query) => $query->where('countries.code', $this->country))
-                ->when($this->regionId, fn($query) => $query->where('cities.region_id', $this->regionId))
+                ->whereHas('country', fn ($query) => $query->matchingCode($this->country))
+                ->when($this->regionId, fn ($query) => $query->where('cities.region_id', $this->regionId))
                 ->orderBy('name')
                 ->paginate(15),
         ];

--- a/resources/views/livewire/courses/index.blade.php
+++ b/resources/views/livewire/courses/index.blade.php
@@ -8,11 +8,13 @@ use Livewire\WithPagination;
 
 new
 #[SeoDataAttribute(key: 'courses_index')]
-class extends Component {
-    use WithPagination;
+class extends Component
+{
     use SeoTrait;
+    use WithPagination;
 
     public $country = 'de';
+
     public $search = '';
 
     public function mount(): void
@@ -25,14 +27,13 @@ class extends Component {
         return [
             'courses' => Course::with(['lecturer', 'createdBy'])
                 ->withExists([
-                    'courseEvents as has_future_events' => fn($query) => $query->where('from', '>=', now())
+                    'courseEvents as has_future_events' => fn ($query) => $query->where('from', '>=', now()),
                 ])
-                ->when($this->search, fn($query)
-                    => $query
+                ->when($this->search, fn ($query) => $query
                     ->whereLike('name', '%'.$this->search.'%')
                     ->orWhereLike('description', '%'.$this->search.'%'),
                 )
-                ->whereHas('courseEvents.city.country', fn($query) => $query->where('countries.code', $this->country))
+                ->whereHas('courseEvents.city.country', fn ($query) => $query->matchingCode($this->country))
                 ->orderByDesc('has_future_events')
                 ->paginate(15),
         ];

--- a/resources/views/livewire/lecturers/index.blade.php
+++ b/resources/views/livewire/lecturers/index.blade.php
@@ -8,11 +8,13 @@ use Livewire\WithPagination;
 
 new
 #[SeoDataAttribute(key: 'lecturers_index')]
-class extends Component {
-    use WithPagination;
+class extends Component
+{
     use SeoTrait;
+    use WithPagination;
 
     public $country = 'de';
+
     public $search = '';
 
     public function mount(): void
@@ -26,20 +28,19 @@ class extends Component {
             'lecturers' => Lecturer::query()
                 ->with([
                     'createdBy',
-                    'coursesEvents' => fn($query) => $query->where('from', '>=', now())->orderBy('from', 'asc'),
+                    'coursesEvents' => fn ($query) => $query->where('from', '>=', now())->orderBy('from', 'asc'),
                     'coursesEvents.course',
                 ])
                 ->withExists([
-                    'coursesEvents as has_future_events' => fn($query) => $query->where('from', '>=', now()),
+                    'coursesEvents as has_future_events' => fn ($query) => $query->where('from', '>=', now()),
                 ])
                 ->withCount([
-                    'coursesEvents as future_events_count' => fn($query) => $query->where('from', '>=', now()),
+                    'coursesEvents as future_events_count' => fn ($query) => $query->where('from', '>=', now()),
                 ])
                 ->whereHas('coursesEvents')
                 ->whereHas('coursesEvents.city.country',
-                    fn($query) => $query->where('countries.code', $this->country))
-                ->when($this->search, fn($query)
-                    => $query
+                    fn ($query) => $query->matchingCode($this->country))
+                ->when($this->search, fn ($query) => $query
                     ->whereLike('name', '%'.$this->search.'%')
                     ->orWhereLike('description', '%'.$this->search.'%')
                     ->orWhereLike('subtitle', '%'.$this->search.'%'),

--- a/resources/views/livewire/meetups/index.blade.php
+++ b/resources/views/livewire/meetups/index.blade.php
@@ -51,7 +51,7 @@ class extends Component
                 })
                 ->selectRaw('meetups.*, MIN(meetup_events.start) as next_event_start')
                 ->groupBy('meetups.id')
-                ->when(in_array($this->currentRouteName, ['meetups.index', 'meetups.index-region'], true), fn ($query) => $query->whereHas('city.country', fn ($query) => $query->where('countries.code', $this->country))
+                ->when(in_array($this->currentRouteName, ['meetups.index', 'meetups.index-region'], true), fn ($query) => $query->whereHas('city.country', fn ($query) => $query->matchingCode($this->country))
                 )
                 ->when($this->regionId, fn ($query) => $query->whereHas('city', fn ($query) => $query->where('cities.region_id', $this->regionId))
                 )

--- a/resources/views/livewire/meetups/map.blade.php
+++ b/resources/views/livewire/meetups/map.blade.php
@@ -5,15 +5,20 @@ use App\Models\Meetup;
 use App\Models\Region;
 use App\Traits\SeoTrait;
 use Livewire\Component;
+use Lwwcas\LaravelCountries\Models\Country;
 
 new
 #[SeoDataAttribute(key: 'meetups_map')]
-class extends Component {
+class extends Component
+{
     use SeoTrait;
 
     public string $country = 'de';
+
     public float $latitude = 0.0;
+
     public float $longitude = 0.0;
+
     public string $currentRouteName = '';
 
     /**
@@ -26,7 +31,7 @@ class extends Component {
         $this->currentRouteName = request()->route()->getName();
         $this->country = request()->route('country', config('app.domain_country'));
         $this->regionId = Region::fromRouteOrFail($this->country)?->id;
-        $geoCountry = \Lwwcas\LaravelCountries\Models\Country::query()
+        $geoCountry = Country::query()
             ->where('iso_alpha_2', str($this->country)->upper())
             ->first()
             ?->coordinates()
@@ -63,20 +68,19 @@ class extends Component {
                 ->with(['city:id,country_id,longitude,latitude', 'city.country'])
                 ->when(
                     in_array($this->currentRouteName, ['meetups.map', 'meetups.map-region'], true),
-                    fn($query)
-                        => $query
-                        ->whereHas('city.country', fn($query) => $query->where('code', $this->country))
+                    fn ($query) => $query
+                        ->whereHas('city.country', fn ($query) => $query->matchingCode($this->country))
                 )
                 ->when(
                     $this->regionId,
-                    fn($query) => $query->whereHas('city', fn($query) => $query->where('cities.region_id', $this->regionId))
+                    fn ($query) => $query->whereHas('city', fn ($query) => $query->where('cities.region_id', $this->regionId))
                 )
                 ->get()
                 ->map(function ($meetup) {
-                    $meetup->load(['meetupEvents' => function($query) {
+                    $meetup->load(['meetupEvents' => function ($query) {
                         $query->where('start', '>=', now())
-                              ->orderBy('start')
-                              ->limit(1);
+                            ->orderBy('start')
+                            ->limit(1);
                     }]);
 
                     $nextEvent = $meetup->meetupEvents->first();
@@ -86,7 +90,7 @@ class extends Component {
                         $eventUrl = route('meetups.landingpage-event', [
                             'country' => $meetup->city->country,
                             'meetup' => $meetup->slug,
-                            'event' => $nextEvent->id
+                            'event' => $nextEvent->id,
                         ]);
                     }
 
@@ -100,9 +104,9 @@ class extends Component {
                             'meetup' => $meetup,
                             'url' => route('meetups.landingpage', [
                                 'country' => $meetup->city->country,
-                                'meetup' => $meetup->slug
+                                'meetup' => $meetup->slug,
                             ]),
-                            'eventUrl' => $eventUrl
+                            'eventUrl' => $eventUrl,
                         ])->render(),
                     ];
                 }),

--- a/tests/Feature/Cities/CityRegionRowTest.php
+++ b/tests/Feature/Cities/CityRegionRowTest.php
@@ -318,3 +318,43 @@ it('still stores a region through the listbox state', function () {
 
     expect($city->fresh()->region_id)->toBe($region->id);
 });
+
+/*
+|--------------------------------------------------------------------------
+| Das Land aus der URL — mit gross gespeichertem Laendercode
+|--------------------------------------------------------------------------
+|
+| Jeder create-Fall oben faehrt `Livewire::test('cities.create')` und setzt
+| `country_id` gleich danach selbst. `mount()` laeuft dabei zwar, sein Ergebnis
+| wird aber sofort ueberschrieben — deshalb konnte keiner dieser Faelle rot
+| werden, als die Vorauswahl in `mount()` den Laendercode case-sensitiv verglich.
+| Mit gespeichertem 'DE' und der Route /de/city-create blieb `country_id` null,
+| und das Formular verlangte „Wähl zuerst ein Land." fuer ein Land, das in der
+| URL steht.
+|
+| Dieser Fall geht darum ueber die ROUTE statt ueber die Komponente und speichert
+| den Code so, wie CountryFactory ihn von sich aus schreibt: gross. `no-catalog`
+| ist der Beleg, dass das Land aufgeloest wurde — die Zeile begruendet sich dann
+| mit dem leeren Regionen-Katalog und nicht mehr mit einer fehlenden Landeswahl.
+|
+*/
+
+it('preselects the country from the url when its stored code is uppercase', function () {
+    Country::factory()->create(['code' => 'DE']);
+
+    $html = $this->actingAs(User::factory()->create())
+        ->get('/de/city-create')
+        ->assertOk()
+        ->getContent();
+
+    // Den Zustand als WERT lesen, nicht als Vorhandensein eines Teilstrings: ein
+    // `not->toContain(...)` auf dem ganzen Dokument meldet im Fehlerfall 26.000
+    // Zeilen HTML und nennt nicht, was statt dessen dasteht. So steht im roten
+    // Lauf `-'no-catalog' +'no-country'`, und das ist die ganze Diagnose.
+    preg_match('/data-region-row="([^"]*)"/', $html, $zustand);
+
+    expect(substr_count($html, 'data-region-row'))->toBe(1)
+        ->and($zustand[1] ?? null)->toBe('no-catalog')
+        // Und dasselbe noch einmal am sichtbaren Symptom, das der Melder gesehen hat.
+        ->and(regionRow($html))->not->toContain('Wähl zuerst ein Land.');
+});

--- a/tests/Feature/DownloadMeetupCalendarTest.php
+++ b/tests/Feature/DownloadMeetupCalendarTest.php
@@ -347,3 +347,43 @@ it('keeps the UID stable across a rename, bumps SEQUENCE, and drops the event on
 
     $this->travelBack();
 });
+
+/*
+|--------------------------------------------------------------------------
+| The gate in resolveCountryCode(), with the code stored the way it is stored
+|--------------------------------------------------------------------------
+|
+| Every country case above seeds its codes LOWERCASE (the shared beforeEach and
+| the three `?country=` cases). That is why none of them could fail while
+| DownloadMeetupCalendar::resolveCountryCode() compared case-sensitively: with
+| a lowercase row the broken gate happens to pass. CountryFactory's own default
+| is uppercase, and production holds both spellings side by side.
+|
+| The failure direction is the dangerous one. The gate is not a filter — when
+| it falls through it returns null and NO filter is applied at all, so a public
+| subscription URL that asked for one country silently ships the whole world.
+| A feed that delivers too much is the kind of defect nobody reports.
+|
+| Counting VEVENTs is therefore the load-bearing assertion: "one event too many"
+| is precisely the observable, and a SUMMARY substring proves nothing on its own
+| because a DESCRIPTION can carry the same text.
+|
+*/
+
+it('scopes the feed to the selected country when the stored country code is uppercase', function () {
+    // The beforeEach seeded this one lowercase; store it the way the database does.
+    Country::whereKey($this->city->country_id)->update(['code' => 'DE']);
+
+    $czechCountry = Country::factory()->create(['code' => 'CZ']);
+    $czechCity = City::factory()->create(['country_id' => $czechCountry->id]);
+
+    $germanMeetup = Meetup::factory()->create(['city_id' => $this->city->id, 'name' => 'German Meetup']);
+    $czechMeetup = Meetup::factory()->create(['city_id' => $czechCity->id, 'name' => 'Czech Meetup']);
+    MeetupEvent::factory()->create(['meetup_id' => $germanMeetup->id, 'title' => 'German Event', 'start' => now()->addWeek()]);
+    MeetupEvent::factory()->create(['meetup_id' => $czechMeetup->id, 'title' => 'Czech Event', 'start' => now()->addWeek()]);
+
+    $ics = unfoldIcs(test()->get('http://portal.einundzwanzig.space/stream-calendar?country=de')->getContent());
+
+    expect(substr_count($ics, 'BEGIN:VEVENT'))->toBe(1)
+        ->and($ics)->toContain('SUMMARY:German Event');
+});

--- a/tests/Feature/SidebarBadgeScopeTest.php
+++ b/tests/Feature/SidebarBadgeScopeTest.php
@@ -1,0 +1,492 @@
+<?php
+
+use App\Models\City;
+use App\Models\Country;
+use App\Models\Course;
+use App\Models\CourseEvent;
+use App\Models\Lecturer;
+use App\Models\Meetup;
+
+/*
+|--------------------------------------------------------------------------
+| Sidebar badges: the country scope, and the casing it is compared with
+|--------------------------------------------------------------------------
+|
+| Issue #58. The country-scoped counters in
+| components/layouts/app/sidebar.blade.php compare the country code with a
+| plain `->where('countries.code', $navCountry)`, while the region lookup a
+| few lines above it deliberately uses `whereRaw('LOWER(code) = ?')`. The
+| stored codes are UPPERCASE — CountryFactory's own table says 'DE', 'AT',
+| 'CH', 'US' — and the URL segment is lowercase. Every country-scoped badge
+| therefore renders 0, including for a country that has content. A badge
+| saying 0 is not a missing feature; it is a wrong statement to an organiser
+| about their own country.
+|
+| Why the existing sidebar tests never caught it: every one of them seeds
+| `Country::factory()->create(['code' => 'de'])` — lowercase, overriding the
+| factory default. Under that fixture the case-sensitive comparison happens
+| to work. The casing of the fixture is a measurement axis here, not a
+| detail, so both directions are exercised below.
+|
+| Issue #51 additionally gives the country map entry its own badge, so that
+| `Karte 🇨🇿 0` next to `Welt-Karte 🌐 307` explains a deliberately
+| country-scoped map by itself. The pair only explains anything if the two
+| numbers can differ, so the fixture makes them differ.
+|
+| Anchoring: `sidebarBadgeFor()` cuts the `<a href="...">` of one entry out
+| of the document first and only then looks for the badge inside it. The
+| badge text is a bare number that also occurs in other badges, breadcrumbs
+| and page bodies — a plain regex for the number alone would match
+| something else. Same approach as SidebarRegionBadgeCountTest (that file
+| already owns the name `badgeFor`, hence the longer name here).
+|
+| Carrier page: /<country>/services. It renders the sidebar but lists
+| services only — it never renders meetup, city, course or lecturer counts
+| of its own, so nothing on the page can accidentally satisfy an assertion.
+|
+| Host: portal.einundzwanzig.space is requested explicitly. It is
+| DomainMiddleware's fallback domain and carries NO region, so
+| country_or_region_route() stays on the plain country routes and the hrefs
+| below are the ones actually rendered. Using the ambient APP_URL host
+| instead would make the expected hrefs depend on a .env value.
+|
+*/
+
+function sidebarBadgeHost(): string
+{
+    return 'http://portal.einundzwanzig.space';
+}
+
+/**
+ * The badge text of exactly one sidebar entry, addressed by its href.
+ *
+ * Returns null when the entry exists without a badge (or not at all) — that
+ * is a different statement from an entry whose badge reads '0', and the
+ * tests below rely on being able to tell those two apart.
+ */
+function sidebarBadgeFor(string $html, string $href): ?string
+{
+    if (! preg_match('/<a\s+href="'.preg_quote($href, '/').'".*?<\/a>/s', $html, $anchor)) {
+        return null;
+    }
+
+    if (! preg_match('/data-flux-navlist-badge[^>]*>([^<]*)</', $anchor[0], $badge)) {
+        return null;
+    }
+
+    return trim($badge[1]);
+}
+
+/**
+ * Every badge of interest on one country page, keyed by the route it links to.
+ *
+ * @return array<string, string|null>
+ */
+function sidebarBadgesOn(string $html, string $segment): array
+{
+    $base = sidebarBadgeHost().'/'.$segment;
+
+    return [
+        'meetups' => sidebarBadgeFor($html, $base.'/meetups'),
+        'all-meetups' => sidebarBadgeFor($html, $base.'/all-meetups'),
+        'map' => sidebarBadgeFor($html, $base.'/map'),
+        'map-world' => sidebarBadgeFor($html, $base.'/map-world'),
+        'courses' => sidebarBadgeFor($html, $base.'/courses'),
+        'lecturers' => sidebarBadgeFor($html, $base.'/lecturers'),
+        'cities' => sidebarBadgeFor($html, $base.'/cities'),
+    ];
+}
+
+function sidebarBadgeScopePage(string $path): string
+{
+    return test()->get(sidebarBadgeHost().'/'.$path)->assertOk()->getContent();
+}
+
+function sidebarBadgePage(string $segment): string
+{
+    return sidebarBadgeScopePage($segment.'/services');
+}
+
+/**
+ * The marker set the map component actually shipped to the page.
+ *
+ * `@js($meetups)` in livewire/meetups/map.blade.php renders as
+ * `markers: JSON.parse('…')` with every quote hex-escaped, and — for an empty
+ * result — as the literal `markers: []`. Both forms were measured on the
+ * rendered page, not inferred from Laravel's Js helper.
+ *
+ * null is a deliberate THIRD outcome next to `[]` and a filled array: "this
+ * page shipped no marker set at all" (component moved, render changed, the
+ * anchor rotted) must never be readable as "this country has no meetups".
+ *
+ * @return array<int, array<string, mixed>>|null
+ */
+function meetupMapMarkers(string $html): ?array
+{
+    $pattern = '/markers:\s*(?:\[\s*\]|JSON\.parse\(\s*\x27(?<payload>[^\x27]*)\x27\s*\))/';
+
+    if (! preg_match($pattern, $html, $match)) {
+        return null;
+    }
+
+    if (($match['payload'] ?? '') === '') {
+        return [];
+    }
+
+    // Two layers: the JS string literal first, the JSON it carries second.
+    $json = json_decode('"'.$match['payload'].'"');
+    $markers = is_string($json) ? json_decode($json, true) : null;
+
+    return is_array($markers) ? $markers : null;
+}
+
+/**
+ * The meetups a list page actually rendered, by slug, sorted.
+ *
+ * Each row links to `meetups.landingpage` more than once (avatar, name, and
+ * the event cell), hence the uniqueness.
+ *
+ * `/{country}/meetup/` is not only the landing page: the calendar stream
+ * picker on the very same page links `/{country}/meetup/stream-calendar`
+ * (route `ics-meetup`), which is not a meetup. Intersecting with the slugs
+ * that actually exist drops it — and it does NOT hide an over-inclusive
+ * list, because a page that failed to filter carries the other country's
+ * real slugs, and those survive the intersection.
+ *
+ * @return array<int, string>
+ */
+function meetupSlugsListedOn(string $html, string $segment): array
+{
+    preg_match_all('#/'.preg_quote($segment, '#').'/meetup/([a-z0-9\-]+)#', $html, $matches);
+
+    $slugs = array_values(array_unique(array_intersect(
+        $matches[1],
+        Meetup::query()->pluck('slug')->all()
+    )));
+    sort($slugs);
+
+    return $slugs;
+}
+
+/**
+ * @param  iterable<int, string>  $slugs
+ * @return array<int, string>
+ */
+function meetupSlugsSorted(iterable $slugs): array
+{
+    $sorted = collect($slugs)->all();
+    sort($sorted);
+
+    return $sorted;
+}
+
+/**
+ * Three countries, and no two numbers in this fixture are the same.
+ *
+ * That is the point of it: a badge that ignores the country scope entirely
+ * and counts the whole table has to produce a DIFFERENT number from the
+ * correct one for every single entry, otherwise the test would pass on a
+ * counter that never scoped anything. Per entry, "home country" vs "whole
+ * table" is 2 vs 7 meetups, 3 vs 6 cities, 2 vs 5 courses, 1 vs 4
+ * lecturers. (Six cities, not five: the third country owns one too.)
+ *
+ * The home country's two courses share ONE lecturer on purpose, so the
+ * course badge and the lecturer badge cannot be confused with each other
+ * either.
+ *
+ * The third country holds a city but nothing else — the state the reporter
+ * of #51 was actually looking at.
+ *
+ * The casing of the three stored codes is the parameter; the URL segments
+ * are always lowercase, because that is what the portal's URLs are.
+ *
+ * @return array{home: Country, other: Country, empty: Country, homeMeetupSlugs: array<int, string>, otherMeetupSlugs: array<int, string>}
+ */
+function sidebarBadgeScopeSeed(string $homeCode, string $otherCode, string $emptyCode): array
+{
+    $home = Country::factory()->create(['name' => 'Deutschland', 'english_name' => 'Germany', 'code' => $homeCode]);
+    $other = Country::factory()->create(['name' => 'Österreich', 'english_name' => 'Austria', 'code' => $otherCode]);
+    $empty = Country::factory()->create(['name' => 'Schweiz', 'english_name' => 'Switzerland', 'code' => $emptyCode]);
+
+    $homeCities = City::factory()->count(3)->create(['country_id' => $home->id, 'region_id' => null]);
+    $otherCities = City::factory()->count(2)->create(['country_id' => $other->id, 'region_id' => null]);
+    City::factory()->create(['country_id' => $empty->id, 'region_id' => null]);
+
+    $homeMeetups = Meetup::factory()->count(2)->create(['city_id' => $homeCities->first()->id]);
+    $otherMeetups = Meetup::factory()->count(5)->create(['city_id' => $otherCities->first()->id]);
+
+    $homeLecturer = Lecturer::factory()->create();
+    foreach (range(1, 2) as $ignored) {
+        CourseEvent::factory()->create([
+            'course_id' => Course::factory()->create(['lecturer_id' => $homeLecturer->id])->id,
+            'city_id' => $homeCities->first()->id,
+        ]);
+    }
+
+    // Three courses, each with its own lecturer from CourseFactory.
+    foreach (range(1, 3) as $ignored) {
+        CourseEvent::factory()->create([
+            'course_id' => Course::factory()->create()->id,
+            'city_id' => $otherCities->first()->id,
+        ]);
+    }
+
+    return [
+        'home' => $home,
+        'other' => $other,
+        'empty' => $empty,
+        'homeMeetupSlugs' => meetupSlugsSorted($homeMeetups->pluck('slug')),
+        'otherMeetupSlugs' => meetupSlugsSorted($otherMeetups->pluck('slug')),
+    ];
+}
+
+/**
+ * Both stored casings, for every case that renders a real page.
+ *
+ * Uppercase is the direction that catches issue #58. Lowercase is not
+ * decoration: it catches the over-correction — a fix that lowercases the
+ * column but uppercases the segment, or the other way round, would pass the
+ * uppercase case and break every installation whose codes are already
+ * lowercase (the portal's own database holds both, 'DE' next to 'us').
+ */
+dataset('stored country code casing', [
+    'stored uppercase' => [['DE', 'AT', 'CH']],
+    'stored lowercase' => [['de', 'at', 'ch']],
+]);
+
+/*
+|--------------------------------------------------------------------------
+| 1 + 2 — the casing, in both directions, against a fixture that scopes
+|--------------------------------------------------------------------------
+*/
+
+it('counts the country when its stored code is uppercase and the url segment is not', function () {
+    sidebarBadgeScopeSeed('DE', 'AT', 'CH');
+
+    $badges = sidebarBadgesOn(sidebarBadgePage('de'), 'de');
+
+    expect($badges)->toMatchArray([
+        // Country-scoped: the home country's own rows, never the whole table.
+        'meetups' => '2',
+        'courses' => '2',
+        'lecturers' => '1',
+        'cities' => '3',
+        // Global on purpose — these two SHOULD count everything.
+        'all-meetups' => '7',
+        'map-world' => '7',
+    ]);
+});
+
+it('still counts the country when its stored code is already lowercase', function () {
+    sidebarBadgeScopeSeed('de', 'at', 'ch');
+
+    $badges = sidebarBadgesOn(sidebarBadgePage('de'), 'de');
+
+    expect($badges)->toMatchArray([
+        'meetups' => '2',
+        'courses' => '2',
+        'lecturers' => '1',
+        'cities' => '3',
+        'all-meetups' => '7',
+        'map-world' => '7',
+    ]);
+});
+
+/*
+|--------------------------------------------------------------------------
+| Negative control for the two cases above
+|--------------------------------------------------------------------------
+|
+| The uppercase fixture only guards anything as long as the test database
+| really does compare strings case-sensitively. It does on SQLite; on MySQL
+| with a utf8mb4_*_ci collation `where('countries.code', 'de')` matches a
+| stored 'DE' all by itself. On such a connection the two tests above would
+| stay green against the very code they exist to reject, and nobody would
+| notice — the badge would be broken in exactly one place: production.
+|
+| So this measures the assumption instead of trusting it: over the same
+| fixture, the shape issue #58 reported (plain equality) has to collapse to
+| 0 while the case-insensitive shape returns the real 2, and the rendered
+| badge has to follow the second one.
+|
+| WHAT IT GUARDS, EXACTLY — and what it does not. It goes red when the
+| CONNECTION stops discriminating (a `_ci` collation), and it goes red when
+| someone lowercases the seed literal on the line right below it. It does
+| NOT cover the `stored country code casing` dataset further down: tidy that
+| dataset to lowercase-only and this control stays green while all eight
+| dataset cases quietly stop discriminating. The dataset carries its own
+| reason in its own docblock for that reason — a control cannot guard a
+| fixture it never reads.
+|
+*/
+
+it('keeps the uppercase fixture discriminating between the two comparison shapes', function () {
+    sidebarBadgeScopeSeed('DE', 'AT', 'CH');
+
+    $reportedShape = Meetup::query()
+        ->whereHas('city.country', fn ($query) => $query->where('countries.code', 'de'))
+        ->count();
+
+    // The map page spelled the very same comparison without qualifying the
+    // column (`->where('code', $this->country)`). Same semantics, same trap —
+    // both spellings that were actually in production are pinned here, so the
+    // control does not silently cover only one of them.
+    $reportedShapeUnqualified = Meetup::query()
+        ->whereHas('city.country', fn ($query) => $query->where('code', 'de'))
+        ->count();
+
+    $caseInsensitiveShape = Meetup::query()
+        ->whereHas('city.country', fn ($query) => $query->whereRaw('LOWER(countries.code) = ?', ['de']))
+        ->count();
+
+    expect($reportedShape)->toBe(0)
+        ->and($reportedShapeUnqualified)->toBe(0)
+        ->and($caseInsensitiveShape)->toBe(2)
+        ->and(sidebarBadgesOn(sidebarBadgePage('de'), 'de')['meetups'])->toBe('2');
+});
+
+/*
+|--------------------------------------------------------------------------
+| 3 — the pair issue #51 wants a reader to compare
+|--------------------------------------------------------------------------
+|
+| The country map entry carries the count of the country it links to, the
+| world map entry the count of everything. Asserting that they differ is
+| part of the case: two equal numbers would explain nothing, and the whole
+| point of the badge is to replace the explanatory prose the owner rejected.
+|
+*/
+
+it('gives the country map its own scoped count next to the global world map count', function () {
+    sidebarBadgeScopeSeed('DE', 'AT', 'CH');
+
+    $badges = sidebarBadgesOn(sidebarBadgePage('de'), 'de');
+
+    expect($badges['map'])->toBe('2')
+        ->and($badges['map-world'])->toBe('7')
+        ->and($badges['map'])->not->toBe($badges['map-world']);
+});
+
+/*
+|--------------------------------------------------------------------------
+| 4 — zero is an answer, not a failure
+|--------------------------------------------------------------------------
+|
+| The country the reporter of #51 was on: nothing of its own, while the
+| world clearly has something. Both statements have to be true at the same
+| time and both have to be rendered — a missing badge (null) is not the
+| same as a badge reading '0', so the assertions are on the string.
+|
+*/
+
+it('renders a truthful zero for a country without meetups while the world entries keep the total', function () {
+    sidebarBadgeScopeSeed('DE', 'AT', 'CH');
+
+    $badges = sidebarBadgesOn(sidebarBadgePage('ch'), 'ch');
+
+    expect($badges)->toMatchArray([
+        'meetups' => '0',
+        'map' => '0',
+        'courses' => '0',
+        'lecturers' => '0',
+        // It does have one city — "no meetups" must not be smeared over
+        // everything else the country owns.
+        'cities' => '1',
+        'all-meetups' => '7',
+        'map-world' => '7',
+    ]);
+});
+
+/*
+|--------------------------------------------------------------------------
+| 5 — the pages behind the links, not only the badges beside them
+|--------------------------------------------------------------------------
+|
+| The same case-sensitive comparison sits on the pages themselves:
+| livewire/meetups/map.blade.php filtered its markers with
+| `->where('code', $this->country)` and livewire/meetups/index.blade.php its
+| rows with `->where('countries.code', $this->country)`. Measured by the
+| author of the sidebar fix: with a stored 'US' and the route /us/map the map
+| drew ZERO markers while the freshly corrected sidebar badge said 3.
+|
+| That is the worse half of issue #58. A badge showing 0 is a wrong number; a
+| badge showing 3 next to an empty map is a wrong number AND a broken
+| promise, and the organiser has no way to tell which of the two lies.
+|
+| These cases therefore assert on the server-rendered payload of the page
+| itself, not on the sidebar of that page.
+|
+*/
+
+it('plots only the country meetups on its own map page', function (array $codes) {
+    $seed = sidebarBadgeScopeSeed(...$codes);
+
+    $markers = meetupMapMarkers(sidebarBadgeScopePage('de/map'));
+
+    expect($markers)->not->toBeNull()
+        ->and(meetupSlugsSorted(collect($markers)->pluck('slug')))->toBe($seed['homeMeetupSlugs'])
+        ->and($markers)->toHaveCount(2);
+})->with('stored country code casing');
+
+it('lists only the country meetups on the meetups page', function (array $codes) {
+    $seed = sidebarBadgeScopeSeed(...$codes);
+
+    expect(meetupSlugsListedOn(sidebarBadgeScopePage('de/meetups'), 'de'))
+        ->toBe($seed['homeMeetupSlugs']);
+})->with('stored country code casing');
+
+/*
+|--------------------------------------------------------------------------
+| 6 — the badge and the page it links to have to be the SAME number
+|--------------------------------------------------------------------------
+|
+| This is the case issue #51 actually rests on. `Karte 🇨🇿 0` next to
+| `Welt-Karte 🌐 307` only explains a country-scoped map if the 0 is the
+| number of markers a reader finds after clicking. The moment the two
+| numbers come from two differently-spelled filters, the badge stops being
+| an explanation and becomes a second, contradicting claim.
+|
+| Asserted against EACH OTHER, so the pair cannot drift apart while both
+| halves still match some constant a test author wrote down. The second
+| expectation is the other half of that trap: "0 equals 0" satisfies
+| agreement perfectly on a badge that counts nothing and a page that filters
+| everything away — which is exactly the state master was in. Agreement is
+| only worth asserting together with the number both sides owe the database.
+|
+*/
+
+it('keeps the sidebar map badge and the markers on the map it links to the same number', function (array $codes) {
+    sidebarBadgeScopeSeed(...$codes);
+
+    $badge = sidebarBadgesOn(sidebarBadgePage('de'), 'de')['map'];
+    $markers = meetupMapMarkers(sidebarBadgeScopePage('de/map'));
+
+    expect($markers)->not->toBeNull()
+        ->and((string) count($markers))->toBe($badge)
+        ->and($badge)->toBe('2');
+})->with('stored country code casing');
+
+/*
+|--------------------------------------------------------------------------
+| 7 — zero on the page, too, and still distinguishable from a broken filter
+|--------------------------------------------------------------------------
+*/
+
+it('renders an empty map and a zero badge for a country without meetups', function (array $codes) {
+    $seed = sidebarBadgeScopeSeed(...$codes);
+
+    $html = sidebarBadgeScopePage('ch/map');
+
+    // `[]`, not null: the page DID ship a marker set and it is empty. A null
+    // here would mean the anchor no longer finds the payload, which must not
+    // be allowed to pass as "this country has no meetups".
+    expect(meetupMapMarkers($html))->toBe([])
+        ->and(sidebarBadgesOn(sidebarBadgePage('ch'), 'ch')['map'])->toBe('0');
+
+    // ... and it is empty because the filter WORKED, not because the page
+    // rendered nothing: the other countries' meetups exist and must be
+    // absent from this page by name.
+    foreach ([...$seed['homeMeetupSlugs'], ...$seed['otherMeetupSlugs']] as $foreignSlug) {
+        expect($html)->not->toContain($foreignSlug);
+    }
+})->with('stored country code casing');


### PR DESCRIPTION
Closes #58. Closes #51.

#58 reported that the country-scoped sidebar badges render `0` for a country that has content — they compared `countries.code` case-sensitively while the region lookup a few lines above deliberately uses `LOWER(code)`. #51 is the same defect wearing a different face: a reporter opened `/cz/map`, saw a nearly empty map, and read it as the map being broken.

The country map is scoped **on purpose** — one country so a visitor is not drowned in markers, with `/{country}/map-world` next to it for all of them, and a flag in the sidebar marking the difference. The counts are what should make that legible, so the country entry now carries its own scoped number beside the world entry's global one, narrowing to the region where the link actually goes.

That badge is only worth having if it tells the truth, which turned out to be larger than one comparison. `Country::scopeMatchingCode()` compares `LOWER(<qualified code>)` and fails closed on an empty code; eleven call sites use it. Measured with a stored `'US'`: `/us/map` 0 → 3 markers, `/us/in/map` 0 → 2, and four list pages that showed nothing now show their records.

Two sites were found by measuring rather than from a list. The city form opened without a preselected country although the URL named it. And the calendar feed failed **open**: the gate ran the same comparison, so a failed gate returned `null` and no filter was applied at all — `?country=de` returned all five events instead of two. An empty calendar would have been noticed; an over-full one is not.

Thirteen tests plus two more added after review found the calendar gate and the city form had no test that could fail — reverting them left 62 of 62 and 148 of 148 tests green. The load-bearing assertion pairs the sidebar badge against the marker count on the map it links to **and** against the number the database owes them, because comparing them only to each other is satisfied by `0 == 0`, which is exactly the state this branch started from.

Full non-Browser suite: 1893 passed, 6951 assertions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A4BKf2zxFNSRKBoMUB8EUW