### PR TITLE
Lowercase the country code before every PHP array lookup

### DIFF
--- a/app/Console/Commands/Nostr/PublishUnpublishedItems.php
+++ b/app/Console/Commands/Nostr/PublishUnpublishedItems.php
@@ -129,15 +129,28 @@ class PublishUnpublishedItems extends Command
         return self::SUCCESS;
     }
 
+    /**
+     * Issue #76: the stored code is lowercased HERE, where it enters the command,
+     * because every use below needs the same lowercase form and a PHP array lookup is
+     * case-sensitive — DOMAIN_MAP and TZ_MAP are keyed lowercase, `app.locale` has to
+     * be 'nl' to resolve lang/nl.json, and the code is also the `{country:code}`
+     * segment of the URL that goes into the published note. The case-insensitive
+     * Country::matchingCode() scope added for #58 compares in SQL and reaches none of
+     * them. CountryFactory writes uppercase codes, so with a stored 'NL' the note went
+     * out with the German domain, Europe/Berlin, and `nostr.meetup_event_text` as its
+     * text — the untranslated key, because lang/NL.json does not exist.
+     */
     private function getCountryCode(Model $model): string
     {
-        return match (true) {
+        $countryCode = match (true) {
             $model instanceof Meetup => $model->city?->country?->code ?? 'de',
             $model instanceof MeetupEvent => $model->meetup?->city?->country?->code ?? 'de',
             $model instanceof Course => $model->lecturer?->country?->code ?? 'de',
             $model instanceof CourseEvent => $model->course?->lecturer?->country?->code ?? 'de',
             default => 'de', // Default fallback
         };
+
+        return mb_strtolower($countryCode);
     }
 
     private function configureForCountry(string $countryCode): void

--- a/app/Support/CountryTimezone.php
+++ b/app/Support/CountryTimezone.php
@@ -27,6 +27,13 @@ class CountryTimezone
     {
         // PHP 8.5 deprecates null as an array offset — the empty string never
         // matches a key, so this stays a one-liner without triggering it.
-        return self::MAP[$countryCode ?? ''] ?? 'Europe/Berlin';
+        //
+        // Lowercased here, at the point of use (issue #76): the keys above are
+        // lowercase, a PHP array lookup is case-sensitive, and the stored
+        // `countries.code` carries whichever case its writer used — CountryFactory
+        // writes 'ES'. The case-insensitive Country::matchingCode() scope added for
+        // #58 compares in SQL and therefore never reaches this lookup, so without
+        // the normalisation a Spanish meetup is published with Europe/Berlin.
+        return self::MAP[mb_strtolower($countryCode ?? '')] ?? 'Europe/Berlin';
     }
 }

--- a/tests/Feature/Console/NostrPublishUppercaseCountryCodeTest.php
+++ b/tests/Feature/Console/NostrPublishUppercaseCountryCodeTest.php
@@ -1,0 +1,104 @@
+<?php
+
+use App\Models\City;
+use App\Models\Country;
+use App\Models\Meetup;
+use App\Models\MeetupEvent;
+use App\Support\NostrEventTransmitter;
+use Illuminate\Process\PendingProcess;
+use Illuminate\Support\Facades\Process;
+use swentel\nostr\Event\Event;
+
+/*
+ * Issue #76: both Nostr publishers key PHP arrays on the stored country code, and a
+ * PHP array lookup is case-sensitive. The `Country::matchingCode()` scope added for
+ * #58 compares in SQL and therefore does not reach them, so an uppercase stored code
+ * misses every key and falls through to the German defaults: a Spanish meetup is
+ * published with `start_tzid: Europe/Berlin`, and a Dutch one with the German domain
+ * and locale. A published Nostr event is immutable on the relays, so a later
+ * correction leaves both versions in circulation.
+ *
+ * The fixtures store 'ES' and 'NL' because that is what `CountryFactory` writes into
+ * every development and test database — the uppercase code is the natural shape here,
+ * not a contrived one. The existing tests for both commands all seed lowercase codes,
+ * which is exactly why none of them could see this.
+ */
+
+const UPPERCASE_CODE_TEST_KEY = '4f964f6b93a5b1e5f6f9b1d3a4f5e6d7c8b9a0f1e2d3c4b5a6978869504132a1';
+
+function uppercaseCodeMeetup(string $countryCode, array $attributes = []): Meetup
+{
+    $city = City::factory()->create([
+        'country_id' => Country::factory()->create(['code' => $countryCode])->id,
+        'latitude' => 40.4168,
+        'longitude' => -3.7038,
+    ]);
+
+    return Meetup::factory()->create(array_merge(['city_id' => $city->id], $attributes));
+}
+
+beforeEach(function () {
+    config([
+        'services.nostr.publisher_key' => UPPERCASE_CODE_TEST_KEY,
+        'services.nostr.relays' => ['wss://fake.relay.test'],
+    ]);
+});
+
+it('publishes a Spanish calendar event with the Madrid timezone when the stored code is uppercase', function () {
+    $transmitted = null;
+
+    $this->mock(NostrEventTransmitter::class, function ($mock) use (&$transmitted) {
+        $mock->shouldReceive('transmit')
+            ->once()
+            ->andReturnUsing(function (Event $event, array $relayUrls) use (&$transmitted) {
+                $transmitted = $event;
+
+                return true;
+            });
+    });
+
+    $meetup = uppercaseCodeMeetup('ES', ['nostr_publishing_enabled' => true]);
+    MeetupEvent::factory()->create([
+        'meetup_id' => $meetup->id,
+        'start' => now()->addWeek(),
+    ]);
+
+    $this->artisan('nostr:publish-calendar', ['--model' => 'MeetupEvent'])
+        ->assertExitCode(0);
+
+    expect($transmitted?->getTag('start_tzid'))->toBe([['start_tzid', 'Europe/Madrid']]);
+});
+
+it('publishes a Dutch note with the Dutch domain, timezone and locale when the stored code is uppercase', function () {
+    $publishedText = null;
+
+    // `noscl publish <text>` is invoked with an argument array; the note text is its third element.
+    Process::fake(function (PendingProcess $process) use (&$publishedText): string {
+        $publishedText = (string) ($process->command[2] ?? '');
+
+        return 'note1'.str_repeat('a', 58);
+    });
+
+    $meetup = uppercaseCodeMeetup('NL');
+    $meetupEvent = MeetupEvent::factory()->create([
+        'meetup_id' => $meetup->id,
+        'start' => now()->addDay(),
+        // MeetupEventFactory fills nostr_status from NostrHelper::fakeNostrEventStatus(),
+        // which returns a status in 10 % of calls — that would take the record out of the
+        // command's `whereNull` gate and flake this test one run in ten.
+        'nostr_status' => null,
+    ]);
+
+    $this->artisan('nostr:publish', ['--model' => 'MeetupEvent'])
+        ->assertExitCode(0);
+
+    // Scheme-free on purpose: `URL::useOrigin('https://…')` only forces the ROOT, the
+    // scheme still comes from the environment (http in the test suite). That is not
+    // what #76 is about — the assertion here is the host and the country segment.
+    $expectedUrl = '//portal.eenentwintig.net/nl/meetup/'
+        ."{$meetup->slug}/event/{$meetupEvent->id}";
+
+    expect($publishedText)->toContain($expectedUrl)
+        ->and(config('app.user-timezone'))->toBe('Europe/Amsterdam')
+        ->and(config('app.locale'))->toBe('nl');
+});


### PR DESCRIPTION
Closes #76.

`CountryTimezone::MAP`, `DOMAIN_MAP`, `TZ_MAP` and the `in_array(['at','ch'])` check are all keyed lowercase and were all fed an un-normalised stored code. These are PHP array lookups, not SQL, so the case-insensitive `Country::matchingCode()` scope from #58 never reached them.

With a stored `'ES'` the timezone lookup missed and a Spanish meetup was published with `start_tzid: Europe/Berlin`. The published NIP-52 event is immutable on the relays, so a later correction leaves both versions in circulation.

Normalised at the point of use: `mb_strtolower` at the `MAP` lookup in `CountryTimezone`, and once in `PublishUnpublishedItems::getCountryCode()` where the stored value enters the class. `NostrCalendarEventFactory` is deliberately untouched — the point of use is the array access, where the fix holds for every caller.

`NostrPublishUppercaseCountryCodeTest` is the first test coverage either path has had. It reads the event actually transmitted and the text actually published, not the values on the way in. Before the fix, with a stored `'NL'`: `app.locale` `NL`, timezone `Europe/Berlin`, and the published note carrying the raw translation key `nostr.meetup_event_text`.

Found on the way and filed rather than fixed: a country code without a matching language file publishes the raw translation key, because `configureForCountry()` sets `app.locale` to the country code unchecked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XfFQ18DFktM3ewnWo9Zt9X
