### PR TITLE
Fail loudly when a gating column is missing

### DIFF
--- a/app/Console/Commands/Nostr/PublishCalendarEvents.php
+++ b/app/Console/Commands/Nostr/PublishCalendarEvents.php
@@ -7,6 +7,7 @@ use App\Models\MeetupEvent;
 use App\Support\NostrCalendarEventFactory;
 use App\Support\NostrEventTransmitter;
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Schema;
 use swentel\nostr\Key\Key;
 use swentel\nostr\Sign\Sign;
 
@@ -86,6 +87,17 @@ class PublishCalendarEvents extends Command
             return self::FAILURE;
         }
 
+        $missingColumns = $this->missingGateColumns($modelName);
+
+        if ($missingColumns !== []) {
+            $this->error(sprintf(
+                'Missing column(s): %s — run php artisan migrate. Without them this command finds nothing to publish and would exit 0 as if everything were up to date.',
+                implode(', ', $missingColumns),
+            ));
+
+            return self::FAILURE;
+        }
+
         $model = $query->first();
 
         if (! $model) {
@@ -124,5 +136,41 @@ class PublishCalendarEvents extends Command
         $this->info("Published calendar event for {$modelName} #{$model->id}");
 
         return self::SUCCESS;
+    }
+
+    /**
+     * The columns the query above gates on, per model — reported, never assumed.
+     *
+     * Issue #72: SQLite degrades a double-quoted identifier that matches no column
+     * into a STRING LITERAL instead of raising an error, and Laravel quotes
+     * identifiers with double quotes. On a database where the 2026_08_29 migrations
+     * have not run, `where "nostr_coordinate" is null` therefore compares the constant
+     * string 'nostr_coordinate' against NULL — never true. This command would find
+     * nothing to publish, print "No unpublished items" and exit 0, which an operator
+     * reading exit codes cannot tell apart from a healthy, caught-up system. The list
+     * is written out rather than derived so that it stays readable next to the queries
+     * it mirrors; `NostrWhoami::publishingState()` contains the same check.
+     *
+     * @return list<string> the missing columns as `table.column`, empty when ready
+     */
+    private function missingGateColumns(string $modelName): array
+    {
+        $required = match ($modelName) {
+            'Meetup' => ['meetups' => ['nostr_coordinate', 'nostr_publishing_enabled']],
+            'MeetupEvent' => ['meetup_events' => ['nostr_coordinate'], 'meetups' => ['nostr_publishing_enabled']],
+            default => [],
+        };
+
+        $missing = [];
+
+        foreach ($required as $table => $columns) {
+            foreach ($columns as $column) {
+                if (! Schema::hasColumn($table, $column)) {
+                    $missing[] = "{$table}.{$column}";
+                }
+            }
+        }
+
+        return $missing;
     }
 }

--- a/app/Console/Commands/Nostr/PublishUnpublishedItems.php
+++ b/app/Console/Commands/Nostr/PublishUnpublishedItems.php
@@ -9,6 +9,7 @@ use App\Models\MeetupEvent;
 use App\Traits\NostrTrait;
 use Illuminate\Console\Command;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Facades\URL;
 
 class PublishUnpublishedItems extends Command
@@ -42,7 +43,16 @@ class PublishUnpublishedItems extends Command
         'default' => 'portal.einundzwanzig.space',
     ];
 
-    public function handle(): void
+    /**
+     * Only the schema gate below returns a non-zero exit code.
+     *
+     * The other error branches (unsupported model, no text, a rejected publish) kept
+     * the exit code 0 they have always had; changing them would change what the
+     * scheduler sees for failures this issue never measured. Issue #72 is about the
+     * one branch that reports SUCCESS while hiding that it could not even ask the
+     * question.
+     */
+    public function handle(): int
     {
         $modelName = $this->option('model');
         $modelClass = '\\App\\Models\\'.$modelName;
@@ -67,7 +77,23 @@ class PublishUnpublishedItems extends Command
         if (! $query) {
             $this->error("Unsupported model: {$modelName}");
 
-            return;
+            return self::SUCCESS;
+        }
+
+        /*
+         * Issue #72: SQLite degrades a double-quoted identifier that matches no column
+         * into a STRING LITERAL instead of raising an error, and Laravel quotes
+         * identifiers with double quotes. Without `nostr_status` the gate above reads
+         * `where 'nostr_status' is null` — never true — so every branch below reports
+         * "No unpublished items" and exits 0, indistinguishable from a caught-up
+         * system. Ask the schema before asking the data.
+         */
+        $table = $query->getModel()->getTable();
+
+        if (! Schema::hasColumn($table, 'nostr_status')) {
+            $this->error("Missing column: {$table}.nostr_status — run php artisan migrate. Without it this command finds nothing to publish and would exit 0 as if everything were up to date.");
+
+            return self::FAILURE;
         }
 
         $model = $query->first();
@@ -75,7 +101,7 @@ class PublishUnpublishedItems extends Command
         if (! $model) {
             $this->info("No unpublished items for model: {$modelName}");
 
-            return;
+            return self::SUCCESS;
         }
 
         // Get country code
@@ -99,6 +125,8 @@ class PublishUnpublishedItems extends Command
         } else {
             $this->error("No text generated for {$modelName}");
         }
+
+        return self::SUCCESS;
     }
 
     private function getCountryCode(Model $model): string

--- a/tests/Feature/Console/NostrPublishSchemaGuardTest.php
+++ b/tests/Feature/Console/NostrPublishSchemaGuardTest.php
@@ -1,0 +1,112 @@
+<?php
+
+use App\Models\City;
+use App\Models\Country;
+use App\Models\Meetup;
+use App\Models\MeetupEvent;
+use Illuminate\Support\Facades\Schema;
+
+/*
+ * Issue #72: a missing column must stop a publishing command, not look like success.
+ *
+ * SQLite degrades a double-quoted identifier that matches no column into a STRING
+ * LITERAL instead of raising an error, and Laravel quotes identifiers with double
+ * quotes. So on a database whose gating migration has not run,
+ * `where "nostr_coordinate" is null` compares the constant string 'nostr_coordinate'
+ * against NULL — never true. The command then finds nothing to publish, prints
+ * "No unpublished items" and exits 0, which is indistinguishable from a healthy,
+ * caught-up system. `DB_CONNECTION` defaults to sqlite in config/database.php and
+ * .env.example, so this is not confined to the test suite.
+ *
+ * The first test below reproduces the degradation itself; the rest assert that each
+ * command now exits non-zero and names the column it is missing.
+ */
+
+const SCHEMA_GUARD_TEST_KEY = '4f964f6b93a5b1e5f6f9b1d3a4f5e6d7c8b9a0f1e2d3c4b5a6978869504132a1';
+
+function schemaGuardMeetup(array $attributes = []): Meetup
+{
+    $city = City::factory()->create([
+        'country_id' => Country::factory()->create(['code' => 'de'])->id,
+    ]);
+
+    return Meetup::factory()->create(array_merge(['city_id' => $city->id], $attributes));
+}
+
+beforeEach(function () {
+    config([
+        'services.nostr.publisher_key' => SCHEMA_GUARD_TEST_KEY,
+        'services.nostr.relays' => ['wss://fake.relay.test'],
+    ]);
+});
+
+it('degrades whereNull to a never-true comparison when the column is missing', function () {
+    schemaGuardMeetup(['nostr_publishing_enabled' => true]);
+
+    Schema::table('meetups', fn ($table) => $table->dropColumn('nostr_coordinate'));
+
+    expect(Meetup::query()->whereNull('nostr_coordinate')->count())->toBe(0)
+        ->and(Meetup::query()->whereNotNull('nostr_coordinate')->count())->toBe(1);
+});
+
+it('fails and names the column when meetups.nostr_coordinate is missing', function () {
+    schemaGuardMeetup(['nostr_publishing_enabled' => true]);
+
+    Schema::table('meetups', fn ($table) => $table->dropColumn('nostr_coordinate'));
+
+    $this->artisan('nostr:publish-calendar', ['--model' => 'Meetup'])
+        ->expectsOutputToContain('meetups.nostr_coordinate')
+        ->assertExitCode(1);
+});
+
+it('fails and names the column when meetups.nostr_publishing_enabled is missing', function () {
+    schemaGuardMeetup();
+
+    Schema::table('meetups', fn ($table) => $table->dropColumn('nostr_publishing_enabled'));
+
+    $this->artisan('nostr:publish-calendar', ['--model' => 'Meetup'])
+        ->expectsOutputToContain('meetups.nostr_publishing_enabled')
+        ->assertExitCode(1);
+});
+
+it('fails and names the column when meetup_events.nostr_coordinate is missing', function () {
+    $meetup = schemaGuardMeetup(['nostr_publishing_enabled' => true]);
+    MeetupEvent::factory()->create([
+        'meetup_id' => $meetup->id,
+        'start' => now()->addWeek(),
+    ]);
+
+    Schema::table('meetup_events', fn ($table) => $table->dropColumn('nostr_coordinate'));
+
+    $this->artisan('nostr:publish-calendar', ['--model' => 'MeetupEvent'])
+        ->expectsOutputToContain('meetup_events.nostr_coordinate')
+        ->assertExitCode(1);
+});
+
+it('fails and names the column when meetups.nostr_status is missing', function () {
+    schemaGuardMeetup();
+
+    Schema::table('meetups', fn ($table) => $table->dropColumn('nostr_status'));
+
+    $this->artisan('nostr:publish', ['--model' => 'Meetup'])
+        ->expectsOutputToContain('meetups.nostr_status')
+        ->assertExitCode(1);
+});
+
+it('fails and names the column when course_events.nostr_status is missing', function () {
+    Schema::table('course_events', fn ($table) => $table->dropColumn('nostr_status'));
+
+    $this->artisan('nostr:publish', ['--model' => 'CourseEvent'])
+        ->expectsOutputToContain('course_events.nostr_status')
+        ->assertExitCode(1);
+});
+
+it('still reports an empty result set when the schema is complete', function () {
+    $this->artisan('nostr:publish-calendar', ['--model' => 'Meetup'])
+        ->expectsOutputToContain('No unpublished items')
+        ->assertExitCode(0);
+
+    $this->artisan('nostr:publish', ['--model' => 'Meetup'])
+        ->expectsOutputToContain('No unpublished items')
+        ->assertExitCode(0);
+});


### PR DESCRIPTION
Closes #72.

SQLite degrades a double-quoted identifier that matches no column into a string literal. Laravel quotes identifiers that way, so `whereNull()` on a column added by a pending migration matches nothing and `whereNotNull()` matches everything. `nostr:publish-calendar` gates exactly on that: with the column missing it printed *"No unpublished items"* and exited **0** — indistinguishable from a healthy system that is simply up to date.

| File | Change |
|---|---|
| `PublishCalendarEvents.php` | new `missingGateColumns()`, called before the query; missing column → error naming `table.column`, exit `1` |
| `PublishUnpublishedItems.php` | `handle(): void` → `handle(): int`; gate table taken from `$query->getModel()->getTable()` |
| `NostrPublishSchemaGuardTest.php` | new, 7 tests |

The `Schema::hasColumn()` shape is the one `NostrWhoami::publishingState()` already uses.

Written before the guards, the five command assertions failed with `Expected status code 1 but received 0` — the exact lie the issue describes. `tests/Feature/Console` → 107 passed (269 assertions).

Deliberately untouched, as they are not what #72 names: `RetryWebhookDeliveries` and the four commands under `app/Console/Commands/Database/`. The exit-code-0 behaviour of the *other* branches of `PublishUnpublishedItems` is filed as #84.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XfFQ18DFktM3ewnWo9Zt9X
