### PR TITLE
Give the meetup-event difficulty scale a middle

### DIFF
--- a/database/migrations/2026_09_05_002216_add_moderate_meetup_event_tag.php
+++ b/database/migrations/2026_09_05_002216_add_moderate_meetup_event_tag.php
@@ -1,0 +1,121 @@
+<?php
+
+use App\Models\Tag;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Adds the missing middle of the event difficulty scale — "Mittelstufe" / "Moderate" —
+ * to a database that already carries the seeded `meetup_event` vocabulary (issue #68).
+ *
+ * TagSeeder alone is not enough for an existing database. It creates the row, but
+ * Spatie's SortableTrait numbers a new tag "highest order_column + 1", so the seeder
+ * would append it after the last library tag and the picker would offer it at the very
+ * bottom of the event list instead of between "Einsteiger" and "Fortgeschrittene". The
+ * position is the point of the issue, so it is set here explicitly.
+ *
+ * Nothing happens when the anchor "Fortgeschrittene" is absent: that is a fresh
+ * database (and every test database), where TagSeeder seeds the whole vocabulary in
+ * file order and the new tag lands in the right place by construction. Re-running is
+ * likewise a no-op once the tag exists, so the migration is idempotent.
+ *
+ * No `taggables` row is read or written: this adds a choice, it does not retag anything.
+ *
+ * The names are frozen here rather than read from database/seeders/data/tags.php. A
+ * migration is a record of what ran, and a later edit to the vocabulary file must not
+ * change what this one did. AddModerateMeetupEventTagTest asserts the two agree today.
+ */
+return new class extends Migration
+{
+    private const TYPE = 'meetup_event';
+
+    private const GERMAN = 'Mittelstufe';
+
+    /** The tag the new one must sort in front of. */
+    private const ANCHOR = 'Fortgeschrittene';
+
+    private const ICON = 'book-open';
+
+    /** @var array<string, string> */
+    private const NAMES = [
+        'de' => 'Mittelstufe',
+        'en' => 'Moderate',
+        'cs' => 'Mírně pokročilí',
+        'es' => 'Intermedio',
+        'hu' => 'Középhaladók',
+        'lv' => 'Vidēji pieredzējušiem',
+        'nl' => 'Halfgevorderden',
+        'pl' => 'Średniozaawansowani',
+        'pt' => 'Intermédio',
+    ];
+
+    public function up(): void
+    {
+        $anchor = $this->findByGermanName(self::ANCHOR);
+
+        if ($anchor === null || $this->findByGermanName(self::GERMAN) !== null) {
+            return;
+        }
+
+        $position = (int) $anchor->order_column;
+
+        /*
+         * Make room at that position. `order_column` is one ladder across all tag
+         * types — SortableTrait counts from the highest row of the whole table — so the
+         * shift is global too. Every relative order stays exactly as it was; only the
+         * numbers move up by one.
+         */
+        DB::table('tags')->where('order_column', '>=', $position)->increment('order_column');
+
+        $tag = new Tag(['type' => self::TYPE]);
+
+        foreach (self::NAMES as $locale => $name) {
+            $tag->setTranslation('name', $locale, $name);
+        }
+
+        $tag->icon = self::ICON;
+        $tag->featured = false;
+        $tag->approved_at = now();
+        $tag->save();
+
+        // Set after the save, not before: SortableTrait's `creating` hook overwrites
+        // whatever order_column the model carries with "highest + 1".
+        $tag->newQuery()->whereKey($tag->id)->update(['order_column' => $position]);
+    }
+
+    /**
+     * Removes the tag again and closes the gap it left in the ladder.
+     *
+     * Except when an event has been tagged with it in the meantime — deleting the row
+     * then cascades into `taggables` and silently strips a tag off somebody's event.
+     * A vocabulary entry in use is left standing; rolling back the migration must not
+     * change data the migration never touched.
+     */
+    public function down(): void
+    {
+        $tag = $this->findByGermanName(self::GERMAN);
+
+        if ($tag === null || DB::table('taggables')->where('tag_id', $tag->id)->exists()) {
+            return;
+        }
+
+        $position = (int) $tag->order_column;
+
+        $tag->delete();
+
+        DB::table('tags')->where('order_column', '>', $position)->decrement('order_column');
+    }
+
+    /**
+     * Matched on type plus German name, the source language of the vocabulary, and
+     * compared in PHP rather than through the JSON column — the same approach TagSeeder
+     * takes, and for the same reason: it works on SQLite and MySQL alike.
+     */
+    private function findByGermanName(string $german): ?Tag
+    {
+        return Tag::query()
+            ->where('type', self::TYPE)
+            ->get()
+            ->first(fn (Tag $tag): bool => $tag->getTranslation('name', 'de', false) === $german);
+    }
+};

--- a/database/seeders/data/tags.php
+++ b/database/seeders/data/tags.php
@@ -73,6 +73,12 @@ return [
             'de' => 'Einsteiger', 'en' => 'Beginners', 'cs' => 'Začátečníci', 'es' => 'Principiantes',
             'hu' => 'Kezdők', 'lv' => 'Iesācēji', 'nl' => 'Beginners', 'pl' => 'Początkujący', 'pt' => 'Iniciantes',
         ]],
+        // Between the two ends of the scale on purpose: the position in this file is
+        // the seeded `order_column`, and that column is what the picker sorts by.
+        ['icon' => 'book-open', 'featured' => false, 'name' => [
+            'de' => 'Mittelstufe', 'en' => 'Moderate', 'cs' => 'Mírně pokročilí', 'es' => 'Intermedio',
+            'hu' => 'Középhaladók', 'lv' => 'Vidēji pieredzējušiem', 'nl' => 'Halfgevorderden', 'pl' => 'Średniozaawansowani', 'pt' => 'Intermédio',
+        ]],
         ['icon' => 'academic-cap', 'featured' => false, 'name' => [
             'de' => 'Fortgeschrittene', 'en' => 'Advanced', 'cs' => 'Pokročilí', 'es' => 'Avanzado',
             'hu' => 'Haladók', 'lv' => 'Pieredzējušiem', 'nl' => 'Gevorderden', 'pl' => 'Zaawansowani', 'pt' => 'Avançado',

--- a/tests/Browser/Tags/TagPickerFlowTest.php
+++ b/tests/Browser/Tags/TagPickerFlowTest.php
@@ -35,8 +35,8 @@ it('shows only featured tags in the resting state and reveals the rest on typing
 
     $page->assertNoJavaScriptErrors();
 
-    // 15 event tags are rendered, only the 7 featured ones are visible at rest.
-    expect($total)->toBe(15)
+    // 16 event tags are rendered, only the 7 featured ones are visible at rest.
+    expect($total)->toBe(16)
         ->and($visible)->toBe(7);
 });
 
@@ -65,7 +65,7 @@ it('opens the panel and keeps the search working across languages', function () 
 it('returns to the resting state after a selection', function () {
     // The assumption under test: Flux clears its own input on select (clear="… select")
     // WITHOUT firing an input event. If our x-on:change reset does not compensate, the
-    // panel stays stuck in search mode and every later visit shows all 15 tags.
+    // panel stays stuck in search mode and every later visit shows all 16 tags.
     $page = visit("/de/meetup/{$this->meetup->id}/events/create");
     $page->wait(1);
 

--- a/tests/Feature/Migrations/AddModerateMeetupEventTagTest.php
+++ b/tests/Feature/Migrations/AddModerateMeetupEventTagTest.php
@@ -1,0 +1,143 @@
+<?php
+
+use App\Models\City;
+use App\Models\Country;
+use App\Models\Meetup;
+use App\Models\MeetupEvent;
+use App\Models\Tag;
+use Database\Seeders\TagSeeder;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * The data migration that adds the "Mittelstufe" / "Moderate" event tag to a database
+ * that was seeded before it existed (issue #68).
+ *
+ * RefreshDatabase already ran it once, on an empty database — that is the "nothing to
+ * do" case. The state it is really meant for is reproduced by seeding the current
+ * vocabulary and then removing the tag again through the migration's own down(), which
+ * is exactly the shape of a database seeded before this change.
+ */
+function moderateTagMigration(): object
+{
+    return require database_path('migrations/2026_09_05_002216_add_moderate_meetup_event_tag.php');
+}
+
+function meetupEventTagNamed(string $german): ?Tag
+{
+    return Tag::query()->where('type', 'meetup_event')->get()
+        ->first(fn (Tag $tag): bool => $tag->getTranslation('name', 'de', false) === $german);
+}
+
+/**
+ * Every tag, in the order `ordered()` returns them, by German name.
+ *
+ * @return array<int, string>
+ */
+function tagLadder(): array
+{
+    return Tag::query()->ordered()->get()
+        ->map(fn (Tag $tag): string => (string) $tag->getTranslation('name', 'de', false))
+        ->all();
+}
+
+it('does nothing on a database without the event vocabulary', function () {
+    moderateTagMigration()->up();
+
+    expect(Tag::count())->toBe(0);
+});
+
+it('slots the tag into the ladder between Beginners and Advanced', function () {
+    $this->seed(TagSeeder::class);
+    $seeded = tagLadder();
+
+    // Back to the state of a database seeded before this change.
+    moderateTagMigration()->down();
+
+    expect(meetupEventTagNamed('Mittelstufe'))->toBeNull()
+        ->and(tagLadder())->not->toContain('Mittelstufe');
+
+    moderateTagMigration()->up();
+
+    $ladder = tagLadder();
+    $moderate = array_search('Mittelstufe', $ladder, true);
+
+    expect($moderate)->not->toBeFalse()
+        ->and($moderate)->toBeGreaterThan(array_search('Einsteiger', $ladder, true))
+        ->and($moderate)->toBeLessThan(array_search('Fortgeschrittene', $ladder, true))
+        ->and($moderate)->toBeLessThan(count($ladder) - 1);
+
+    // Same sequence as a fresh seed produces, so the migrated database and a newly
+    // seeded one offer the vocabulary in one and the same order.
+    expect($ladder)->toBe($seeded);
+});
+
+it('creates the tag exactly as the seeder vocabulary describes it', function () {
+    $this->seed(TagSeeder::class);
+
+    moderateTagMigration()->down();
+    moderateTagMigration()->up();
+
+    $vocabulary = require database_path('seeders/data/tags.php');
+
+    $expected = collect($vocabulary['meetup_event'])
+        ->first(fn (array $each): bool => is_array($each['name']) && $each['name']['de'] === 'Mittelstufe');
+
+    $tag = meetupEventTagNamed('Mittelstufe');
+
+    expect($expected)->not->toBeNull()
+        ->and($tag->icon)->toBe($expected['icon'])
+        ->and($tag->featured)->toBe((bool) $expected['featured']);
+
+    foreach ($expected['name'] as $locale => $name) {
+        expect($tag->getTranslation('name', $locale, false))->toBe($name, "locale {$locale}");
+    }
+});
+
+it('is idempotent', function () {
+    $this->seed(TagSeeder::class);
+    $ladder = tagLadder();
+
+    moderateTagMigration()->up();
+    moderateTagMigration()->up();
+
+    expect(Tag::query()->where('type', 'meetup_event')->count())->toBe(16)
+        ->and(tagLadder())->toBe($ladder);
+});
+
+it('leaves the tags of existing events untouched', function () {
+    $this->seed(TagSeeder::class);
+
+    $country = Country::factory()->create(['code' => 'de']);
+    $city = City::factory()->create(['country_id' => $country->id]);
+    $meetup = Meetup::factory()->create(['city_id' => $city->id]);
+    $event = MeetupEvent::factory()->create(['meetup_id' => $meetup->id]);
+
+    $event->attachTag(meetupEventTagNamed('Vortrag'));
+    $event->attachTag(meetupEventTagNamed('Einsteiger'));
+
+    $taggables = DB::table('taggables')->orderBy('tag_id')->get()->toArray();
+    $tagIds = $event->fresh()->tags->pluck('id')->sort()->values()->all();
+
+    moderateTagMigration()->down();
+    moderateTagMigration()->up();
+
+    expect(DB::table('taggables')->orderBy('tag_id')->get()->toArray())->toEqual($taggables)
+        ->and($event->fresh()->tags->pluck('id')->sort()->values()->all())->toBe($tagIds);
+});
+
+it('keeps a tag that an event already uses when rolled back', function () {
+    $this->seed(TagSeeder::class);
+
+    $country = Country::factory()->create(['code' => 'de']);
+    $city = City::factory()->create(['country_id' => $country->id]);
+    $meetup = Meetup::factory()->create(['city_id' => $city->id]);
+    $event = MeetupEvent::factory()->create(['meetup_id' => $meetup->id]);
+
+    $moderate = meetupEventTagNamed('Mittelstufe');
+    $event->attachTag($moderate);
+
+    moderateTagMigration()->down();
+
+    expect(meetupEventTagNamed('Mittelstufe'))->not->toBeNull()
+        ->and($event->fresh()->tags->pluck('id')->all())->toBe([$moderate->id]);
+});

--- a/tests/Feature/Migrations/MergeDuplicateTagsTest.php
+++ b/tests/Feature/Migrations/MergeDuplicateTagsTest.php
@@ -178,7 +178,7 @@ it('reduces the real production set from 89 to 75 and leaves it seedable', funct
 
     $this->seed(TagSeeder::class);
 
-    // The seeder adds the 15 event tags on top; nothing gets duplicated.
-    expect(Tag::query()->where('type', 'meetup_event')->count())->toBe(15)
+    // The seeder adds the 16 event tags on top; nothing gets duplicated.
+    expect(Tag::query()->where('type', 'meetup_event')->count())->toBe(16)
         ->and(Tag::query()->where('type', 'library_item')->count())->toBe(74);
 });

--- a/tests/Feature/Seeders/TagSeederTest.php
+++ b/tests/Feature/Seeders/TagSeederTest.php
@@ -10,7 +10,7 @@ it('seeds the full curated vocabulary', function () {
     $expected = collect($vocabulary)->flatten(1)->count();
 
     expect(Tag::count())->toBe($expected)
-        ->and(Tag::query()->where('type', 'meetup_event')->count())->toBe(15)
+        ->and(Tag::query()->where('type', 'meetup_event')->count())->toBe(16)
         ->and(Tag::query()->where('type', 'library_item')->count())->toBe(74)
         ->and(Tag::query()->where('type', 'course')->count())->toBe(1);
 });

--- a/tests/Feature/Tags/EventTagPickerTest.php
+++ b/tests/Feature/Tags/EventTagPickerTest.php
@@ -41,7 +41,7 @@ it('offers only event tags, not the library vocabulary', function () {
     $options = Livewire::test('tags.picker', ['type' => 'meetup_event'])
         ->instance()->options;
 
-    expect($options)->toHaveCount(15)
+    expect($options)->toHaveCount(16)
         ->and($options->pluck('type')->unique()->all())->toBe(['meetup_event']);
 });
 

--- a/tests/Feature/Tags/ModerateEventTagTest.php
+++ b/tests/Feature/Tags/ModerateEventTagTest.php
@@ -1,0 +1,86 @@
+<?php
+
+use App\Models\Tag;
+use Database\Seeders\TagSeeder;
+use Livewire\Livewire;
+
+/**
+ * Issue #68: the event difficulty scale had a beginner end and an expert end and
+ * nothing in between.
+ *
+ * The ordering assertions read the picker's RENDERED rows rather than the seeder file,
+ * because those are two different orders: the file's position becomes `order_column`,
+ * but the picker lifts the whole featured block above the rest before it renders, and
+ * "Einsteiger" is featured while the other two are not. What the organiser sees is
+ * therefore the only order worth asserting.
+ */
+beforeEach(function () {
+    $this->seed(TagSeeder::class);
+});
+
+/**
+ * The rendered rows of the event picker, in DOM order, by their German name.
+ *
+ * @return array<int, string>
+ */
+function renderedEventTagNames(): array
+{
+    $html = Livewire::test('tags.picker', ['type' => 'meetup_event'])->html();
+
+    preg_match_all('/data-testid="tag-option-(\d+)"/', $html, $matches);
+
+    return collect($matches[1])
+        ->map(fn (string $id): string => (string) Tag::findOrFail((int) $id)->getTranslation('name', 'de', false))
+        ->all();
+}
+
+it('adds Moderate to the meetup_event vocabulary in every locale', function () {
+    $moderate = Tag::query()->where('type', 'meetup_event')->get()
+        ->first(fn (Tag $tag): bool => $tag->getTranslation('name', 'de', false) === 'Mittelstufe');
+
+    expect($moderate)->not->toBeNull()
+        ->and($moderate->isApproved())->toBeTrue()
+        ->and($moderate->getTranslation('name', 'en'))->toBe('Moderate')
+        ->and($moderate->getTranslation('name', 'cs'))->toBe('Mírně pokročilí')
+        ->and($moderate->getTranslation('name', 'pl'))->toBe('Średniozaawansowani')
+        ->and($moderate->getTranslation('slug', 'en'))->toBe('moderate');
+
+    foreach (config('einundzwanzig.tag_locales') as $locale) {
+        expect($moderate->getTranslation('name', $locale, false))
+            ->not->toBe('', "missing {$locale} for the Moderate tag");
+    }
+});
+
+it('renders Moderate between Beginners and Advanced, not at the end of the picker', function () {
+    actingAsUser();
+
+    $names = renderedEventTagNames();
+
+    $beginners = array_search('Einsteiger', $names, true);
+    $moderate = array_search('Mittelstufe', $names, true);
+    $advanced = array_search('Fortgeschrittene', $names, true);
+
+    expect($names)->toHaveCount(16)
+        ->and($beginners)->not->toBeFalse()
+        ->and($moderate)->not->toBeFalse()
+        ->and($advanced)->not->toBeFalse();
+
+    expect($moderate)->toBeGreaterThan($beginners)
+        ->and($moderate)->toBeLessThan($advanced)
+        // The scale must read as a scale: the row is somewhere in the middle of the
+        // list, not appended behind everything else.
+        ->and($moderate)->toBeLessThan(count($names) - 1);
+});
+
+it('offers Moderate the same way as Advanced: selectable, not in the resting list', function () {
+    actingAsUser();
+
+    $options = Livewire::test('tags.picker', ['type' => 'meetup_event'])->instance()->options;
+
+    $moderate = $options->first(fn (Tag $tag): bool => $tag->getTranslation('name', 'de', false) === 'Mittelstufe');
+    $advanced = $options->first(fn (Tag $tag): bool => $tag->getTranslation('name', 'de', false) === 'Fortgeschrittene');
+
+    expect($moderate)->not->toBeNull()
+        ->and($moderate->featured)->toBe($advanced->featured)
+        ->and($moderate->featured)->toBeFalse();
+});


### PR DESCRIPTION
Closes #68.

`Nostr` and `Advanced` were already in the `meetup_event` group; only `Moderate` was missing, leaving the difficulty scale with a beginner end and an expert end and nothing between.

Added to the seeder between `Einsteiger` and `Fortgeschrittene`, with names in all nine locales.

`lang/*.json` needed no change, and that is a finding rather than an omission: the difficulty tags are not keyed in the JSON catalogues at all — they exist only as `spatie/laravel-translatable` values inside `tags.name`.

Display order comes from `tags.order_column`, not from the seeder array, so a seeder entry alone would have put `Moderate` last on every already-seeded database. The migration increments `order_column` globally at and above the anchor and writes the new row into the gap. No-op without the anchor, no-op if the tag exists; `down()` closes the gap but refuses when an event already carries the tag.

Placement is proven from the rendered picker DOM — row 10 of 16, after Beginners and before Advanced. "Existing events untouched" is proven by snapshotting the whole `taggables` table across a `down()`/`up()` cycle.

`Feature --filter="Tag|Moderate"` → 172 passed (1418 assertions). Four mutation probes, each reddening the assertion that claims to cover it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XfFQ18DFktM3ewnWo9Zt9X
