### PR TITLE
Stop mandating a .ai/rules directory that does not exist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,10 +48,6 @@ This project has domain-specific skills available in `**/skills/**`. You MUST ac
 
 # Laravel Boost
 
-## Project Rules
-
-- This project contains committed, area-grouped rules in `.ai/rules` when that directory exists (settled decisions, non-obvious traps, standing constraints). Framework and package guidelines that only apply to specific paths (testing, frontend, components) also live there, under `.ai/rules/boost` — this is not just recorded decisions, it is load-bearing guidance you have not seen inline. Before you enter plan mode or create/edit any file, you MUST first: open @.ai/rules/index.md (it maps file globs to rule files), read every rule file whose globs cover the path(s) in scope, and run `grep -rin 'keyword' .ai/rules` to catch what a path match alone misses. Do not write code until you have read and are following every matching rule. If `.ai/rules` does not exist, continue without it.
-
 ## Artisan
 
 - Run Artisan commands directly via the command line (e.g., `php artisan route:list`). Use `php artisan list` to discover available commands and `php artisan [command] --help` to check parameters.

--- a/config/boost.php
+++ b/config/boost.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+
+    /*
+    |--------------------------------------------------------------------------
+    | Boost Master Switch
+    |--------------------------------------------------------------------------
+    |
+    | This option may be used to disable all Boost functionality which will
+    | prevent Boost's routes from being registered and will also disable
+    | Boost's browser logging functionality from reading or operating.
+    |
+    */
+
+    'enabled' => env('BOOST_ENABLED', true),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Boost Project Rules
+    |--------------------------------------------------------------------------
+    |
+    | Project rules let agents write decisions, traps and standing constraints
+    | as tracked Markdown in /.ai/rules/. Enabling "scoped_guidelines" also
+    | moves path-scoped guidelines to .ai/rules/boost/ - it stays opt-in.
+    |
+    | Disabled here on purpose (see issue #60). This project does not keep a
+    | /.ai/rules/ directory: its conventions live in CLAUDE.md and in the Boost
+    | guidelines themselves. With rules enabled, Boost writes a paragraph into
+    | CLAUDE.md ordering every agent to read /.ai/rules/index.md before editing
+    | any file - an instruction that fails silently on a missing directory, so
+    | an agent cannot distinguish "no rules apply" from "no rules exist".
+    |
+    */
+
+    'rules' => [
+        'enabled' => env('BOOST_RULES_ENABLED', false),
+        'scoped_guidelines' => env('BOOST_RULES_SCOPED_GUIDELINES', false),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Excluded Guidelines
+    |--------------------------------------------------------------------------
+    |
+    | Any guidelines listed here will be excluded whenever Boost composes your
+    | AI guidelines during boost:install or boost:update. Entries match the
+    | names shown within the boost:install summary, e.g. "livewire/core".
+    |
+    */
+
+    'guidelines' => [
+        'exclude' => [],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Excluded Skills
+    |--------------------------------------------------------------------------
+    |
+    | Any skills listed here will not be installed or synced to your agents
+    | by boost:install and boost:update, e.g. "fluxui-development". Your
+    | own skills within the ".ai/skills" directory are never excluded.
+    |
+    */
+
+    'skills' => [
+        'exclude' => [],
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Boost Executables Paths
+    |--------------------------------------------------------------------------
+    |
+    | These options allow you to specify custom paths for the executables that
+    | Boost uses. While configured, they take precedence over the automatic
+    | discovery mechanism. When undefined, your system defaults are used.
+    |
+    */
+
+    'executable_paths' => [
+        'php' => env('BOOST_PHP_EXECUTABLE_PATH'),
+        'composer' => env('BOOST_COMPOSER_EXECUTABLE_PATH'),
+        'npm' => env('BOOST_NPM_EXECUTABLE_PATH'),
+        'vendor_bin' => env('BOOST_VENDOR_BIN_EXECUTABLE_PATH'),
+        'current_directory' => env('BOOST_CURRENT_DIRECTORY_EXECUTABLE_PATH'),
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Boost Browser Logs Watcher
+    |--------------------------------------------------------------------------
+    |
+    | The following option may be used to enable or disable the browser logs
+    | watcher feature within Laravel Boost. The log watcher will read any
+    | errors within the browser's console to give Boost better context.
+    |
+    */
+
+    'browser_logs_watcher' => env('BOOST_BROWSER_LOGS_WATCHER', true),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Browser Log Levels
+    |--------------------------------------------------------------------------
+    |
+    | This option defines which browser console log levels will be captured by
+    | Boost's browser logger. You may trim this list down to ['error'] when
+    | warnings, info, and debug messages become too noisy to be relevant.
+    |
+    */
+
+    'browser_log_levels' => explode(',', env('BOOST_BROWSER_LOG_LEVELS', 'error,warning,info,debug')),
+
+];

--- a/tests/Feature/BoostProjectRulesDisabledTest.php
+++ b/tests/Feature/BoostProjectRulesDisabledTest.php
@@ -1,0 +1,47 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| Guard against #60 regressing: CLAUDE.md must not order agents to read a
+| /.ai/rules/ directory this project does not keep.
+|
+| The paragraph is not hand-written. Boost renders it from
+| vendor/laravel/boost/.ai/boost/core.blade.php, gated on
+| config('boost.rules.enabled'), and rewrites CLAUDE.md on every
+| `boost:install`. Deleting the paragraph alone would therefore bring it
+| back at the next install; disabling the config alone would leave the
+| stale paragraph in place until someone regenerates. Both have to hold,
+| which is what this test asserts.
+|
+| Why the paragraph is harmful rather than merely unused: `grep -rin 'x'
+| .ai/rules` against a missing directory returns nothing that reads as an
+| error, so an agent following the instruction cannot tell "the rules were
+| read and none applied" from "the rules never existed".
+|--------------------------------------------------------------------------
+*/
+
+it('keeps Boost project rules disabled', function () {
+    expect(config('boost.rules.enabled'))->toBeFalse(
+        'config/boost.php must keep boost.rules.enabled false, or boost:install writes the '
+        .'.ai/rules paragraph back into CLAUDE.md.'
+    );
+});
+
+it('does not mandate a .ai/rules directory in CLAUDE.md', function () {
+    $claudeMd = file_get_contents(base_path('CLAUDE.md'));
+
+    // Deliberately str_contains() rather than expect()->not->toContain(): Pest's
+    // toContain() is variadic, so a failure message passed as a second argument
+    // becomes a second needle and the negated assertion passes whenever only one
+    // of the two is present. Caught by a mutation probe, which stayed green.
+    expect(str_contains($claudeMd, '.ai/rules'))->toBeFalse(
+        'CLAUDE.md must not reference .ai/rules while no such directory exists.'
+    );
+});
+
+it('has no .ai/rules directory to justify the instruction', function () {
+    expect(is_dir(base_path('.ai/rules')))->toBeFalse(
+        'A .ai/rules directory appeared. Either remove it, or re-enable '
+        .'boost.rules.enabled and drop this guard — the two must not disagree.'
+    );
+});


### PR DESCRIPTION
Closes #60.

CLAUDE.md ordered every agent to read `.ai/rules/index.md` before entering plan mode or editing any file. No such directory exists here — `.ai/` holds only `mcp/mcp.json`.

The instruction failed silently: `grep -rin 'x' .ai/rules` against a missing directory returns nothing that reads as an error, so an agent concluded "no rules apply" where the truth was "no rules exist".

| | |
|---|---|
| `config/boost.php` | published, `rules.enabled` default flipped to `false` |
| `CLAUDE.md` | the `## Project Rules` section removed (810 bytes) |
| `tests/Feature/BoostProjectRulesDisabledTest.php` | guards all three states |

The paragraph is Boost-generated, not hand-written: `vendor/laravel/boost/.ai/boost/core.blade.php:25-32`, gated on `config('boost.rules.enabled')` (package default `true`). Deleting the text alone would have brought it back at the next `boost:install`, so the config flag is off as well — both, or neither holds.

Each of the three assertions was proven able to fail by mutation. The second one initially could not: `expect()->not->toContain()` is variadic, so the failure message became a second needle and the negated assertion stayed green with the mandate present. It uses `str_contains()` now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XfFQ18DFktM3ewnWo9Zt9X
