### PR TITLE
Emit zone-marked timestamps beside the ambiguous ones

### DIFF
--- a/app/Http/Controllers/Api/MeetupEventController.php
+++ b/app/Http/Controllers/Api/MeetupEventController.php
@@ -70,19 +70,41 @@ class MeetupEventController extends Controller
             'id' => $event->id,
             'title' => $event->title,
             /*
-             * Deliberately NOT switched to the App\Support\Carbon formatters by the ISO
-             * 8601 work (issue #48): this is a published API contract with a live mobile
-             * consumer, and it is already ISO-shaped. `Y-m-d H:i` in UTC, with no zone
-             * marker and no seconds — a raw ->format() that skips the user-timezone
-             * conversion on purpose, because an API has no "current user's timezone".
+             * DEPRECATED (issue #71), and kept anyway: `Y-m-d H:i` in UTC with no zone
+             * marker and no seconds. A consumer reading `2026-09-16 17:00` cannot tell
+             * UTC from the organiser's zone from its own.
              *
-             * Changing it (adding a zone suffix, going full ISO 8601 with T and offset,
-             * or rendering in a requested zone) is a breaking change for that consumer
-             * and needs its own decision — not a side effect of a display-layer fix.
+             * Replaced by `start_iso` / `end_iso` below. These two stay unchanged, byte
+             * for byte, until the live mobile client has moved over — removing them is a
+             * breaking change and belongs to a coordinated client release, not here.
+             * Until then both pairs describe the SAME instant, so a client can migrate
+             * one field at a time without any shift in what it renders.
+             *
+             * Still a raw ->format() that skips the App\Support\Carbon user-timezone
+             * conversion on purpose, because an API has no "current user's timezone".
              * MobileMeetupListController::__invoke() mirrors this format on purpose.
              */
             'start' => $event->start->format('Y-m-d H:i'),
             'end' => $event->end?->format('Y-m-d H:i'),
+            /*
+             * The zone-marked replacement for `start` / `end` (issue #71):
+             * `2026-09-16T17:00:00+00:00` — ISO 8601 with a numeric OFFSET, not the `Z`
+             * shorthand, because that is what `toIso8601String()` emits and what this
+             * codebase already puts on the wire elsewhere (WebhookSubscriptionResource).
+             * One spelling across the API beats picking the prettier one here.
+             *
+             * ->setTimezone('UTC') is explicit rather than incidental. The datetime cast
+             * already yields UTC on this route (config('app.timezone') is 'UTC', and
+             * SetTimezone runs on the web middleware group only — never on an API
+             * request), so both fields name the same wall clock. Spelling the conversion
+             * out makes the +00:00 offset a promise of this endpoint instead of a side
+             * effect of that configuration.
+             *
+             * MobileMeetupListController::__invoke() emits the same format under the same
+             * `_iso` naming — both endpoints move together, per issue #71.
+             */
+            'start_iso' => $event->start->setTimezone('UTC')->toIso8601String(),
+            'end_iso' => $event->end?->setTimezone('UTC')->toIso8601String(),
             /*
              * The venue in up to two layers, and the six osm_* keys are ALWAYS present
              * — null when no map place was picked, never absent (Issue #37 follow-up).

--- a/app/Http/Controllers/Api/MobileMeetupListController.php
+++ b/app/Http/Controllers/Api/MobileMeetupListController.php
@@ -76,15 +76,34 @@ class MobileMeetupListController extends Controller
                 // app should show the initials avatar, so null instead of a placeholder URL.
                 'logo' => $meetup->getFirstMedia('logo')?->getUrl(),
                 /*
-                 * Same format as GET /api/meetup-events (see MeetupEventController),
-                 * and deliberately left alone by the ISO 8601 work (issue #48):
-                 * `Y-m-d H:i` in UTC, no zone marker, no user-timezone conversion.
-                 * A published API contract with a live mobile consumer — changing its
-                 * shape is a breaking change that needs its own decision, and it has to
-                 * be taken for both endpoints at once.
+                 * DEPRECATED (issue #71), and kept anyway: `Y-m-d H:i` in UTC with no zone
+                 * marker, same format as `start` on GET /api/meetup-events.
+                 *
+                 * Replaced by `next_event_start_iso` below. This one stays unchanged, byte
+                 * for byte, until the live mobile client has moved over; dropping it is a
+                 * breaking change and belongs to a coordinated client release. Both fields
+                 * describe the same instant, so the client can switch when it is ready.
                  */
                 'next_event_start' => $meetup->next_event_start
                     ? Carbon::parse($meetup->next_event_start)->format('Y-m-d H:i')
+                    : null,
+                /*
+                 * The zone-marked replacement (issue #71): `2026-09-16T17:00:00+00:00` —
+                 * ISO 8601 with a numeric OFFSET rather than the `Z` shorthand, because
+                 * that is what `toIso8601String()` emits and what the rest of this API
+                 * already sends. Identical field naming (`<field>_iso`) and identical
+                 * format to `start_iso` / `end_iso` on GET /api/meetup-events: issue #71
+                 * requires both endpoints to move together.
+                 *
+                 * The subquery hands us a bare `Y-m-d H:i:s` string carrying no zone of its
+                 * own, so the zone goes INTO parse() rather than onto the result:
+                 * `parse($v, 'UTC')` reads the value as UTC, which is how the column is
+                 * stored, whereas a trailing ->setTimezone('UTC') would convert it and,
+                 * under a non-UTC PHP default, shift it away from the deprecated field
+                 * above. Same instant, two spellings — that is the whole migration path.
+                 */
+                'next_event_start_iso' => $meetup->next_event_start
+                    ? Carbon::parse($meetup->next_event_start, 'UTC')->toIso8601String()
                     : null,
             ]);
     }

--- a/tests/Feature/Api/MeetupEventIso8601TimestampsApiTest.php
+++ b/tests/Feature/Api/MeetupEventIso8601TimestampsApiTest.php
@@ -1,0 +1,133 @@
+<?php
+
+use App\Models\City;
+use App\Models\Country;
+use App\Models\Meetup;
+use App\Models\MeetupEvent;
+use Illuminate\Support\Carbon;
+
+/*
+ * Issue #71: GET /api/meetup-events and GET /api/mobile/meetups emitted `Y-m-d H:i`
+ * in UTC with NO zone marker, so a consumer could not tell UTC from the organiser's
+ * zone from its own.
+ *
+ * The fix is ADDITIVE: an ISO 8601 twin next to each legacy field, same naming scheme
+ * (`<field>_iso`) and same format on both endpoints. The legacy fields stay for the
+ * shipped mobile client, which is why half of this file asserts that they did NOT move.
+ *
+ * Every assertion is on the literal emitted string. `assertJsonStructure()` or
+ * `toHaveKey()` would stay green through exactly the silent format change this issue
+ * is about.
+ */
+
+beforeEach(function () {
+    // Frozen clock: both endpoints filter against now(), and the expected strings
+    // below are literals, not re-derived from the same call under test.
+    $this->travelTo(Carbon::parse('2026-09-01 12:00:00', 'UTC'));
+
+    $country = Country::factory()->create(['code' => 'de']);
+    $city = City::factory()->create(['country_id' => $country->id]);
+    $this->meetup = Meetup::factory()->create([
+        'city_id' => $city->id,
+        'visible_on_map' => true,
+    ]);
+});
+
+it('leaves the legacy start/end strings of GET /api/meetup-events untouched', function () {
+    $event = MeetupEvent::factory()->create([
+        'meetup_id' => $this->meetup->id,
+        'start' => '2026-09-16 17:00:00',
+        'end' => '2026-09-16 20:30:00',
+    ]);
+
+    $row = collect($this->getJson('/api/meetup-events')->assertOk()->json())
+        ->firstWhere('id', $event->id);
+
+    expect($row['start'])->toBe('2026-09-16 17:00')
+        ->and($row['end'])->toBe('2026-09-16 20:30');
+});
+
+it('adds zone-marked ISO 8601 twins to GET /api/meetup-events', function () {
+    $event = MeetupEvent::factory()->create([
+        'meetup_id' => $this->meetup->id,
+        'start' => '2026-09-16 17:00:00',
+        'end' => '2026-09-16 20:30:00',
+    ]);
+
+    $row = collect($this->getJson('/api/meetup-events')->assertOk()->json())
+        ->firstWhere('id', $event->id);
+
+    expect($row['start_iso'])->toBe('2026-09-16T17:00:00+00:00')
+        ->and($row['end_iso'])->toBe('2026-09-16T20:30:00+00:00');
+});
+
+it('keeps end_iso present and null for an open-ended event, exactly like end', function () {
+    $event = MeetupEvent::factory()->create([
+        'meetup_id' => $this->meetup->id,
+        'start' => '2026-09-16 17:00:00',
+        'end' => null,
+    ]);
+
+    $row = collect($this->getJson('/api/meetup-events')->assertOk()->json())
+        ->firstWhere('id', $event->id);
+
+    expect($row)->toHaveKey('end_iso')
+        ->and($row['end'])->toBeNull()
+        ->and($row['end_iso'])->toBeNull()
+        ->and($row['start_iso'])->toBe('2026-09-16T17:00:00+00:00');
+});
+
+it('leaves the legacy next_event_start string of GET /api/mobile/meetups untouched', function () {
+    MeetupEvent::factory()->create([
+        'meetup_id' => $this->meetup->id,
+        'start' => '2026-09-16 17:00:00',
+    ]);
+
+    $row = collect($this->getJson('/api/mobile/meetups')->assertOk()->json())
+        ->firstWhere('name', $this->meetup->name);
+
+    expect($row['next_event_start'])->toBe('2026-09-16 17:00');
+});
+
+it('adds a zone-marked ISO 8601 twin to GET /api/mobile/meetups', function () {
+    MeetupEvent::factory()->create([
+        'meetup_id' => $this->meetup->id,
+        'start' => '2026-09-16 17:00:00',
+    ]);
+
+    $row = collect($this->getJson('/api/mobile/meetups')->assertOk()->json())
+        ->firstWhere('name', $this->meetup->name);
+
+    expect($row['next_event_start_iso'])->toBe('2026-09-16T17:00:00+00:00');
+});
+
+it('keeps next_event_start_iso present and null without an upcoming event', function () {
+    MeetupEvent::factory()->create([
+        'meetup_id' => $this->meetup->id,
+        'start' => '2026-08-01 17:00:00',
+    ]);
+
+    $row = collect($this->getJson('/api/mobile/meetups')->assertOk()->json())
+        ->firstWhere('name', $this->meetup->name);
+
+    expect($row)->toHaveKey('next_event_start_iso')
+        ->and($row['next_event_start'])->toBeNull()
+        ->and($row['next_event_start_iso'])->toBeNull();
+});
+
+it('emits byte-identical ISO 8601 for the same instant on both endpoints', function () {
+    // The issue's third checkbox: a consumer reading one format from the list endpoint
+    // and another from the detail endpoint would be worse than the current ambiguity.
+    $event = MeetupEvent::factory()->create([
+        'meetup_id' => $this->meetup->id,
+        'start' => '2026-09-16 17:00:00',
+    ]);
+
+    $detail = collect($this->getJson('/api/meetup-events')->assertOk()->json())
+        ->firstWhere('id', $event->id);
+    $mobile = collect($this->getJson('/api/mobile/meetups')->assertOk()->json())
+        ->firstWhere('name', $this->meetup->name);
+
+    expect($mobile['next_event_start_iso'])->toBe($detail['start_iso'])
+        ->and($detail['start_iso'])->toBe('2026-09-16T17:00:00+00:00');
+});


### PR DESCRIPTION
Closes #71.

`GET /api/meetup-events` and `GET /api/mobile/meetups` formatted dates as `Y-m-d H:i` in UTC with **no zone marker**. A consumer receiving `2026-09-16 17:00` cannot tell whether that is UTC, the organiser's zone or its own.

Additive, not a replacement. `start_iso`, `end_iso` and `next_event_start_iso` are new; `start`, `end` and `next_event_start` stay byte-identical until the live mobile client has moved. Both pairs describe the same instant, so a client can migrate one field at a time.

Format is ISO 8601 with a numeric offset (`2026-09-16T17:00:00+00:00`), not `Z`: it is what `toIso8601String()` emits and what this API already puts on the wire in `WebhookSubscriptionResource`.

The two call sites need **different** operations. The detail endpoint converts (a cast Carbon that already knows its zone); the mobile endpoint reinterprets (`Carbon::parse($v, 'UTC')` on a bare subquery string). A trailing `setTimezone()` there would convert instead and, under a non-UTC PHP default, shift this field away from the deprecated one beside it.

Three mutation probes, including one that reverts only the detail endpoint — the cross-endpoint test catches the divergence, which a test asserting each endpoint against its own literal would not have.

Not verified: no real mobile client was exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XfFQ18DFktM3ewnWo9Zt9X
