### PR TITLE
Derive geography topic tags for published calendar events

### DIFF
--- a/app/Support/NostrCalendarEventFactory.php
+++ b/app/Support/NostrCalendarEventFactory.php
@@ -2,8 +2,10 @@
 
 namespace App\Support;
 
+use App\Models\City;
 use App\Models\Meetup;
 use App\Models\MeetupEvent;
+use Illuminate\Support\Str;
 use swentel\nostr\Event\Event;
 
 /**
@@ -19,12 +21,29 @@ use swentel\nostr\Event\Event;
  *    Spec — unbekannte Tags werden von Clients ignoriert).
  *  - 31923 Time-Based Calendar Event: `d`, `title`, `start` Pflicht; `D` (Tages-
  *    Granularitaet, floor(start / 86400)) ebenfalls Pflicht.
+ *
+ * The `t` topic tags added for issue #69 sit on both kinds, but they are spec'd on only
+ * one of them: NIP-52 lists `t` ("hashtag to categorize calendar event") among the
+ * optional tags of 31923, while its 31924 section lists `a` and nothing else. On the
+ * calendar they are therefore the same kind of deliberate extension as `location`/`g`/`r`
+ * above — a client that does not know them ignores them, and a client filtering
+ * `{"#t": ["berlin"]}` finds the calendar as well as its events. See
+ * {@see self::topicTags()} for the derivation and the normalisation rule.
  */
 class NostrCalendarEventFactory
 {
     private const KIND_CALENDAR = 31924;
 
     private const KIND_TIME_BASED_EVENT = 31923;
+
+    /**
+     * The `t` topics every published calendar event carries, wherever it is.
+     *
+     * They stand in front of the geography so that a client filtering `{"#t":
+     * ["bitcoin"]}` sees this portal's events at all — the geography alone is only
+     * findable by someone who already knows the region's name.
+     */
+    private const STATIC_TOPICS = ['bitcoin', 'meetup'];
 
     public static function calendarDTag(Meetup $meetup): string
     {
@@ -67,6 +86,10 @@ class NostrCalendarEventFactory
             $event->addTag(['g', $geohash]);
         }
 
+        foreach (self::topicTags($meetup->city) as $topic) {
+            $event->addTag(['t', $topic]);
+        }
+
         foreach (self::socialLinks($meetup) as $url) {
             $event->addTag(['r', $url]);
         }
@@ -106,6 +129,13 @@ class NostrCalendarEventFactory
             $event->addTag(['g', $geohash]);
         }
 
+        // Deliberately the MEETUP's city, not the event's own OSM match above: the `g`
+        // tag wants the most precise point it can get, a topic wants the name people
+        // search for. `osm_name` is a venue ("Bar 21"), never an administrative area.
+        foreach (self::topicTags($meetupEvent->meetup->city) as $topic) {
+            $event->addTag(['t', $topic]);
+        }
+
         $event->addTag(['a', self::coordinate(
             self::KIND_CALENDAR,
             $pubkeyHex,
@@ -113,6 +143,130 @@ class NostrCalendarEventFactory
         )]);
 
         return $event;
+    }
+
+    /**
+     * The `t` topic tags for a meetup's location (issue #69).
+     *
+     * Order is the reporter's: the two static topics, then the geography from most to
+     * least specific — city, region name, `<region>-<country>`, region code, country
+     * code. For Indianapolis: `bitcoin, meetup, indianapolis, indiana, in-us, in, us`.
+     *
+     * `in-us` is region-first and lowercase, i.e. NOT the ISO 3166-2 code that
+     * `App\Models\Region::isoCode()` returns (`US-IN`). That is the form asked for
+     * in the issue, and NIP-24 forbids the uppercase one outright; the ISO code is not
+     * emitted in addition, because a `t` tag nobody searches for is dead weight on every
+     * event we ever publish.
+     *
+     * ## Normalisation
+     *
+     * NIP-24: "`t`: a hashtag. The value MUST be a lowercase string." On top of the
+     * lowercasing, every value is trimmed and every run of characters that is neither a
+     * letter, a digit nor a combining mark collapses into a single `-`, with leading and
+     * trailing separators dropped. So `New York` is published as `new-york` and
+     * `St. Gallen` as `st-gallen`. A hyphen, not a bare join: it is the separator the
+     * issue's own `in-us` uses, and it keeps the two words legible.
+     *
+     * A part that normalises to the empty string contributes NO tag — that is what makes
+     * an incomplete address emit fewer tags instead of `['t', '']`. `<region>-<country>`
+     * needs both halves and disappears if either is missing; the bare codes do not.
+     *
+     * ## Non-ASCII names: both forms, on purpose
+     *
+     * `München`, `Łódź`, `Székesfehérvár`, `Plzeň` and `Rīga` are real inputs here, and a
+     * `t` tag is matched byte for byte — relays index the string, they do not fold it.
+     * Folding to ASCII only would drop the form a local actually types; keeping only the
+     * native form would drop everyone whose keyboard or search box does not produce it.
+     * Both are emitted, native first: `münchen` + `munchen`, `łódź` + `lodz`. Where the
+     * fold changes nothing (`berlin`) exactly one tag is emitted, and where two parts
+     * agree the duplicate is dropped.
+     *
+     * The fold is {@see Str::ascii()} with its DEFAULT language, deliberately not the
+     * request locale: `app.locale` is not a constant in this codebase — the sibling
+     * publisher rewrites it per country
+     * (`App\Console\Commands\Nostr\PublishUnpublishedItems::configureForCountry()`)
+     * and {@see City::getSlugOptions()} already documents 37 slugs shifting with it. A
+     * locale-dependent fold would emit `muenchen` in one run and `munchen` in the next
+     * for the same city. These events are replaceable and get re-published, so their tags
+     * must not depend on which record happened to go out before them.
+     *
+     * @return list<string>
+     */
+    private static function topicTags(?City $city): array
+    {
+        $regionCode = self::nonEmpty($city?->region?->code);
+        $countryCode = self::nonEmpty($city?->country?->code);
+
+        /*
+         * The `!== null` pair on the combined value is belt-and-braces, and measured as
+         * such: removing it leaves every test in `NostrCalendarTopicTagsTest` green,
+         * because a half-empty `"in-"` normalises to `in` and the dedupe below then drops
+         * it against the bare region code. It stays because the requirement is "both
+         * halves or nothing", and that must not rest on two unrelated rules downstream
+         * happening to cancel the mistake out.
+         */
+        $sources = [
+            $city?->name,
+            $city?->region?->name,
+            $regionCode !== null && $countryCode !== null ? "{$regionCode}-{$countryCode}" : null,
+            $regionCode,
+            $countryCode,
+        ];
+
+        $topics = self::STATIC_TOPICS;
+
+        foreach ($sources as $source) {
+            foreach (self::topicVariants($source) as $topic) {
+                $topics[] = $topic;
+            }
+        }
+
+        // Two parts can normalise to the same value — a city named after its region
+        // ("New York, New York"), or India's country code next to Indiana's region code.
+        // A repeated `t` tag is legal and pointless; first occurrence wins, which keeps
+        // the most-specific-first order intact.
+        return array_values(array_unique($topics));
+    }
+
+    /**
+     * The one or two forms a single address part contributes: the normalised value and,
+     * when it differs, its ASCII fold. Nothing in, nothing out.
+     *
+     * @return list<string>
+     */
+    private static function topicVariants(?string $value): array
+    {
+        $native = self::normaliseTopic((string) $value);
+
+        if ($native === '') {
+            return [];
+        }
+
+        $folded = self::normaliseTopic(Str::ascii((string) $value));
+
+        return $folded === '' || $folded === $native ? [$native] : [$native, $folded];
+    }
+
+    private static function normaliseTopic(string $value): string
+    {
+        /*
+         * `\p{M}` is in the keep set on purpose. Without it a DECOMPOSED "Mu" + U+0308
+         * would lose its combining diaeresis to the separator and read `mu-nchen` — the
+         * one input shape where a Unicode-aware regex silently produces nonsense.
+         *
+         * `?? ''` is not decoration either: preg_replace returns null on malformed UTF-8,
+         * and a null cast to string would emit `['t', '']`. No tag beats an empty one.
+         */
+        $separated = preg_replace('/[^\p{L}\p{N}\p{M}]+/u', '-', mb_strtolower(trim($value)));
+
+        return trim($separated ?? '', '-');
+    }
+
+    private static function nonEmpty(?string $value): ?string
+    {
+        $trimmed = trim((string) $value);
+
+        return $trimmed === '' ? null : $trimmed;
     }
 
     private static function geohashFor(mixed $lat, mixed $lon): ?string

--- a/app/Support/NostrCalendarEventFactory.php
+++ b/app/Support/NostrCalendarEventFactory.php
@@ -182,13 +182,20 @@ class NostrCalendarEventFactory
      * agree the duplicate is dropped.
      *
      * The fold is {@see Str::ascii()} with its DEFAULT language, deliberately not the
-     * request locale: `app.locale` is not a constant in this codebase — the sibling
-     * publisher rewrites it per country
-     * (`App\Console\Commands\Nostr\PublishUnpublishedItems::configureForCountry()`)
-     * and {@see City::getSlugOptions()} already documents 37 slugs shifting with it. A
-     * locale-dependent fold would emit `muenchen` in one run and `munchen` in the next
-     * for the same city. These events are replaceable and get re-published, so their tags
-     * must not depend on which record happened to go out before them.
+     * request locale, so that the tag is a property of the city rather than of whoever
+     * happened to trigger the publish. `Str::ascii($value, 'de')` returns `muenchen`
+     * where the default returns `munchen`; these events are replaceable and get
+     * re-published, so a tag that moves with the caller's language would split one city
+     * across two hashtags over time.
+     *
+     * A CORRECTION to what stood here first, because the reasoning was wrong even though
+     * the code is right: this docblock claimed `app.locale` is mutated under this path,
+     * citing PublishUnpublishedItems::configureForCountry(). That command is
+     * `nostr:publish` — a different scheduler entry, and therefore a different process,
+     * from the `nostr:publish-calendar` command that reaches this method. A config()
+     * mutation lives in one process's memory and cannot leak into a later independent
+     * run (there is no Octane here), so app()->getLocale() is in fact CONSTANT on this
+     * path. The decision stands on the paragraph above, not on that claim.
      *
      * @return list<string>
      */

--- a/tests/Feature/Console/NostrPublishCalendarTopicTagsTest.php
+++ b/tests/Feature/Console/NostrPublishCalendarTopicTagsTest.php
@@ -1,0 +1,105 @@
+<?php
+
+use App\Models\City;
+use App\Models\Country;
+use App\Models\Meetup;
+use App\Models\MeetupEvent;
+use App\Models\Region;
+use App\Support\NostrEventTransmitter;
+use swentel\nostr\Event\Event;
+
+/*
+ * Issue #69, end to end: what the relays actually receive.
+ *
+ * `NostrCalendarTopicTagsTest` pins the factory in isolation. This file asks the other
+ * half of the question — does the command that signs and transmits carry those tags
+ * out? — by mocking `NostrEventTransmitter::transmit` and reading the event that was
+ * handed to it, the technique issue #76 established in
+ * `NostrPublishUppercaseCountryCodeTest`.
+ */
+
+const TOPIC_TAG_TEST_KEY = '7c1d3e5f7a9b1c3d5e7f9a1b3c5d7e9f1a3b5c7d9e1f3a5b7c9d1e3f5a7b9c1d';
+
+/**
+ * A meetup in Indianapolis, Indiana, US — the address from the issue.
+ */
+function topicTagIndianapolisMeetup(array $attributes = []): Meetup
+{
+    $country = Country::factory()->create(['code' => 'us']);
+    $region = Region::factory()->indiana()->create(['country_id' => $country->id]);
+
+    $city = City::factory()->create([
+        'country_id' => $country->id,
+        'region_id' => $region->id,
+        'name' => 'Indianapolis',
+        'latitude' => 39.7684,
+        'longitude' => -86.1581,
+    ]);
+
+    return Meetup::factory()->create(array_merge([
+        'city_id' => $city->id,
+        'nostr_publishing_enabled' => true,
+    ], $attributes));
+}
+
+/**
+ * @return list<string>
+ */
+function topicTagValuesOf(?Event $event): array
+{
+    return array_map(static fn (array $tag): string => $tag[1], $event?->getTag('t') ?? []);
+}
+
+beforeEach(function () {
+    config([
+        'services.nostr.publisher_key' => TOPIC_TAG_TEST_KEY,
+        'services.nostr.relays' => ['wss://fake.relay.test'],
+    ]);
+});
+
+function topicTagCaptureTransmitted(&$captured): void
+{
+    test()->mock(NostrEventTransmitter::class, function ($mock) use (&$captured) {
+        $mock->shouldReceive('transmit')
+            ->once()
+            ->andReturnUsing(function (Event $event, array $relayUrls) use (&$captured) {
+                $captured = $event;
+
+                return true;
+            });
+    });
+}
+
+it('transmits the geography topics on a published calendar', function () {
+    $transmitted = null;
+    topicTagCaptureTransmitted($transmitted);
+
+    topicTagIndianapolisMeetup();
+
+    $this->artisan('nostr:publish-calendar', ['--model' => 'Meetup'])
+        ->assertExitCode(0);
+
+    expect($transmitted?->getKind())->toBe(31924)
+        ->and(topicTagValuesOf($transmitted))->toBe([
+            'bitcoin', 'meetup', 'indianapolis', 'indiana', 'in-us', 'in', 'us',
+        ]);
+});
+
+it('transmits the geography topics on a published time-based event', function () {
+    $transmitted = null;
+    topicTagCaptureTransmitted($transmitted);
+
+    $meetup = topicTagIndianapolisMeetup();
+    MeetupEvent::factory()->create([
+        'meetup_id' => $meetup->id,
+        'start' => now()->addWeek(),
+    ]);
+
+    $this->artisan('nostr:publish-calendar', ['--model' => 'MeetupEvent'])
+        ->assertExitCode(0);
+
+    expect($transmitted?->getKind())->toBe(31923)
+        ->and(topicTagValuesOf($transmitted))->toBe([
+            'bitcoin', 'meetup', 'indianapolis', 'indiana', 'in-us', 'in', 'us',
+        ]);
+});

--- a/tests/Feature/Support/NostrCalendarTopicTagsTest.php
+++ b/tests/Feature/Support/NostrCalendarTopicTagsTest.php
@@ -1,0 +1,228 @@
+<?php
+
+use App\Models\City;
+use App\Models\Country;
+use App\Models\Meetup;
+use App\Models\MeetupEvent;
+use App\Models\Region;
+use App\Support\GeoHash;
+use App\Support\NostrCalendarEventFactory;
+use swentel\nostr\Event\Event;
+
+/*
+ * Issue #69: published NIP-52 events carried a `g` geohash and nothing searchable.
+ * These tests pin the `t` topic tags derived from the meetup's address — the full
+ * set, every partial address, the normalisation, and the fact that the geohash is
+ * untouched.
+ *
+ * Helper names are prefixed `topic*` on purpose: Pest loads every test file into the
+ * same process, and `NostrCalendarEventFactoryTest.php` next door already owns the
+ * global names `testPubkey()` and `makeMeetupWithCity()`.
+ */
+
+function topicPubkey(): string
+{
+    return str_repeat('b2', 32);
+}
+
+/**
+ * The values of the `t` tags, in the order the factory emitted them.
+ *
+ * @return list<string>
+ */
+function topicValues(Event $event): array
+{
+    return array_map(static fn (array $tag): string => $tag[1], $event->getTag('t'));
+}
+
+/**
+ * A meetup in a city with the given address parts.
+ *
+ * `$region` is either null (city without a region, the shape of 300 of the 305 stored
+ * cities) or `['code' => …, 'name' => …]`.
+ *
+ * @param  array{code: string, name: string}|null  $region
+ */
+function topicMeetup(string $cityName, string $countryCode = 'us', ?array $region = null): Meetup
+{
+    $country = Country::factory()->create(['code' => $countryCode]);
+
+    $regionModel = $region === null ? null : Region::factory()->create([
+        'country_id' => $country->id,
+        'code' => $region['code'],
+        'name' => $region['name'],
+    ]);
+
+    $city = City::factory()->create([
+        'country_id' => $country->id,
+        'region_id' => $regionModel?->id,
+        'name' => $cityName,
+        'latitude' => 39.7684,
+        'longitude' => -86.1581,
+    ]);
+
+    return Meetup::factory()->create(['city_id' => $city->id]);
+}
+
+it('derives the full topic set from a complete address', function () {
+    $meetup = topicMeetup('Indianapolis', 'us', ['code' => 'in', 'name' => 'Indiana']);
+
+    $event = NostrCalendarEventFactory::forMeetup($meetup);
+
+    // The set from issue #69, in the order the reporter listed it: the two static
+    // topics first, then the geography from most to least specific.
+    expect(topicValues($event))->toBe([
+        'bitcoin', 'meetup', 'indianapolis', 'indiana', 'in-us', 'in', 'us',
+    ]);
+});
+
+it('carries the same topic tags on the time-based calendar event', function () {
+    $meetup = topicMeetup('Indianapolis', 'us', ['code' => 'in', 'name' => 'Indiana']);
+    $meetupEvent = MeetupEvent::factory()->create(['meetup_id' => $meetup->id]);
+
+    $event = NostrCalendarEventFactory::forMeetupEvent($meetupEvent, topicPubkey());
+
+    expect($event->getKind())->toBe(31923)
+        ->and(topicValues($event))->toBe([
+            'bitcoin', 'meetup', 'indianapolis', 'indiana', 'in-us', 'in', 'us',
+        ]);
+});
+
+it('lowercases stored codes that are held in upper case', function () {
+    // CountryFactory writes uppercase codes into every development and test database
+    // (issue #76), so this is the ordinary shape here, not a contrived one. NIP-24:
+    // "`t`: a hashtag. The value MUST be a lowercase string."
+    $meetup = topicMeetup('Indianapolis', 'US', ['code' => 'IN', 'name' => 'Indiana']);
+
+    $event = NostrCalendarEventFactory::forMeetup($meetup);
+
+    expect(topicValues($event))->toBe([
+        'bitcoin', 'meetup', 'indianapolis', 'indiana', 'in-us', 'in', 'us',
+    ]);
+});
+
+it('omits the region topics when the city has no region', function () {
+    $meetup = topicMeetup('Indianapolis', 'us');
+
+    $event = NostrCalendarEventFactory::forMeetup($meetup);
+
+    expect(topicValues($event))->toBe(['bitcoin', 'meetup', 'indianapolis', 'us']);
+});
+
+it('omits the code topics when the region carries no code', function () {
+    $meetup = topicMeetup('Indianapolis', 'us', ['code' => '', 'name' => 'Indiana']);
+
+    $event = NostrCalendarEventFactory::forMeetup($meetup);
+
+    // The region NAME still stands on its own; only `in-us` and `in` need the code.
+    expect(topicValues($event))->toBe(['bitcoin', 'meetup', 'indianapolis', 'indiana', 'us']);
+});
+
+it('omits the country topics when the city has no country', function () {
+    $meetup = topicMeetup('Indianapolis', 'us', ['code' => 'in', 'name' => 'Indiana']);
+
+    // `cities.country_id` is NOT NULL, so this state cannot be stored — but the factory
+    // reads the relation through `?->` and would emit `['t', '']` for a detached one.
+    // Detaching the loaded relation is the only way to exercise that guard.
+    $meetup->city->setRelation('country', null);
+    $meetup->setRelation('city', $meetup->city);
+
+    $event = NostrCalendarEventFactory::forMeetup($meetup);
+
+    // `in-us` needs both halves and falls away; the bare region code does not.
+    expect(topicValues($event))->toBe(['bitcoin', 'meetup', 'indianapolis', 'indiana', 'in']);
+});
+
+it('emits the static topics and the city alone when nothing else is known', function () {
+    $meetup = topicMeetup('Indianapolis', '');
+
+    $event = NostrCalendarEventFactory::forMeetup($meetup);
+
+    expect(topicValues($event))->toBe(['bitcoin', 'meetup', 'indianapolis']);
+});
+
+it('emits only the static topics when the meetup has no city at all', function () {
+    $meetup = topicMeetup('Indianapolis');
+    $meetup->setRelation('city', null);
+
+    $event = NostrCalendarEventFactory::forMeetup($meetup);
+
+    expect(topicValues($event))->toBe(['bitcoin', 'meetup']);
+});
+
+it('emits no empty topic for address parts that normalise to nothing', function () {
+    $meetup = topicMeetup('Indianapolis', '  ', ['code' => ' ', 'name' => '--']);
+
+    $event = NostrCalendarEventFactory::forMeetup($meetup);
+
+    expect(topicValues($event))->toBe(['bitcoin', 'meetup', 'indianapolis'])
+        ->and(topicValues($event))->not->toContain('');
+});
+
+it('hyphenates multi-word and punctuated names', function () {
+    $meetup = topicMeetup('St. Gallen', 'ch', ['code' => 'sg', 'name' => 'Sankt Gallen']);
+
+    $event = NostrCalendarEventFactory::forMeetup($meetup);
+
+    expect(topicValues($event))->toBe([
+        'bitcoin', 'meetup', 'st-gallen', 'sankt-gallen', 'sg-ch', 'sg', 'ch',
+    ]);
+});
+
+it('adds an ASCII fold next to a German name', function () {
+    $meetup = topicMeetup('München', 'de', ['code' => 'by', 'name' => 'Bayern']);
+
+    $event = NostrCalendarEventFactory::forMeetup($meetup);
+
+    expect(topicValues($event))->toBe([
+        'bitcoin', 'meetup', 'münchen', 'munchen', 'bayern', 'by-de', 'by', 'de',
+    ]);
+});
+
+it('adds an ASCII fold for Polish, Hungarian, Czech and Latvian names', function () {
+    $cases = [
+        ['Łódź', 'pl', ['łódź', 'lodz', 'pl']],
+        ['Székesfehérvár', 'hu', ['székesfehérvár', 'szekesfehervar', 'hu']],
+        ['Plzeň', 'cz', ['plzeň', 'plzen', 'cz']],
+        ['Rīga', 'lv', ['rīga', 'riga', 'lv']],
+    ];
+
+    foreach ($cases as [$cityName, $countryCode, $expected]) {
+        $event = NostrCalendarEventFactory::forMeetup(topicMeetup($cityName, $countryCode));
+
+        expect(topicValues($event))->toBe(array_merge(['bitcoin', 'meetup'], $expected));
+    }
+});
+
+it('keeps a combining mark instead of breaking the word at it', function () {
+    // A decomposed "München": "Mu" + U+0308 (combining diaeresis) + "nchen". Rare, but
+    // the one input shape where a Unicode-aware regex silently produces nonsense — with
+    // `\p{M}` missing from the keep set the mark becomes a separator and the tag reads
+    // `mu-nchen`. Note the native tag is NOT byte-identical to the precomposed `münchen`
+    // (that is what NFC would fix, and this codebase does not normalise). Precisely why
+    // the ASCII fold earns its place: `munchen` is the same string for both shapes.
+    $meetup = topicMeetup("Mu\u{0308}nchen", 'de');
+
+    $event = NostrCalendarEventFactory::forMeetup($meetup);
+
+    expect(topicValues($event))->toBe(['bitcoin', 'meetup', "mu\u{0308}nchen", 'munchen', 'de']);
+});
+
+it('emits each topic once when two address parts normalise to the same value', function () {
+    $meetup = topicMeetup('New York', 'us', ['code' => 'ny', 'name' => 'New York']);
+
+    $event = NostrCalendarEventFactory::forMeetup($meetup);
+
+    // City and region both yield `new-york`; a repeated `t` tag is legal but useless.
+    expect(topicValues($event))->toBe([
+        'bitcoin', 'meetup', 'new-york', 'ny-us', 'ny', 'us',
+    ]);
+});
+
+it('leaves the geohash tag untouched', function () {
+    $meetup = topicMeetup('Indianapolis', 'us', ['code' => 'in', 'name' => 'Indiana']);
+
+    $event = NostrCalendarEventFactory::forMeetup($meetup);
+
+    expect($event->getTag('g'))->toBe([['g', GeoHash::encode(39.7684, -86.1581, 5)]]);
+});


### PR DESCRIPTION
Closes #69.

Published NIP-52 events carried a geohash `g` tag and nothing else. A geohash is machine-precise and useless as a search term; `t` tags are what Nostr clients filter on, and the portal already knows city, region, region code and country code — so the tags are derived, not typed.

```
bitcoin, meetup, indianapolis, indiana, in-us, in, us
```

**Normalisation:** trim, `mb_strtolower`, then collapse every run of characters that is not a letter, digit or combining mark into a single `-`. Lowercase is not a preference — NIP-24: *"a hashtag. The value MUST be a lowercase string."*

**Non-ASCII emits both forms, native first:** `münchen` AND `munchen`. A `t` tag is matched byte for byte; relays index the string, they do not fold it. Folding only loses the form a local types, native only loses everyone whose keyboard cannot produce it. `Str::ascii()` runs with the default language so the tag is a property of the city, not of the caller.

`\p{M}` in the keep set is measured: a decomposed `Mu`+U+0308 yields `mu-nchen` without it.

Partial addresses emit what they can and no empty tags — `<region>-<country>` disappears as soon as either half is missing, the bare codes stay.

Ten mutation probes; nine redden between 1 and 16 tests. The tenth stayed green — the null check on the combined value is redundant, because `"in-"` normalises to `in` and deduplication then drops it. It is kept anyway, with the measurement recorded at the line: "both halves or neither" must not depend on two unrelated rules cancelling the mistake by accident.

Filed rather than fixed: already-published events are never re-sent, so these tags reach records published from now on (#92).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XfFQ18DFktM3ewnWo9Zt9X
