### PR TITLE
Give tags a locale key, and document where the parameter works

### DIFF
--- a/app/Http/Controllers/Api/MeetupEventController.php
+++ b/app/Http/Controllers/Api/MeetupEventController.php
@@ -29,6 +29,16 @@ use Symfony\Component\HttpFoundation\Response;
 class MeetupEventController extends Controller
 {
     /**
+     * The one description behind every `locale` query parameter of this controller.
+     *
+     * Five endpoints honour the parameter — the public list, `store`, `update`, `mine`
+     * and `mineShow` — and the API reference used to advertise it on the list alone
+     * (issue #57). Held as a constant rather than copied five times so the reference
+     * cannot start describing the same parameter in five slightly different ways.
+     */
+    private const LOCALE_PARAMETER_DESCRIPTION = 'Requested language for tag names (ISO 639-1, e.g. "cs"). Falls back to the Accept-Language header, then to the existing display-chain default. The language you actually get is in each tag\'s `locale` field, which can differ when the tag has no name in the requested language.';
+
+    /**
      * List meetup events
      *
      * Returns upcoming/past meetup events. With an optional date, the result is filtered
@@ -37,7 +47,7 @@ class MeetupEventController extends Controller
      * @return Collection<int, array<string, mixed>>
      */
     #[PathParameter(name: 'date', description: 'Optional date (Y-m-d); filters to the month of that date.', required: false, type: 'string')]
-    #[QueryParameter(name: 'locale', description: 'Requested language for tag names (ISO 639-1, e.g. "cs"). Falls back to the Accept-Language header, then to the existing display-chain default.', required: false, type: 'string')]
+    #[QueryParameter(name: 'locale', description: self::LOCALE_PARAMETER_DESCRIPTION, required: false, type: 'string')]
     #[ResponseAttribute(status: 400, description: 'The given date cannot be parsed (Y-m-d is expected).')]
     public function __invoke(Request $request, ?string $date = null): Collection
     {
@@ -157,6 +167,32 @@ class MeetupEventController extends Controller
     }
 
     /**
+     * List meetup events
+     *
+     * Returns every upcoming/past meetup event, unfiltered. The same list
+     * `GET /meetup-events/{date}` returns when no date is given.
+     *
+     * EXISTS FOR THE API REFERENCE, NOT FOR THE BEHAVIOUR (issue #57). The route used
+     * to be `meetup-events/{date?}` alone, and Scramble collapses an optional path
+     * parameter — it rewrites the URI with `Str::replace('?}', '}', …)` before building
+     * the operation, so the document held `/meetup-events/{date}` and nothing at all
+     * for the path consumers actually call. A route of its own is the only way to get
+     * that path generated rather than synthesised into the document afterwards.
+     *
+     * A SEPARATE METHOD rather than a second route onto `__invoke()`: the attributes
+     * are per method, so sharing one would put `#[PathParameter(name: 'date')]` on a
+     * path that has no `{date}` placeholder — invalid OpenAPI, measured. The body
+     * delegates, so there is exactly one implementation and the two paths cannot drift.
+     *
+     * @return Collection<int, array<string, mixed>>
+     */
+    #[QueryParameter(name: 'locale', description: self::LOCALE_PARAMETER_DESCRIPTION, required: false, type: 'string')]
+    public function index(Request $request): Collection
+    {
+        return $this->__invoke($request);
+    }
+
+    /**
      * Create meetup event
      *
      * Allows an authenticated user to create a meetup event programmatically.
@@ -167,6 +203,7 @@ class MeetupEventController extends Controller
      * upper limit of 100 meetup events), and the response contains the list of all created events.
      * Without these fields, a single meetup event is created.
      */
+    #[QueryParameter(name: 'locale', description: self::LOCALE_PARAMETER_DESCRIPTION, required: false, type: 'string')]
     #[ResponseAttribute(status: 401, description: 'Not authenticated.')]
     #[ResponseAttribute(status: 422, description: 'Validation error.')]
     public function store(StoreMeetupEventRequest $request, CreateMeetupEventSeries $createSeries): JsonResponse
@@ -193,6 +230,7 @@ class MeetupEventController extends Controller
      *
      * Updates a meetup event; only for the creator or a super admin.
      */
+    #[QueryParameter(name: 'locale', description: self::LOCALE_PARAMETER_DESCRIPTION, required: false, type: 'string')]
     #[ResponseAttribute(status: 403, description: 'Only the creator or a super admin may change the meetup event.')]
     #[ResponseAttribute(status: 422, description: 'Validation error.')]
     public function update(UpdateMeetupEventRequest $request, MeetupEvent $meetupEvent): MeetupEventResource
@@ -208,6 +246,7 @@ class MeetupEventController extends Controller
      * Returns all meetup events the authenticated user may edit
      * (created by themselves OR leader of the associated meetup), sorted by start time descending.
      */
+    #[QueryParameter(name: 'locale', description: self::LOCALE_PARAMETER_DESCRIPTION, required: false, type: 'string')]
     public function mine(Request $request): AnonymousResourceCollection
     {
         Gate::authorize('viewAny', MeetupEvent::class);
@@ -226,6 +265,7 @@ class MeetupEventController extends Controller
      *
      * Shows a single meetup event created by the authenticated user.
      */
+    #[QueryParameter(name: 'locale', description: self::LOCALE_PARAMETER_DESCRIPTION, required: false, type: 'string')]
     #[ResponseAttribute(status: 403, description: 'Only the creator or a super admin may view the meetup event.')]
     public function mineShow(MeetupEvent $meetupEvent): MeetupEventResource
     {

--- a/app/Http/Resources/TagResource.php
+++ b/app/Http/Resources/TagResource.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Resources;
 
+use App\Http\Controllers\Api\MeetupEventController;
 use App\Jobs\DeliverWebhookJob;
 use App\Models\Tag;
 use App\Support\Broadcasting\ChangeRecorder;
@@ -9,6 +10,24 @@ use Illuminate\Http\Request;
 use Illuminate\Http\Resources\Json\JsonResource;
 
 /**
+ * TWO KEYS, ONE VALUE: `locale` AND `name_locale` (issue #57).
+ *
+ * The hand-built tag array of `GET /api/meetup-events`
+ * ({@see MeetupEventController::__invoke()}) has always called
+ * this field `locale`; every response that goes through this resource — the
+ * authenticated read endpoints, the write responses, the webhook and change-log
+ * envelope, the course events — has always called it `name_locale`. Since PR #52 both
+ * carry the same information, so only the names differed.
+ *
+ * The decision was ADDITIVE, not a rename: `name_locale` stays for as long as consumers
+ * need it, because renaming it would break every existing parser at once — including the
+ * webhook receivers, which cannot ask for a locale and read `name_locale` and
+ * `translations` precisely because of that. `locale` is the name new consumers should
+ * read; it is the one the public list endpoint already uses.
+ *
+ * Both keys are filled from the same `$displayLocale` and can never disagree. Dropping
+ * `name_locale` is a separate, announced breaking change, not a cleanup.
+ *
  * @mixin Tag
  */
 class TagResource extends JsonResource
@@ -18,8 +37,9 @@ class TagResource extends JsonResource
      *
      * Tags are multilingual: one tag carries a name in each of the nine portal languages.
      * Which one you get depends on what the request asked for — `?locale=`, then
-     * `Accept-Language`, see {@see self::requestedLocale()} — and `name_locale` always
-     * tells you which one you actually got, which is not always the one you asked for.
+     * `Accept-Language`, see {@see self::requestedLocale()} — and `locale` (as well as
+     * its older twin `name_locale`) always tells you which one you actually got, which
+     * is not always the one you asked for.
      *
      * @return array<string, mixed>
      */
@@ -27,8 +47,8 @@ class TagResource extends JsonResource
     {
         $requestedLocale = self::requestedLocale($request);
         // Resolved once: displayLocale() walks the whole candidate chain and hits
-        // getTranslation() per candidate, and `name`, `name_locale` and `slug` must
-        // agree on the answer anyway.
+        // getTranslation() per candidate, and `name`, `locale`/`name_locale` and `slug`
+        // must agree on the answer anyway.
         $displayLocale = $this->displayLocale($requestedLocale);
 
         return [
@@ -42,8 +62,8 @@ class TagResource extends JsonResource
              * The name in the requested language, with a fallback.
              *
              * Never empty: when a tag has no name in the requested language, the portal
-             * language is used, then English, then whatever exists. Check `name_locale`
-             * to find out which one you are looking at.
+             * language is used, then English, then whatever exists. Check `locale` to
+             * find out which one you are looking at.
              */
             // Resolved through the display chain for the language the client asked
             // for, so a consumer asking in Czech gets the German name rather than an
@@ -53,9 +73,19 @@ class TagResource extends JsonResource
              * The language `name` and `slug` are actually in — an ISO 639-1 code such as
              * `de` or `cs`. Differs from the requested language whenever a fallback kicked
              * in, which is your cue to show the name as a foreign-language label.
+             *
+             * Read this one. It is the same name `GET /api/meetup-events` uses, and the
+             * same value as `name_locale`, which is kept only for existing parsers.
+             */
+            'locale' => $displayLocale,
+            /**
+             * The same value as `locale`, under the older name.
+             *
+             * Kept because every existing parser of this resource reads it — see the
+             * class docblock. New consumers should read `locale`.
              */
             'name_locale' => $displayLocale,
-            /** URL-safe form of `name`, in the language given by `name_locale`. */
+            /** URL-safe form of `name`, in the language given by `locale`. */
             'slug' => $this->getTranslation('slug', $displayLocale ?? app()->getLocale(), false),
             /**
              * Whether the tag is one of the curated suggestions offered before the user
@@ -100,8 +130,8 @@ class TagResource extends JsonResource
      * `api_changes.payload` — and from there into every webhook delivery of it,
      * because {@see DeliverWebhookJob} re-sends the stored bytes and never
      * re-renders the resource. A queue worker has no request and cannot resolve a
-     * locale; `name_locale` and `translations` travel with each tag precisely so a
-     * receiver never has to guess which language it got.
+     * locale; `locale` (with its older twin `name_locale`) and `translations` travel
+     * with each tag precisely so a receiver never has to guess which language it got.
      */
     public static function requestedLocale(Request $request): ?string
     {

--- a/resources/views/livewire/docs/webhooks.blade.php
+++ b/resources/views/livewire/docs/webhooks.blade.php
@@ -283,7 +283,8 @@ class extends Component
      * Ein echtes Beispiel je Aktion.
      *
      * Die Feldmenge ist die, die `MeetupEventResource` wirklich erzeugt — inklusive
-     * der sechs `osm_*`-Felder und der Tag-Gestalt mit `name_locale`. Nur die Werte
+     * der sechs `osm_*`-Felder und der Tag-Gestalt mit `locale` und dessen aelterem
+     * Zwilling `name_locale` (gleicher Wert, Issue #57). Nur die Werte
      * (Ids, Namen, Zeiten) sind auf etwas Lesbares gesetzt.
      *
      * @return list<array{title:string, note:HtmlString, json:string}>
@@ -323,6 +324,7 @@ class extends Component
                         "id": 5,
                         "type": "meetup_event",
                         "name": "Vortrag",
+                        "locale": "de",
                         "name_locale": "de",
                         "slug": "vortrag",
                         "featured": true,
@@ -1104,9 +1106,14 @@ class extends Component
                     Tags are multilingual and the envelope is written once, at the moment of the
                     change — so <code>name</code> is in the language of the request that CAUSED
                     the change, not in one you can ask for. You never have to guess which:
-                    <code>name_locale</code> names it, and <code>translations</code> carries every
+                    <code>locale</code> names it, and <code>translations</code> carries every
                     other language of the same tag. Pick from there instead of trusting
                     <code>name</code>.
+                </p>
+                <p class="mt-3 text-pretty leading-relaxed text-zinc-600 dark:text-zinc-300">
+                    Every tag also carries <code>name_locale</code> with exactly the same value.
+                    It is the older name of the same field and stays for parsers that already
+                    read it; new receivers should read <code>locale</code>.
                 </p>
             </div>
         </div>

--- a/routes/api.php
+++ b/routes/api.php
@@ -42,7 +42,12 @@ Route::middleware([SetApiLocale::class, 'throttle:60,1'])
         // Bewusst NICHT in der API-Referenz (ExcludeRouteFromDocs) — erreichbar,
         // aber nicht beworben, solange die Form sich noch setzen kann.
         Route::get('meetup-leaders', PublicMeetupLeaderController::class);
-        Route::get('meetup-events/{date?}', MeetupEventController::class);
+        // Zwei Routen statt `meetup-events/{date?}`, damit der nackte Pfad in der
+        // API-Referenz ueberhaupt auftaucht: Scramble kollabiert einen optionalen
+        // Pfad-Parameter und dokumentiert nur die Variante MIT ihm (Issue #57).
+        // Gleiches Verhalten wie vorher — index() delegiert an __invoke().
+        Route::get('meetup-events', [MeetupEventController::class, 'index']);
+        Route::get('meetup-events/{date}', MeetupEventController::class);
         Route::get('btc-map-communities', BtcMapCommunityController::class);
         // Der Resync-Weg fuer Konsumenten (Issue #29): alle Aenderungen ab einem
         // Cursor, inklusive der Loeschungen, die sonst nirgends sichtbar sind.

--- a/tests/Feature/Api/MeetupEventListRouteTest.php
+++ b/tests/Feature/Api/MeetupEventListRouteTest.php
@@ -1,0 +1,154 @@
+<?php
+
+use App\Models\City;
+use App\Models\Country;
+use App\Models\Meetup;
+use App\Models\MeetupEvent;
+use App\Models\Tag;
+use Database\Seeders\TagSeeder;
+
+/*
+|--------------------------------------------------------------------------
+| Issue #57 — the bare list path exists as its own route, and is documented
+|--------------------------------------------------------------------------
+|
+| `GET /api/meetup-events` used to be the optional-parameter half of a single
+| `meetup-events/{date?}` route. Scramble collapses that: it rewrites the URI with
+| `Str::replace('?}', '}', …)` before building the operation, so the document held
+| exactly one GET — `/meetup-events/{date}` — and the path consumers actually call had
+| no operation at all, annotation or not.
+|
+| The route is therefore split, and the bare path has its own thin controller method:
+| a shared method would drag its `#[PathParameter(name: 'date')]` onto a path with no
+| `{date}` placeholder, which is invalid OpenAPI.
+|
+| Two things have to hold, and each has a test below:
+|
+|  1. Nothing changed for existing consumers. The split is a documentation fix, not a
+|     payload change — same status, same keys, same values as the dated variant.
+|  2. The bare path is in the generated document, with `locale` and without a `date`
+|     path parameter. That is the whole point of the split; without it the second test
+|     goes red.
+|
+*/
+
+beforeEach(function () {
+    $country = Country::factory()->create(['code' => 'de']);
+    $city = City::factory()->create(['country_id' => $country->id]);
+    $this->meetup = Meetup::factory()->create(['city_id' => $city->id]);
+});
+
+it('answers the bare list path with the unchanged payload of the dated one', function () {
+    $event = MeetupEvent::factory()->create([
+        'meetup_id' => $this->meetup->id,
+        'title' => 'Einsteigerabend',
+        'start' => now()->addWeek()->setTime(19, 0),
+        'end' => now()->addWeek()->setTime(22, 0),
+    ]);
+
+    $bare = $this->getJson('/api/meetup-events')->assertOk()->json();
+    $dated = $this->getJson('/api/meetup-events/'.now()->addWeek()->format('Y-m-d'))
+        ->assertOk()
+        ->json();
+
+    $bareRow = collect($bare)->firstWhere('id', $event->id);
+    $datedRow = collect($dated)->firstWhere('id', $event->id);
+
+    /*
+     * The published contract of this endpoint, key by key and in order. Spelled out
+     * rather than derived from the response, because a list derived from what the
+     * endpoint currently emits would agree with any change it ever makes — including
+     * the one this test exists to catch. Top level stays a bare array: this endpoint
+     * has never had a `data` wrapper and gaining one would break every consumer.
+     */
+    expect($bare)->toBeArray()
+        ->and(array_keys($bareRow))->toBe([
+            'id',
+            'title',
+            'start',
+            'end',
+            'start_iso',
+            'end_iso',
+            'location',
+            'osm_type',
+            'osm_id',
+            'osm_name',
+            'osm_address',
+            'osm_lat',
+            'osm_lon',
+            'description',
+            'link',
+            'tags',
+            'attendees',
+            'might_attendees',
+            'meetup.name',
+            'meetup.portalLink',
+            'meetup.url',
+            'meetup.country',
+            'meetup.city',
+            'meetup.longitude',
+            'meetup.latitude',
+            'meetup.twitter_username',
+            'meetup.website',
+            'meetup.simplex',
+            'meetup.signal',
+            'meetup.nostr',
+            'meetup.logo',
+            'meetup.rsvp_enabled',
+        ])
+        ->and($bareRow['title'])->toBe('Einsteigerabend')
+        // Both routes reach the same code, and the value comparison says so for every
+        // field at once — a divergence between the two halves of the former single
+        // route is exactly what a split can introduce.
+        ->and($bareRow)->toBe($datedRow);
+});
+
+it('honours ?locale= on the bare list path', function () {
+    $this->seed(TagSeeder::class);
+
+    // Looked up here rather than through the helper in MeetupEventTagsApiTest: a
+    // function declared in another test file only exists when that file happens to be
+    // loaded in the same run, which a filtered run cannot promise.
+    $tag = Tag::query()->where('type', 'meetup_event')->get()
+        ->first(fn (Tag $t): bool => $t->getTranslation('name', 'de') === 'Vortrag');
+
+    $event = MeetupEvent::factory()->create(['meetup_id' => $this->meetup->id]);
+    $event->attachTag($tag);
+
+    $row = collect(
+        $this->getJson('/api/meetup-events?locale=cs')->assertOk()->json(),
+    )->firstWhere('id', $event->id);
+
+    expect($row['tags'][0]['name'])->toBe('Přednáška')
+        ->and($row['tags'][0]['locale'])->toBe('cs');
+});
+
+it('documents the bare list path with locale and without a date path parameter', function () {
+    $document = $this->get(route('scramble.docs.document'))
+        ->assertSuccessful()
+        ->json();
+
+    $operation = $document['paths']['/meetup-events']['get'] ?? null;
+
+    // The operation itself first: before the split this key did not exist, and every
+    // assertion below would have failed on a null instead of naming the real problem.
+    expect($operation)->not->toBeNull();
+
+    $parameters = collect($operation['parameters'] ?? []);
+
+    expect($parameters->firstWhere('name', 'locale')['in'] ?? null)->toBe('query')
+        /*
+         * No path parameter at all. A `date` parameter here would be the failure mode
+         * of the cheaper fix — splitting the route but leaving both halves on the
+         * method that carries `#[PathParameter(name: 'date')]`. The document would
+         * then declare a path parameter for a placeholder the path does not have,
+         * which is invalid OpenAPI and misleads every generated client.
+         */
+        ->and($parameters->where('in', 'path')->pluck('name')->all())->toBe([]);
+
+    // The dated variant is untouched and keeps carrying both.
+    $datedParameters = collect($document['paths']['/meetup-events/{date}']['get']['parameters'] ?? []);
+
+    expect($datedParameters->firstWhere('name', 'date')['in'] ?? null)->toBe('path')
+        ->and($datedParameters->firstWhere('name', 'locale')['in'] ?? null)->toBe('query');
+});

--- a/tests/Feature/Api/MeetupEventTagsApiTest.php
+++ b/tests/Feature/Api/MeetupEventTagsApiTest.php
@@ -130,9 +130,9 @@ it('never returns an empty tag name, even for a german-only tag', function () {
 | Accept-Language — so the authenticated endpoints, the write responses and the
 | change-log/webhook envelope all answered in German no matter what was asked.
 |
-| Note the field name difference, and that it is deliberate: the hand-built array
-| above calls it `locale`, TagResource calls it `name_locale`. Renaming either
-| would break existing parsers, so both stay.
+| Note the field name difference: the hand-built array above calls it `locale`,
+| TagResource historically called it `name_locale`. Resolved in #57 by emitting both
+| from TagResource — see the "Issue #57" section below.
 |
 */
 it('returns the tag name in the requested locale on my-meetup-events', function () {
@@ -212,6 +212,63 @@ it('keeps answering in the display-chain default when nothing was requested', fu
 
     expect($row['tags'][0]['name'])->toBe('Vortrag')
         ->and($row['tags'][0]['name_locale'])->toBe('de');
+});
+
+/*
+|--------------------------------------------------------------------------
+| Issue #57 — `locale` and `name_locale` are the same field under two names
+|--------------------------------------------------------------------------
+|
+| The decision on the naming split was additive, not a rename: `GET /api/meetup-events`
+| has always called the field `locale` and TagResource has always called it
+| `name_locale`, so TagResource now emits BOTH from the same resolved value. Renaming
+| would have broken every existing parser, webhook receivers included.
+|
+| These two tests are what keeps the pair honest: they must both be present and they
+| must never disagree — including when a fallback kicked in and the answer is not the
+| language that was asked for.
+|
+*/
+it('emits locale and name_locale with the same value', function () {
+    Sanctum::actingAs($user = User::factory()->create());
+
+    $event = MeetupEvent::factory()->create([
+        'meetup_id' => $this->meetup->id,
+        'created_by' => $user->id,
+    ]);
+    $event->attachTag(anEventTag('Vortrag'));
+
+    $tag = collect(
+        $this->getJson('/api/my-meetup-events?locale=cs')->assertOk()->json('data'),
+    )->firstWhere('id', $event->id)['tags'][0];
+
+    // array_key_exists, not the value: a key that silently disappeared would otherwise
+    // read as "both are null" and pass.
+    expect($tag)->toHaveKeys(['locale', 'name_locale'])
+        ->and($tag['locale'])->toBe('cs')
+        ->and($tag['name_locale'])->toBe($tag['locale']);
+});
+
+it('keeps locale and name_locale equal when a fallback answered instead', function () {
+    Sanctum::actingAs($user = User::factory()->create());
+
+    $event = MeetupEvent::factory()->create([
+        'meetup_id' => $this->meetup->id,
+        'created_by' => $user->id,
+    ]);
+    $event->attachTag(anEventTag('Vortrag'));
+
+    // `zz` is in no tag_locales list, so the display chain falls through to
+    // app.fallback_locale — the case where the answer is NOT what was asked for, and
+    // the one where a second, separately computed key would drift apart from the first.
+    $tag = collect(
+        $this->getJson('/api/my-meetup-events?locale=zz')->assertOk()->json('data'),
+    )->firstWhere('id', $event->id)['tags'][0];
+
+    expect($tag)->toHaveKeys(['locale', 'name_locale'])
+        ->and($tag['locale'])->toBe('en')
+        ->and($tag['name_locale'])->toBe($tag['locale'])
+        ->and($tag['name'])->toBe('Talk');
 });
 
 /*


### PR DESCRIPTION
Closes #57.

**Field name:** add `locale`, keep `name_locale`. Renaming would break every existing parser; both keys read the same local variable, so they cannot drift. The reasoning lives in a docblock on `TagResource`, not only in this PR.

**Documentation:** the annotation is now on all five endpoints that honour the parameter, with the description held as a constant rather than five copies.

The bare `GET /meetup-events` was not merely missing parameters — it had **no operation in the document at all**. `RequestEssentialsExtension.php:72` rewrites the URI with `Str::replace('?}', '}', …)` unconditionally, collapsing `meetup-events/{date?}` into `meetup-events/{date}` alone. No config, attribute or extension point exists for it.

The route is split and the bare path gets a thin `index()` that delegates to `__invoke()`. A second route onto `__invoke()` was measured and rejected: attributes are per method, so it dragged `#[PathParameter(name: 'date')]` onto a path with no `{date}` placeholder — invalid OpenAPI.

The document test goes red in both failure modes: without the split, on the operation being absent; against the shared-method variant, on the invented path parameter. The two behaviour tests were green before the split as well as after, which is what makes them evidence that the bare path did not change.

Not touched: `/api/course-events` goes through `TagResource` and gains `locale` with it, but carries no annotation — outside what #57 names.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XfFQ18DFktM3ewnWo9Zt9X
