### PR TITLE
Close the three loose ends #40 left in the webhook approval flow

### DIFF
--- a/app/Console/Commands/ApproveWebhookSubscription.php
+++ b/app/Console/Commands/ApproveWebhookSubscription.php
@@ -17,6 +17,17 @@ use Illuminate\Console\Command;
  * RetryWebhookDeliveries' "leave re-enabling to the owner". A previously
  * rejected subscription may still be approved — an operator reviewing again
  * and changing their mind is not a special case.
+ *
+ * Writes the two operator columns and nothing else, the same pair the admin
+ * UI's approve() writes (resources/views/livewire/admin/webhooks.blade.php).
+ * Until Issue #54 it also forced `active` to true and `disabled_at` to null,
+ * which contradicted the paragraph above as well as the migration's "only the
+ * owner clears it again (PATCH)": on a new subscription those two writes
+ * changed nothing (both start that way), and on the one row where they did —
+ * a subscription the owner paused, or one the system auto-disabled and an
+ * operator then revoked back into the pending queue — approving silently
+ * released the brake, while leaving `consecutive_failures` untouched so the
+ * next failure disabled it straight away.
  */
 class ApproveWebhookSubscription extends Command
 {
@@ -61,8 +72,6 @@ class ApproveWebhookSubscription extends Command
         $subscription->forceFill([
             'approved_at' => now(),
             'rejected_at' => null,
-            'active' => true,
-            'disabled_at' => null,
         ])->save();
 
         $this->info("Subscription #{$subscription->id} approved.");

--- a/app/Policies/WebhookSubscriptionPolicy.php
+++ b/app/Policies/WebhookSubscriptionPolicy.php
@@ -48,6 +48,16 @@ class WebhookSubscriptionPolicy
     }
 
     /**
+     * Board-only: records the decline in `rejected_at`, without touching
+     * `approved_at`, `active` or the subscription itself — the request leaves
+     * the pending queue for good (Issue #40).
+     */
+    public function reject(User $user, WebhookSubscription $subscription): bool
+    {
+        return BoardGate::allows($user);
+    }
+
+    /**
      * Board-only: clears `approved_at` again, without touching `active` or
      * the subscription itself.
      */

--- a/config/einundzwanzig.php
+++ b/config/einundzwanzig.php
@@ -297,6 +297,28 @@ return [
     | that fails ten separate events in a row is disabled and stays disabled
     | until its owner re-enables it via PATCH.
     |
+    | `contact_npub` is where an owner asks after a subscription that is still
+    | waiting (Issue #54). No turnaround time is promised anywhere in the UI —
+    | nobody can hold one — so the address IS the whole answer to "and if
+    | nothing happens?" and has to be reachable, not decorative.
+    |
+    | Deliberately its own key rather than `board_members[0]`: that list is an
+    | authorisation allowlist whose order carries no meaning, and reading a
+    | contact out of it would silently reassign the mailbox the day someone
+    | re-sorts the array. Deliberately not hardcoded in a Blade view either.
+    | Counted 2026-09-04, this npub already stands in SIX places outside this
+    | key: README.md, CODE_OF_CONDUCT.md, config/horizon.php, twice in this
+    | file (`tag_editors` and `board_members`) and .github/ISSUE_TEMPLATE/
+    | config.yml. A seventh copy inside a template is the one that gets missed
+    | when the board hands the role over, and unlike the other six it would be
+    | the one users are told to write to. Both the settings page and the
+    | webhooks documentation derive their njump URL from this value, so there
+    | is exactly one string to change here — and both hide their contact block
+    | entirely when it is empty rather than rendering a link to nowhere.
+    |
+    | Today's value is also a board member, which is a coincidence of staffing,
+    | not a rule: any npub that a human actually reads DMs on belongs here.
+    |
     */
 
     'webhooks' => [
@@ -305,6 +327,7 @@ return [
         'timeout_seconds' => 10,
         'backoff_seconds' => [60, 300, 1800, 7200, 21600],
         'auto_disable_after' => 10,
+        'contact_npub' => 'npub1pt0kw36ue3w2g4haxq3wgm6a2fhtptmzsjlc2j2vphtcgle72qesgpjyc6',
     ],
 
     /*

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -891,5 +891,7 @@
     "Besucher sehen an dieser Stelle dasselbe.": "Návštěvníci zde vidí totéž.",
     "Ort als Text": "Místo jako text",
     "z.B. Hinterzimmer im Café Mustermann": "např. zadní místnost v Café Mustermann",
-    "Freitext für Besucher. Auch Details, die ein Kartenpunkt nicht zeigt.": "Volný text pro návštěvníky. I detaily, které bod na mapě neukáže."
+    "Freitext für Besucher. Auch Details, die ein Kartenpunkt nicht zeigt.": "Volný text pro návštěvníky. I detaily, které bod na mapě neukáže.",
+    "Eine feste Bearbeitungszeit nennen wir nicht — wir könnten sie nicht zusagen. Wenn du nichts hörst, frag per Nostr-DM nach:": "Neslibujeme žádnou lhůtu na vyřízení — nedokázali bychom ji dodržet. Pokud se nikdo neozve, napiš nám přes Nostr DM:",
+    "Profil auf njump öffnen": "Otevřít profil na njump"
 }

--- a/lang/de.json
+++ b/lang/de.json
@@ -891,5 +891,7 @@
     "Besucher sehen an dieser Stelle dasselbe.": "",
     "Ort als Text": "",
     "z.B. Hinterzimmer im Café Mustermann": "",
-    "Freitext für Besucher. Auch Details, die ein Kartenpunkt nicht zeigt.": ""
+    "Freitext für Besucher. Auch Details, die ein Kartenpunkt nicht zeigt.": "",
+    "Eine feste Bearbeitungszeit nennen wir nicht — wir könnten sie nicht zusagen. Wenn du nichts hörst, frag per Nostr-DM nach:": "",
+    "Profil auf njump öffnen": ""
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -891,5 +891,7 @@
     "Besucher sehen an dieser Stelle dasselbe.": "Visitors see the same thing here.",
     "Ort als Text": "Location as text",
     "z.B. Hinterzimmer im Café Mustermann": "e.g. back room at Cafe Mustermann",
-    "Freitext für Besucher. Auch Details, die ein Kartenpunkt nicht zeigt.": "Free text for visitors. Also details a map pin cannot show."
+    "Freitext für Besucher. Auch Details, die ein Kartenpunkt nicht zeigt.": "Free text for visitors. Also details a map pin cannot show.",
+    "Eine feste Bearbeitungszeit nennen wir nicht — wir könnten sie nicht zusagen. Wenn du nichts hörst, frag per Nostr-DM nach:": "We do not promise a turnaround time — we could not keep one. If you hear nothing, ask by Nostr DM:",
+    "Profil auf njump öffnen": "Open profile on njump"
 }

--- a/lang/es.json
+++ b/lang/es.json
@@ -891,5 +891,7 @@
     "Besucher sehen an dieser Stelle dasselbe.": "Los visitantes ven aquí lo mismo.",
     "Ort als Text": "Ubicación como texto",
     "z.B. Hinterzimmer im Café Mustermann": "p. ej. sala trasera del Café Mustermann",
-    "Freitext für Besucher. Auch Details, die ein Kartenpunkt nicht zeigt.": "Texto libre para los visitantes. También detalles que un punto en el mapa no muestra."
+    "Freitext für Besucher. Auch Details, die ein Kartenpunkt nicht zeigt.": "Texto libre para los visitantes. También detalles que un punto en el mapa no muestra.",
+    "Eine feste Bearbeitungszeit nennen wir nicht — wir könnten sie nicht zusagen. Wenn du nichts hörst, frag per Nostr-DM nach:": "No prometemos un plazo de respuesta: no podríamos cumplirlo. Si no recibes noticias, escríbenos por DM en Nostr:",
+    "Profil auf njump öffnen": "Abrir el perfil en njump"
 }

--- a/lang/hu.json
+++ b/lang/hu.json
@@ -891,5 +891,7 @@
     "Besucher sehen an dieser Stelle dasselbe.": "A látogatók ugyanezt látják itt.",
     "Ort als Text": "Helyszín szövegként",
     "z.B. Hinterzimmer im Café Mustermann": "pl. hátsó terem a Café Mustermannban",
-    "Freitext für Besucher. Auch Details, die ein Kartenpunkt nicht zeigt.": "Szabad szöveg a látogatóknak. Olyan részletek is, amelyeket a térképpont nem mutat."
+    "Freitext für Besucher. Auch Details, die ein Kartenpunkt nicht zeigt.": "Szabad szöveg a látogatóknak. Olyan részletek is, amelyeket a térképpont nem mutat.",
+    "Eine feste Bearbeitungszeit nennen wir nicht — wir könnten sie nicht zusagen. Wenn du nichts hörst, frag per Nostr-DM nach:": "Nem ígérünk átfutási időt — nem tudnánk betartani. Ha nem kapsz választ, írj nekünk Nostr DM-ben:",
+    "Profil auf njump öffnen": "Profil megnyitása a njumpon"
 }

--- a/lang/lv.json
+++ b/lang/lv.json
@@ -891,5 +891,7 @@
     "Besucher sehen an dieser Stelle dasselbe.": "Apmeklētāji šeit redz to pašu.",
     "Ort als Text": "Vieta kā teksts",
     "z.B. Hinterzimmer im Café Mustermann": "piem., aizmugurējā telpa Café Mustermann",
-    "Freitext für Besucher. Auch Details, die ein Kartenpunkt nicht zeigt.": "Brīvs teksts apmeklētājiem. Arī detaļas, ko kartes punkts neparāda."
+    "Freitext für Besucher. Auch Details, die ein Kartenpunkt nicht zeigt.": "Brīvs teksts apmeklētājiem. Arī detaļas, ko kartes punkts neparāda.",
+    "Eine feste Bearbeitungszeit nennen wir nicht — wir könnten sie nicht zusagen. Wenn du nichts hörst, frag per Nostr-DM nach:": "Mēs nesolām apstrādes termiņu — mēs to nevarētu ievērot. Ja atbildes nav, raksti mums Nostr ziņā:",
+    "Profil auf njump öffnen": "Atvērt profilu vietnē njump"
 }

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -891,5 +891,7 @@
     "Besucher sehen an dieser Stelle dasselbe.": "Bezoekers zien hier hetzelfde.",
     "Ort als Text": "Locatie als tekst",
     "z.B. Hinterzimmer im Café Mustermann": "bijv. achterzaal in Café Mustermann",
-    "Freitext für Besucher. Auch Details, die ein Kartenpunkt nicht zeigt.": "Vrije tekst voor bezoekers. Ook details die een kaartpunt niet toont."
+    "Freitext für Besucher. Auch Details, die ein Kartenpunkt nicht zeigt.": "Vrije tekst voor bezoekers. Ook details die een kaartpunt niet toont.",
+    "Eine feste Bearbeitungszeit nennen wir nicht — wir könnten sie nicht zusagen. Wenn du nichts hörst, frag per Nostr-DM nach:": "We beloven geen doorlooptijd — die zouden we niet kunnen waarmaken. Hoor je niets, stuur ons dan een Nostr-DM:",
+    "Profil auf njump öffnen": "Profiel openen op njump"
 }

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -891,5 +891,7 @@
     "Besucher sehen an dieser Stelle dasselbe.": "Odwiedzający widzą tutaj to samo.",
     "Ort als Text": "Lokalizacja jako tekst",
     "z.B. Hinterzimmer im Café Mustermann": "np. zaplecze w Café Mustermann",
-    "Freitext für Besucher. Auch Details, die ein Kartenpunkt nicht zeigt.": "Wolny tekst dla odwiedzających. Także szczegóły, których nie pokaże punkt na mapie."
+    "Freitext für Besucher. Auch Details, die ein Kartenpunkt nicht zeigt.": "Wolny tekst dla odwiedzających. Także szczegóły, których nie pokaże punkt na mapie.",
+    "Eine feste Bearbeitungszeit nennen wir nicht — wir könnten sie nicht zusagen. Wenn du nichts hörst, frag per Nostr-DM nach:": "Nie obiecujemy czasu rozpatrzenia — nie moglibyśmy go dotrzymać. Jeśli nie dostaniesz odpowiedzi, napisz do nas przez DM na Nostr:",
+    "Profil auf njump öffnen": "Otwórz profil na njump"
 }

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -891,5 +891,7 @@
     "Besucher sehen an dieser Stelle dasselbe.": "Os visitantes veem aqui o mesmo.",
     "Ort als Text": "Local como texto",
     "z.B. Hinterzimmer im Café Mustermann": "p. ex. sala dos fundos no Café Mustermann",
-    "Freitext für Besucher. Auch Details, die ein Kartenpunkt nicht zeigt.": "Texto livre para os visitantes. Também detalhes que um ponto no mapa não mostra."
+    "Freitext für Besucher. Auch Details, die ein Kartenpunkt nicht zeigt.": "Texto livre para os visitantes. Também detalhes que um ponto no mapa não mostra.",
+    "Eine feste Bearbeitungszeit nennen wir nicht — wir könnten sie nicht zusagen. Wenn du nichts hörst, frag per Nostr-DM nach:": "Não prometemos um prazo de resposta: não conseguiríamos cumpri-lo. Se não tiveres notícias, escreve-nos por DM no Nostr:",
+    "Profil auf njump öffnen": "Abrir perfil no njump"
 }

--- a/resources/views/livewire/admin/webhooks.blade.php
+++ b/resources/views/livewire/admin/webhooks.blade.php
@@ -26,6 +26,17 @@ new class extends Component
 {
     use SeoTrait;
 
+    /**
+     * Stays a BoardGate check rather than an $this->authorize() call, unlike
+     * the three actions below: this page's guard is about the whole pending
+     * queue — every owner's URL — and there is no subscription to pass to a
+     * policy ability here. WebhookSubscriptionPolicy::viewAny() could not
+     * carry the rule as it stands either: it returns true for every
+     * authenticated user, and nothing calls it — grepped 2026-09-04, the
+     * ability has no caller in app/, routes/ or resources/ — so wiring it up
+     * here without rewriting it would gate nothing. Both mechanisms ask
+     * BoardGate in the end (Issue #54).
+     */
     public function mount(): void
     {
         abort_unless(BoardGate::allows(auth()->user()), 403);
@@ -58,6 +69,22 @@ new class extends Component
             ->get();
     }
 
+    /**
+     * Unlocks delivery, and takes back a rejection while doing so: approving
+     * is a statement that overrides an earlier decline, the same rule the
+     * `webhook:approve` command follows. Without clearing `rejected_at` a row
+     * could end up carrying both timestamps, and settings/webhooks.blade.php's
+     * statusFor() reads `rejected_at` first — the owner would be shown
+     * "Abgelehnt" for a subscription that is delivering (Issue #54). The
+     * reachable route to that state is a stale render: the pending list
+     * excludes rejected rows, but a second operator can reject between this
+     * page's render and the click on its Freigeben button.
+     *
+     * `active` and `disabled_at` stay untouched here — the owner's pause
+     * switch and the system's auto-disable are not the board's to flip (see
+     * the migration's docblock); an approved-but-blocked subscription is
+     * flagged by stillBlocked() instead.
+     */
     public function approve(int $id): void
     {
         $subscription = WebhookSubscription::findOrFail($id);
@@ -65,6 +92,7 @@ new class extends Component
         $this->authorize('approve', $subscription);
 
         $subscription->approved_at = now();
+        $subscription->rejected_at = null;
         $subscription->save();
 
         session()->flash('status', __('Webhook-Subscription freigegeben.'));
@@ -79,21 +107,15 @@ new class extends Component
      * `approved_at`, the owner's `active` switch and the row itself stay
      * untouched, exactly as in revoke().
      *
-     * Gated through BoardGate instead of $this->authorize() because
-     * WebhookSubscriptionPolicy carries no `reject` ability and app/Policies
-     * is outside this change; mount() uses the same gate, and this check is
-     * the one that holds on a follow-up Livewire request, where mount() does
-     * not run again.
-     *
      * An already decided subscription is a no-op rather than an error: the
      * only way to get here is a second click on a stale render, and the row
      * has left the pending list either way.
      */
     public function reject(int $id): void
     {
-        abort_unless(BoardGate::allows(auth()->user()), 403);
-
         $subscription = WebhookSubscription::findOrFail($id);
+
+        $this->authorize('reject', $subscription);
 
         if ($subscription->approved_at !== null || $subscription->rejected_at !== null) {
             return;

--- a/resources/views/livewire/docs/webhooks.blade.php
+++ b/resources/views/livewire/docs/webhooks.blade.php
@@ -820,11 +820,40 @@ class extends Component
                         @endif
                     </flux:heading>
                 </div>
+                @php
+                    // Read once for the whole page: this box and the webhook:retry box below
+                    // both route "my thing is stuck" to the same address, and two config
+                    // lookups are two chances to mistype one.
+                    $contactNpub = config('einundzwanzig.webhooks.contact_npub');
+                @endphp
                 <p class="mt-3 text-pretty text-sm leading-relaxed text-zinc-700 dark:text-zinc-200">
+                    {{-- Issue #54: two questions, two channels, and they are deliberately not
+                         the same one. "My subscription is stuck" — including "please re-queue
+                         my deliveries" further down — is answered by a DM, because it is
+                         addressed to a person and the asker wants an answer about ONE record,
+                         not a ticket. "Please offer resource X" is answered by the issue
+                         tracker at the bottom of this page, because it is a change to the
+                         software and belongs where changes are argued. Do not merge them back
+                         together: the box below used to answer both with one link to issue
+                         #36, which has been closed since 2026-08-31 — so the person waiting
+                         was being sent to a closed issue, and one without a GitHub account
+                         nowhere at all.
+
+                         The DM clause is conditional for the same reason the settings page
+                         hides its whole block: with the key empty this used to render
+                         `href="https://njump.me/"` (measured 2026-09-04), a link to nothing.
+                         The npub comes from config so this page and the settings page cannot
+                         drift apart; see config/einundzwanzig.php, webhooks.contact_npub. --}}
                     @if ($this->requiresApproval)
                         A new subscription is <code>pending</code> and receives nothing until an
-                        operator approves it. Say hello on the issue below if nothing happens —
-                        and run a catch-up over <code>/api/changes</code> as your first act once
+                        operator approves it.
+                        @if ($contactNpub)
+                            We do not promise a turnaround — we could not keep one; if nothing
+                            happens, ask by
+                            <a href="https://njump.me/{{ $contactNpub }}"
+                               class="underline underline-offset-4" target="_blank" rel="noopener">Nostr DM</a>.
+                        @endif
+                        Run a catch-up over <code>/api/changes</code> as your first act once
                         it is live.
                     @else
                         Approval is switched off on this installation: the subscription is
@@ -990,8 +1019,24 @@ class extends Component
                         re-queues every delivery of one subscription that we gave up on. It
                         deliberately refuses while the subscription is pending, paused or
                         disabled — re-enabling is the owner's decision, and requeueing behind
-                        their back would defeat the auto-disable. Ask for it on the issue below if
-                        you need it; for a gap you can close yourself, <code>/api/changes</code> is
+                        their back would defeat the auto-disable.
+                        {{-- This one moved from the issue tracker to the DM on second reading,
+                             and it is the sharper test of the split: "run webhook:retry on
+                             subscription 41" names ONE record, asks an operator to act on it
+                             now, and produces nothing anyone else can read. That is the same
+                             shape as a stalled approval, not the shape of "please offer city
+                             webhooks" — which changes the software for everybody and belongs
+                             on the tracker. The rule is the OBJECT of the request, not who is
+                             asking: one record, one person's problem, a DM. --}}
+                        @if ($contactNpub)
+                            Ask for it by
+                            <a href="https://njump.me/{{ $contactNpub }}"
+                               class="underline underline-offset-4" target="_blank" rel="noopener">Nostr DM</a>
+                            if you need it;
+                        @else
+                            Ask an operator for it if you need it;
+                        @endif
+                        for a gap you can close yourself, <code>/api/changes</code> is
                         faster.
                     </p>
                 </div>
@@ -1169,13 +1214,27 @@ class extends Component
             <div class="flex items-start gap-4 rounded-2xl border border-zinc-200 bg-white/60 p-6 dark:border-white/10 dark:bg-white/[0.03]">
                 <flux:icon name="chat-bubble-left-right" class="mt-0.5 size-5 shrink-0 text-orange-500"/>
                 <div>
-                    <flux:heading size="lg" class="mb-2">Missing a resource, or waiting for approval?</flux:heading>
+                    <flux:heading size="lg" class="mb-2">Missing a resource?</flux:heading>
+                    {{-- The heading used to read "Missing a resource, or waiting for approval?"
+                         and answered both with the same link. A stalled approval is now answered
+                         where it is felt, in "Then it waits" above; this box keeps the question
+                         an issue tracker is actually good at. Issue #36 was the wrong target for
+                         either: it is the implementation issue and has been closed since
+                         2026-08-31, so a comment on it reaches its participants and nobody else.
+
+                         The old link was worse than stale, it was DEAD. Measured 2026-09-04
+                         with curl: einundzwanzig-app is a former repository name, and GitHub's
+                         rename redirect covers the repo root and /issues (both HTTP 301 with a
+                         Location header) but NOT a single-issue path — /einundzwanzig-app/
+                         issues/36 answers 404 with no Location at all. So this now points at
+                         the issue LIST, which redirects and stays live, and at the current
+                         repository name, which does not depend on a redirect surviving. --}}
                     <p class="text-pretty leading-relaxed text-zinc-600 dark:text-zinc-300">
                         Cities, courses, course events and lecturers are in the change log but not
                         on the webhook offer; widening it is a config change, not a feature. Say
                         so — with the resource you need by name — on
-                        <a href="https://github.com/HolgerHatGarKeineNode/einundzwanzig-app/issues/36"
-                           class="underline underline-offset-4" target="_blank" rel="noopener">issue #36</a>.
+                        <a href="https://github.com/HolgerHatGarKeineNode/einundzwanzig-portal/issues"
+                           class="underline underline-offset-4" target="_blank" rel="noopener">the issue tracker</a>.
                     </p>
                 </div>
             </div>

--- a/resources/views/livewire/settings/webhooks.blade.php
+++ b/resources/views/livewire/settings/webhooks.blade.php
@@ -247,9 +247,76 @@ class extends Component
                        :subheading="__('Erhalte eine HTTP-Benachrichtigung, sobald sich ein Meetup oder ein Meetup-Termin ändert.')">
 
         <div class="space-y-8">
-            <flux:text>
-                {{ __('Eine Webhook-Subscription sendet einen signierten HTTP-POST an deine URL, sobald sich eine der ausgewählten Ressourcen ändert. Neue Subscriptions müssen vom Vorstand des EINUNDZWANZIG e.V. freigeschaltet werden, bevor sie Zustellungen erhalten.') }}
-            </flux:text>
+            {{-- Issue #54: the paragraph named WHO approves but left "and then?"
+                 unanswered. Deliberately no turnaround time — nobody can hold one,
+                 and an invented "usually a few days" is a promise the reader would
+                 measure us against. What replaces it is an address, so the silence
+                 is a stated choice with a way out rather than a gap. --}}
+            <div class="space-y-3">
+                <flux:text>
+                    {{ __('Eine Webhook-Subscription sendet einen signierten HTTP-POST an deine URL, sobald sich eine der ausgewählten Ressourcen ändert. Neue Subscriptions müssen vom Vorstand des EINUNDZWANZIG e.V. freigeschaltet werden, bevor sie Zustellungen erhalten.') }}
+                </flux:text>
+
+                @php
+                    $contactNpub = config('einundzwanzig.webhooks.contact_npub');
+                @endphp
+
+                {{-- Sentence and address stand or fall TOGETHER. With the key empty, the
+                     sentence used to render on its own and end in a dangling colon —
+                     measured 2026-09-04, an unfulfilled promise, which is worse than the
+                     gap issue #54 started from. There is deliberately no fallback wording
+                     either: a sentence that announces "we promise no turnaround" and then
+                     offers no way to ask states the omission and leaves the reader exactly
+                     where they were. That is the same information as silence, with more
+                     noise. So an empty key means the paragraph above is the whole answer,
+                     as it was before this issue. --}}
+                @if ($contactNpub)
+                    <flux:text>
+                        {{ __('Eine feste Bearbeitungszeit nennen wir nicht — wir könnten sie nicht zusagen. Wenn du nichts hörst, frag per Nostr-DM nach:') }}
+                    </flux:text>
+
+                    {{-- The address is the control: clicking the npub copies the npub,
+                         so there is no separate copy button and no icon to explain.
+                         A real <button> rather than the <code role="button"> used by
+                         x-nostr-calendar-address — that Alpine directive binds `click`
+                         only, so on a non-button element Enter and Space do nothing
+                         (WCAG 2.1.1). A button gets both for free.
+
+                         `break-all` because an npub is 63 characters with no break
+                         opportunity. Measured 2026-09-04: unwrapped it is 555px wide,
+                         so in a 375px viewport it would set the page's minimum width
+                         and force horizontal scroll. With break-all it is 327px and the
+                         document stays at 375.
+
+                         The BORDER, not the fill, is what identifies this as a control
+                         (WCAG 1.4.11 wants 3:1 for that). A fill cannot do the job here:
+                         Flux's dark page background IS zinc-800 in this build — measured
+                         rgb(38,38,38) for both — so `dark:bg-zinc-800` rendered a panel
+                         with a contrast of 1.00:1 against its own page, i.e. no panel at
+                         all. zinc-500 measures 4.74:1 against the light page and 3.19:1
+                         against the dark one. The fill is kept for hover only, where it
+                         is feedback rather than identification. --}}
+                    <div x-data class="space-y-2">
+                        <button type="button"
+                                data-testid="webhook-contact-npub"
+                                x-copy-to-clipboard="'{{ $contactNpub }}'"
+                                title="{{ __('In die Zwischenablage kopieren') }}"
+                                class="block w-full break-all rounded-lg border border-zinc-500 p-3 text-left font-mono text-sm text-zinc-800 transition-colors hover:bg-zinc-100 dark:text-zinc-100 dark:hover:bg-zinc-700">{{ $contactNpub }}</button>
+
+                        {{-- `underline` and `py-1` are not decoration. Measured 2026-09-04:
+                             a flux:link renders with text-decoration `none` and no external
+                             icon, so on its own line it would be a link identified by colour
+                             alone (WCAG 1.4.1), and it measured 19px tall against the 24px
+                             floor of WCAG 2.5.8 — whose "inline" exception does not cover a
+                             link that is its own block. The underline matches the docs page,
+                             which underlines every outbound link. --}}
+                        <flux:link :href="'https://njump.me/'.$contactNpub" external variant="subtle"
+                                   class="inline-block py-1 text-sm underline underline-offset-4">
+                            {{ __('Profil auf njump öffnen') }}
+                        </flux:link>
+                    </div>
+                @endif
+            </div>
 
             @if (session('status'))
                 <flux:callout variant="success">{{ session('status') }}</flux:callout>

--- a/tests/Feature/Admin/WebhookApprovalTest.php
+++ b/tests/Feature/Admin/WebhookApprovalTest.php
@@ -85,7 +85,13 @@ it('flips the owners settings page status from awaiting approval to active once 
     Livewire::test('admin.webhooks')->call('approve', $subscription->id);
 
     $this->actingAs($owner);
-    Livewire::test('settings.webhooks')->assertSee('Aktiv');
+    // assertSee('Aktiv') alone does not measure anything on this page: the
+    // reveal-secret hint above the list contains "Aktiviert, kannst du es …",
+    // so the substring is present even while the row still reads "Wartet auf
+    // Freigabe" (measured 2026-09-04). The status itself is what flipped.
+    Livewire::test('settings.webhooks')
+        ->assertSee('Aktiv')
+        ->assertDontSee('Wartet auf Freigabe');
 });
 
 it('refuses approval from a non-board user even by direct policy check', function () {
@@ -304,6 +310,46 @@ it('refuses a rejection from a non-board user', function () {
 });
 
 /*
+ * The mirror of the approve/revoke pair above, which reject() was missing. Its
+ * absence was not theoretical: with `WebhookSubscriptionPolicy::reject()`
+ * replaced by `return true`, or with the `$this->authorize('reject', …)` line
+ * deleted from the component, all 109 webhook tests stayed green — the test
+ * above only sees the mount() gate, which is a different mechanism.
+ */
+it('refuses a rejection from a non-board user even by direct policy check', function () {
+    $outsider = actingAsUser();
+    $subscription = WebhookSubscription::factory()->pending()->create();
+
+    expect($outsider->can('reject', $subscription))->toBeFalse();
+    expect($subscription->fresh()->rejected_at)->toBeNull();
+});
+
+/*
+ * And the path mount() structurally cannot cover: mount runs once, on the
+ * initial render. Every follow-up Livewire request hydrates the existing
+ * snapshot and goes straight to the action, so a request that arrives without
+ * board membership — a session that changed, or a hand-built update payload
+ * against a captured snapshot — never passes mount() again. Only the ability
+ * on the action stands between it and the write.
+ */
+it('refuses reject on an already mounted component once the caller is no longer on the board', function () {
+    $this->actingAs(boardMember());
+    $subscription = WebhookSubscription::factory()->pending()->create();
+
+    // Mounted while the caller was on the board — assertOk() so this test cannot
+    // pass by accident through a mount-time 403 instead of the action guard.
+    $mounted = Livewire::test('admin.webhooks')->assertOk();
+
+    $this->actingAs(User::factory()->create());
+
+    $mounted->call('reject', $subscription->id)->assertStatus(403);
+
+    expect($subscription->fresh()->rejected_at)->toBeNull()
+        // Still awaiting a real decision, not silently taken out of the queue.
+        ->and(WebhookSubscription::query()->pending()->whereKey($subscription->id)->exists())->toBeTrue();
+});
+
+/*
 |--------------------------------------------------------------------------
 | Click acknowledgement
 |--------------------------------------------------------------------------
@@ -347,4 +393,81 @@ it('disables approve, reject and revoke while their own request is in flight', f
             ->and($button)->toContain('wire:loading.attr="disabled"')
             ->and($button)->toContain('wire:target="'.$call.'"');
     }
+});
+
+/*
+|--------------------------------------------------------------------------
+| Issue #54 — approve() writes the operator's two columns, and only those
+|--------------------------------------------------------------------------
+|
+| The admin approve() and the webhook:approve command had drifted apart: the
+| command cleared `rejected_at`, `active` and `disabled_at`, this view wrote
+| only `approved_at`. Both now write `approved_at` + `rejected_at` and leave
+| the owner's pause switch and the system's auto-disable alone (the migration
+| docblock's "only the owner clears it again").
+|
+| Neither half was measured. Dropping `$subscription->rejected_at = null;`
+| from approve() left all 106 webhook tests green, which is why the first
+| test below exists; the second pins the half that must NOT be aligned, the
+| one a future "let's make approve fix everything" change would break.
+|
+*/
+
+it('clears an earlier rejection when approving a row that was rejected under a stale render', function () {
+    $owner = User::factory()->create();
+    $this->actingAs(boardMember());
+
+    $subscription = WebhookSubscription::factory()->pending()->create(['user_id' => $owner->id]);
+
+    // Nothing is crafted here: the pending queue excludes rejected rows, but this
+    // operator's queue was rendered while the row was still pending and a second
+    // operator rejected it in between. reject() already guards the mirror case.
+    $staleQueue = Livewire::test('admin.webhooks');
+    Livewire::test('admin.webhooks')->call('reject', $subscription->id);
+    expect($subscription->fresh()->rejected_at)->not->toBeNull();
+
+    $staleQueue->call('approve', $subscription->id);
+
+    $fresh = $subscription->fresh();
+
+    expect($fresh->approved_at)->not->toBeNull()
+        ->and($fresh->rejected_at)->toBeNull()
+        ->and(WebhookSubscription::query()->eligibleForDelivery()->whereKey($subscription->id)->exists())->toBeTrue();
+
+    // Without the cleared rejection the row carries both timestamps: statusFor()
+    // reads `rejected_at` first and tells the owner "Abgelehnt" about a
+    // subscription that scopeEligibleForDelivery() is happily delivering.
+    $this->actingAs($owner);
+    $settings = Livewire::test('settings.webhooks');
+
+    expect($settings->instance()->statusFor($fresh))->toBe('active');
+    $settings->assertDontSee('Abgelehnt');
+});
+
+it('leaves the owners pause switch and the systems auto-disable untouched when approving', function () {
+    $owner = User::factory()->create();
+    $this->actingAs(boardMember());
+
+    // Seeded AGAINST the factory default on both columns (default: active => true,
+    // disabled_at => null). On a default row the two assertions below would be
+    // satisfied by the seed no matter what approve() writes.
+    $subscription = WebhookSubscription::factory()->pending()->disabled()->create([
+        'user_id' => $owner->id,
+        'active' => false,
+    ]);
+
+    Livewire::test('admin.webhooks')->call('approve', $subscription->id);
+
+    $fresh = $subscription->fresh();
+
+    expect($fresh->approved_at)->not->toBeNull()
+        ->and($fresh->active)->toBeFalse()
+        ->and($fresh->disabled_at)->not->toBeNull()
+        // Releasing the brake while leaving the failure counter at 10 would disable
+        // the subscription again on the very next failure.
+        ->and($fresh->consecutive_failures)->toBe(10)
+        ->and(WebhookSubscription::query()->eligibleForDelivery()->whereKey($subscription->id)->exists())->toBeFalse();
+
+    $this->actingAs($owner);
+    expect(Livewire::test('settings.webhooks')->instance()->statusFor($fresh))->toBe('disabled');
 });

--- a/tests/Feature/Api/WebhookDocsPageTest.php
+++ b/tests/Feature/Api/WebhookDocsPageTest.php
@@ -212,3 +212,50 @@ it('links from the api reference to the webhook documentation', function () {
         ->toContain('## Webhooks')
         ->toContain('/docs/webhooks');
 });
+
+/*
+ * Issue #54, item 1 — the second of the two pages that answer "and then?".
+ *
+ * The npub comes from config/einundzwanzig.php (webhooks.contact_npub), which
+ * is the whole point of the key: this page and settings/webhooks must not drift
+ * apart, so both are asserted against the config value rather than a literal.
+ *
+ * Two DM clauses render it, in two independent conditionals (the stalled
+ * approval and the webhook:retry request), and each has to disappear when the
+ * key is empty: measured 2026-09-04, an unset key rendered
+ * href="https://njump.me/" — njump's front page, a link to nobody. Same rule as
+ * the settings page, which drops sentence and address together.
+ */
+it('points a waiting subscriber at the contact npub from config', function () {
+    $npub = config('einundzwanzig.webhooks.contact_npub');
+
+    // Guard on the fixture: with an empty key this would silently become the
+    // negative case while claiming to measure the positive one.
+    expect($npub)->toBeString()->not->toBe('');
+    expect(config('einundzwanzig.webhooks.require_approval'))->toBeTrue();
+
+    $content = $this->get(route('docs.webhooks'))
+        ->assertSuccessful()
+        ->assertSee('https://njump.me/'.$npub, false)
+        ->getContent();
+
+    // Both clauses, not just the first one to render.
+    expect(substr_count($content, 'https://njump.me/'.$npub))->toBeGreaterThanOrEqual(2);
+});
+
+it('drops every DM clause instead of linking to njumps front page when no contact npub is configured', function () {
+    config()->set('einundzwanzig.webhooks.contact_npub', '');
+
+    $content = $this->get(route('docs.webhooks'))
+        ->assertSuccessful()
+        ->assertDontSee('njump.me')
+        // The stalled-approval clause goes, the paragraph around it stays.
+        ->assertDontSee('We do not promise a turnaround')
+        ->assertSee('Run a catch-up over')
+        // The retry clause names a fallback rather than leaving the sentence
+        // half-built — the reader still learns whom to ask.
+        ->assertSee('Ask an operator for it')
+        ->getContent();
+
+    expect($content)->not->toMatch('#https://njump\.me/["\'\s>]#');
+});

--- a/tests/Feature/Console/WebhookApprovalTest.php
+++ b/tests/Feature/Console/WebhookApprovalTest.php
@@ -14,10 +14,42 @@ it('approves a pending subscription', function () {
     $this->artisan('webhook:approve', ['subscription' => $subscription->id])
         ->assertExitCode(0);
 
+    // Only `approved_at` is asserted here. This row carries the factory defaults
+    // for `active` (true) and `disabled_at` (null), so asserting those two would
+    // be satisfied by the seed whatever the command writes — measured: with them
+    // in place, a command that force-fills both stays green. They are asserted in
+    // the next test instead, on a row where they differ from the default.
+    expect($subscription->fresh())->approved_at->not->toBeNull();
+});
+
+/**
+ * Issue #54: until then the command also forced `active` to true and
+ * `disabled_at` to null, contradicting its own docblock and the migration's
+ * "only the owner clears it again (PATCH)" — approving a subscription the
+ * owner had paused, or the system had auto-disabled, silently released the
+ * brake while leaving `consecutive_failures` untouched.
+ *
+ * The seed is deliberately the OPPOSITE of the factory default on both
+ * columns (default: active => true, disabled_at => null). That is the whole
+ * point of this test: on a default row the two assertions hold no matter what
+ * the command does, which is how the old version of the assertion above could
+ * not tell the pre-#54 command from the current one.
+ */
+it('approves a pending subscription without un-pausing or un-disabling it', function () {
+    $subscription = WebhookSubscription::factory()->pending()->disabled()->create(['active' => false]);
+
+    $this->artisan('webhook:approve', ['subscription' => $subscription->id])
+        ->assertExitCode(0);
+
     expect($subscription->fresh())
         ->approved_at->not->toBeNull()
-        ->active->toBeTrue()
-        ->disabled_at->toBeNull();
+        ->active->toBeFalse()
+        ->disabled_at->not->toBeNull()
+        ->consecutive_failures->toBe(10);
+
+    // Approved on the board's side, still not delivering — the owner's pause and
+    // the auto-disable are separate gates, and only the owner reopens them.
+    expect(WebhookSubscription::query()->eligibleForDelivery()->whereKey($subscription->id)->exists())->toBeFalse();
 });
 
 it('refuses to approve an already approved subscription', function () {

--- a/tests/Feature/Settings/WebhooksTest.php
+++ b/tests/Feature/Settings/WebhooksTest.php
@@ -3,7 +3,6 @@
 use App\Models\User;
 use App\Models\WebhookSubscription;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
-use Illuminate\Support\Facades\Lang;
 use Livewire\Livewire;
 
 /*
@@ -191,12 +190,18 @@ it('labels the resource checkboxes with product wording, not the config slugs', 
     actingAsUser();
 
     $html = Livewire::test('settings.webhooks')
-        ->assertSee('Meetup-Termin')
         // The submitted value is still the API slug, not the label.
         ->assertSeeHtml('value="meetup-event"')
         ->html();
 
-    expect(visibleText($html))->not->toContain('meetup-event');
+    // Deliberately NOT assertSee('Meetup-Termin'): the page subheading says
+    // "sobald sich ein Meetup oder ein Meetup-Termin ändert", so the string
+    // occurs three times in this HTML and the assertion could not fail even if
+    // the checkbox were labelled with the raw slug (measured 2026-09-04). What
+    // this test claims is that THIS checkbox carries THAT label, so the
+    // assertion has to tie the two together on one element.
+    expect($html)->toMatch('/<ui-checkbox[^>]*value="meetup-event"[^>]*label="Meetup-Termin"/')
+        ->and(visibleText($html))->not->toContain('meetup-event');
 });
 
 it('labels the resources of an existing subscription with product wording', function () {
@@ -218,16 +223,19 @@ it('translates the resource labels instead of printing one string for all nine l
         'resources' => ['meetup-event'],
     ]);
 
-    // lang/*.json only gains the key in P6, so the label is injected here instead:
-    // a raw slug could not follow the locale at all, a translated label must.
+    // The injected label this test used to carry is gone: lang/en.json now holds
+    // the key for real ("Meetup events"), so Lang::addLines() no longer changed
+    // anything, and assertSee('Meetup event') passed on the plural regardless of
+    // whether the injection worked (measured 2026-09-04). The claim is that the
+    // label FOLLOWS the locale, so the German label has to be gone from the page.
     app()->setLocale('en');
-    Lang::addLines(['*.Meetup-Termin' => 'Meetup event'], 'en');
 
-    $html = Livewire::test('settings.webhooks')
-        ->assertSee('Meetup event')
-        ->html();
+    $html = Livewire::test('settings.webhooks')->html();
 
-    expect(visibleText($html))->not->toContain('meetup-event');
+    expect(visibleText($html))
+        ->toContain(__('Meetup-Termin'))
+        ->not->toContain('Meetup-Termin')
+        ->not->toContain('meetup-event');
 });
 
 it('falls back to the raw slug for a resource that has no label yet', function () {
@@ -235,4 +243,58 @@ it('falls back to the raw slug for a resource that has no label yet', function (
 
     expect(Livewire::test('settings.webhooks')->instance()->resourceLabel('brand-new-resource'))
         ->toBe('brand-new-resource');
+});
+
+/*
+|--------------------------------------------------------------------------
+| Issue #54, item 1 — the "and then?" contact block
+|--------------------------------------------------------------------------
+|
+| The page named who approves but not what to do while nothing happens. It
+| now says so and hands over an address. Same shape as ServiceDisclaimerTest:
+| assert the njump link where it belongs, and its ABSENCE in the negative
+| case, because that is the half a rendering bug actually breaks.
+|
+| The npub lives in config/einundzwanzig.php (webhooks.contact_npub) so this
+| page and /docs/webhooks cannot drift apart; both tests read it from there
+| rather than hardcoding it, so a rotated key does not turn into a red suite.
+|
+*/
+
+it('shows the contact npub, its copy control and its njump link', function () {
+    actingAsUser();
+
+    $npub = config('einundzwanzig.webhooks.contact_npub');
+
+    // Guard on the fixture itself: with an empty key the assertions below would
+    // be measuring the negative case while claiming to measure the positive one.
+    expect($npub)->toBeString()->not->toBe('');
+
+    $html = Livewire::test('settings.webhooks')
+        ->assertSee('frag per Nostr-DM nach')
+        ->assertSee($npub)
+        ->assertSeeHtml('https://njump.me/'.$npub)
+        ->html();
+
+    // The address IS the copy control — clicking the npub copies the npub, which
+    // is why there is no separate copy button to look for.
+    expect($html)->toMatch('/<button[^>]*data-testid="webhook-contact-npub"[^>]*x-copy-to-clipboard/');
+});
+
+it('drops the whole ask-by-DM sentence when no contact npub is configured', function () {
+    actingAsUser();
+
+    config()->set('einundzwanzig.webhooks.contact_npub', '');
+
+    $html = Livewire::test('settings.webhooks')
+        // The sentence and the address stand or fall together: on its own the
+        // sentence ends in a colon and promises an address that never arrives,
+        // which is worse than the gap this issue started from.
+        ->assertDontSee('frag per Nostr-DM nach')
+        ->assertDontSee('njump.me')
+        ->html();
+
+    expect($html)->not->toContain('webhook-contact-npub')
+        // Nothing left over that ends in a dangling colon.
+        ->and(visibleText($html))->not->toContain('Nostr-DM');
 });


### PR DESCRIPTION
Closes #54.

Three loose ends #40 left behind. None blocked anything; all three would have bitten.

| # | Item | Delivered |
|---|---|---|
| 1 | Approval copy gave the reader nothing to act on | No turnaround is promised — the page says so and hands over a Nostr DM address; the npub itself is the copy control |
| 2 | UI `approve()` and `webhook:approve` wrote different columns | Aligned; the CLI stopped writing `active`/`disabled_at`, which it had no business touching |
| 3 | `reject` had no policy ability | Added, mirroring `revoke()`; the view goes through `$this->authorize()` |

Beyond the issue, and found while writing item 1: the public docs page answered "please offer resource X" and "my subscription is stuck" with a single link to closed issue #36 under the repository's former name. Measured 2026-09-04, that link was dead rather than stale — GitHub's rename redirect covers the repo root and `/issues` (301) but not a single-issue path, which answers 404 with no `Location`. The box is now split by the object of the request: the issue tracker for a change to the software, a DM for one stuck record. `webhook:retry` moved to the DM side for the same reason.

Nothing pinned any of this. The first attempt's own `reject` guard was no exception: with the policy ability forced to `return true`, or with the `authorize()` line deleted outright, 109 of 109 webhook tests stayed green. Six cases now cover the three items, each shown red first against the mutation it is meant to catch, including the path `mount()` structurally cannot reach. Three pre-existing assertions that could not fail were replaced along the way.

Full non-Browser suite: **1905 passed, 7024 assertions.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A4BKf2zxFNSRKBoMUB8EUW
