### PR TITLE
Let an unrecognised ?country= match nothing, and say so in the feed name

### DIFF
--- a/app/Http/Controllers/DownloadMeetupCalendar.php
+++ b/app/Http/Controllers/DownloadMeetupCalendar.php
@@ -17,6 +17,14 @@ use Spatie\IcalendarGenerator\Enums\EventStatus;
 class DownloadMeetupCalendar extends Controller
 {
     /**
+     * Longest requested country code X-WR-CALNAME will repeat back. Two octets
+     * for ISO 3166-1 alpha-2, three for alpha-3, five for a locale-shaped
+     * "de-DE" — eight leaves headroom for all of them while keeping an
+     * arbitrarily long query string out of the property.
+     */
+    private const UNKNOWN_COUNTRY_LABEL_LIMIT = 8;
+
+    /**
      * Handle the incoming request.
      */
     public function __invoke(Request $request): Response
@@ -89,17 +97,22 @@ class DownloadMeetupCalendar extends Controller
             $entries[] = $this->buildEntry($event, $timezone, $fallbackImageUrl, $fallbackImageMime, $language);
         }
 
-        $calendarName = $language !== null
-            ? (config("lang-country.languages.{$language}.calendar_name") ?? config('app.name'))
-            : config('app.name');
-
-        $calendar = Calendar::create($calendarName)
+        $calendar = Calendar::create($this->resolveCalendarName($language, $countryCode))
             ->event($entries);
 
         return response($calendar->get())
             ->header('Content-Type', 'text/calendar; charset=utf-8');
     }
 
+    /**
+     * The case-insensitive comparison in `matchingCode()` stays load-bearing
+     * after #77; only the direction in which it fails changed. While it was
+     * case-sensitive, `?country=de` against an uppercase stored `DE` missed,
+     * `resolveCountryCode()` returned null and NO filter was applied at all —
+     * the whole world instead of one country (measured then: 5 events instead
+     * of 2, fixed in #78). Today the same miss would deliver an empty feed
+     * instead. Still wrong, but reported instead of silent.
+     */
     private function scopeToCountry(Builder $query, string $countryCode): Builder
     {
         return $query->whereHas('meetup.city.country', fn ($query) => $query->matchingCode($countryCode));
@@ -107,35 +120,86 @@ class DownloadMeetupCalendar extends Controller
 
     /**
      * `country` only ever scopes the feed CONTENT (the "all events" vs. "this
-     * country only" button pair) — never the calendar name or timezone of the
-     * output, unlike `language`/`timezone` below. That is why an unknown or
-     * malformed value resolves to null (no filter) here instead of falling
-     * back to the domain's own country: unlike language/timezone, where a
-     * fallback only changes display, defaulting country to the domain would
-     * silently narrow an existing subscription's content on a typo'd or
-     * stale URL — the exact regression the "no `country` param" case is
-     * required to avoid. No filter is the behavior every URL had before this
-     * feature existed, so it is also the safe default for a value we can't
-     * make sense of.
+     * country only" button pair) — never the timezone of the output, unlike
+     * `language`/`timezone` below; it reaches the calendar NAME only to report
+     * itself back (see `resolveCalendarName()`).
+     *
+     * A value that matches no country has three possible answers, and two of
+     * them fail open. Both were considered; this is what #77 settled:
+     *
+     * - Fall back to the domain's own country — rejected. Unlike language and
+     *   timezone, where a fallback only changes display, defaulting country to
+     *   the domain would silently NARROW an existing subscription's content on
+     *   a typo'd or stale URL, answering it with some other country's
+     *   calendar. That is the regression the "no `country` param" case is
+     *   required to avoid.
+     * - Ignore the unusable parameter and return every country — this was the
+     *   behavior until #77, and it is rejected too. A `country=` that is
+     *   present states the intent to narrow, so returning the whole world
+     *   delivers MORE than was asked for. It is the same shape of fail-open
+     *   the casing bug had (#78): the gate misses, the filter is never set. A
+     *   calendar subscription is set up once and then never looked at again,
+     *   which is exactly why over-delivery goes unnoticed while an empty feed
+     *   is reported within a day. Of the two failure directions, the reported
+     *   one is the one to take.
+     * - Pass the requested code through and let it match nothing — chosen. The
+     *   subscriber gets what an unmatched filter means, no events, and
+     *   X-WR-CALNAME names the code that matched nothing, so the empty feed
+     *   reads as "this portal does not know 'zz'" rather than "this portal is
+     *   broken". That is the answer to the objection in favor of ignoring it:
+     *   hand-typed and pasted feed URLs are exactly why the code has to be
+     *   visible in the client, not why the parameter should be dropped.
+     *
+     * Recognition itself therefore no longer happens here — an unrecognized
+     * code is not filtered out, it is a filter that matches no row.
      */
     private function resolveCountryCode(Request $request): ?string
     {
         $requested = mb_strtolower(trim((string) $request->query('country', '')));
 
-        if ($requested === '') {
-            return null;
+        return $requested !== '' ? $requested : null;
+    }
+
+    /**
+     * X-WR-CALNAME is the only line a subscriber's client still shows once the
+     * feed is empty, so an unrecognized `country=` is named there:
+     * "EINUNDZWANZIG Portal (unknown country: zz)". Without it, "no events
+     * matched your country" and "the portal is broken" are the same file. A
+     * recognized code is NOT repeated back — an empty feed for a code this
+     * portal knows really does mean "nothing coming up there", and renaming
+     * every working subscription is not this issue's business.
+     *
+     * The requested value is user input reaching an output property, so it is
+     * sanitized before it gets there rather than relying on the generator's
+     * escaping (TextProperty escapes `\`, `"`, `,`, `;` and newlines — a
+     * second line of defense, not the first): everything outside [a-z0-9-] is
+     * dropped, which also removes any CR/LF that could split or extend the
+     * property line, and the remainder is capped at
+     * self::UNKNOWN_COUNTRY_LABEL_LIMIT so an arbitrarily long query string
+     * cannot inflate the header field. The pattern runs WITHOUT `/u` on
+     * purpose: on invalid UTF-8 a unicode pattern would return null instead of
+     * stripping, and since only ASCII survives, no partial multibyte sequence
+     * can. If nothing survives, the marker is emitted without a code.
+     */
+    private function resolveCalendarName(?string $language, ?string $countryCode): string
+    {
+        $name = $language !== null
+            ? (config("lang-country.languages.{$language}.calendar_name") ?? config('app.name'))
+            : config('app.name');
+
+        if ($countryCode === null || Country::query()->matchingCode($countryCode)->exists()) {
+            return $name;
         }
 
-        /*
-         * Dieser Vergleich ist das Tor, nicht scopeToCountry(): faellt er durch, wird
-         * `null` zurueckgegeben und der Filter unten gar nicht erst gesetzt. Er war
-         * case-sensitiv, waehrend `$requested` immer kleingeschrieben ankommt — mit
-         * gross gespeicherten Codes lieferte `?country=de` deshalb NICHT einen leeren
-         * Kalender, sondern den ganzen weltweiten Feed (gemessen: 5 statt 2 Termine).
-         * Von den beiden moeglichen Richtungen war das die falsche: ein Abo, das still
-         * mehr ausliefert als bestellt, faellt niemandem auf.
-         */
-        return Country::query()->matchingCode($requested)->exists() ? $requested : null;
+        $label = mb_substr(
+            (string) preg_replace('/[^a-z0-9-]/', '', $countryCode),
+            0,
+            self::UNKNOWN_COUNTRY_LABEL_LIMIT
+        );
+
+        return $label === ''
+            ? $name.' (unknown country)'
+            : $name.' (unknown country: '.$label.')';
     }
 
     /**

--- a/tests/Feature/DownloadMeetupCalendarTest.php
+++ b/tests/Feature/DownloadMeetupCalendarTest.php
@@ -281,7 +281,10 @@ it('falls back to the domain default instead of erroring on an unknown or malfor
         'start' => now()->addWeek()->setTime(19, 0),
     ]);
 
-    $response = test()->get('http://portal.einundzwanzig.space/stream-calendar?country=zz&language=xx&timezone=Not%2FARealZone');
+    // No `country` here on purpose: since #77 an unrecognized country is not a fallback
+    // case at all — it empties the feed and renames the calendar, which would drown out
+    // what this test is about. That case has its own two tests below.
+    $response = test()->get('http://portal.einundzwanzig.space/stream-calendar?language=xx&timezone=Not%2FARealZone');
 
     $response->assertSuccessful();
 
@@ -293,23 +296,104 @@ it('falls back to the domain default instead of erroring on an unknown or malfor
         ->toContain('DTSTART;TZID=Europe/Berlin:');
 });
 
-it('leaves the feed content unfiltered — not scoped to the domain default — for an unknown or malformed country value', function () {
+it('matches nothing — not every country — for an unknown or malformed country value', function () {
     $czechCountry = Country::factory()->create(['code' => 'cz']);
     $czechCity = City::factory()->create(['country_id' => $czechCountry->id]);
+    $austrianCountry = Country::factory()->create(['code' => 'at']);
+    $austrianCity = City::factory()->create(['country_id' => $austrianCountry->id]);
 
     $germanMeetup = Meetup::factory()->create(['city_id' => $this->city->id, 'name' => 'German Meetup']);
     $czechMeetup = Meetup::factory()->create(['city_id' => $czechCity->id, 'name' => 'Czech Meetup']);
-    MeetupEvent::factory()->create(['meetup_id' => $germanMeetup->id, 'title' => 'German Event', 'start' => now()->addWeek()]);
+    $austrianMeetup = Meetup::factory()->create(['city_id' => $austrianCity->id, 'name' => 'Austrian Meetup']);
+
+    // Two German events among five — the sample issue #77 measured the old behavior
+    // against (?country=zz -> 5, ?country=d -> 5, ?country=de -> 2).
+    MeetupEvent::factory()->count(2)->create(['meetup_id' => $germanMeetup->id, 'start' => now()->addWeek()]);
+    MeetupEvent::factory()->count(2)->create(['meetup_id' => $czechMeetup->id, 'start' => now()->addWeek()]);
+    MeetupEvent::factory()->create(['meetup_id' => $austrianMeetup->id, 'start' => now()->addWeek()]);
+
+    $countEvents = fn (string $query): int => substr_count(
+        unfoldIcs(test()->get('http://portal.einundzwanzig.space/stream-calendar'.$query)->getContent()),
+        'BEGIN:VEVENT'
+    );
+
+    /*
+     * The premise this file carried until #77 was that "an unrecognized value is the
+     * same as no country parameter at all", and that was the defect: a `country=` that
+     * is present states the intent to narrow, so answering it with the whole world
+     * delivers MORE than was asked for — and nobody re-reads a calendar subscription,
+     * so over-delivery is never reported. "zz" matches no Country row and "d" is a
+     * prefix of "de" that matches none either; both now match nothing.
+     *
+     * What has NOT changed is the other direction: an unrecognized value must still not
+     * fall back to the domain default. The domain serving this request
+     * (portal.einundzwanzig.space) defaults to "de" — a fallback would answer
+     * `?country=zz` with the two German events, i.e. silently serve a stale or typo'd
+     * URL some other country's calendar. Counting is the load-bearing assertion here:
+     * "0 vs. 2 vs. 5" is precisely the observable, and the unfiltered count guards that
+     * an empty feed really is the filter's doing and not an empty database.
+     */
+    expect([
+        'country=zz' => $countEvents('?country=zz'),
+        'country=d' => $countEvents('?country=d'),
+        'country=de' => $countEvents('?country=de'),
+        'no country' => $countEvents(''),
+    ])->toBe([
+        'country=zz' => 0,
+        'country=d' => 0,
+        'country=de' => 2,
+        'no country' => 5,
+    ]);
+});
+
+it('names the unrecognized country in X-WR-CALNAME so an empty feed is not mistaken for a broken portal', function () {
+    $czechCountry = Country::factory()->create(['code' => 'cz']);
+    $czechCity = City::factory()->create(['country_id' => $czechCountry->id]);
+    $czechMeetup = Meetup::factory()->create(['city_id' => $czechCity->id, 'name' => 'Czech Meetup']);
     MeetupEvent::factory()->create(['meetup_id' => $czechMeetup->id, 'title' => 'Czech Event', 'start' => now()->addWeek()]);
 
-    // "zz" matches no Country row. The domain serving this request (portal.einundzwanzig.space)
-    // defaults to "de" — if resolveCountryCode() fell back to that domain default instead of
-    // null, this would silently drop the Czech event, exactly like an explicit ?country=de
-    // would. It must not: an unrecognized value is not a request for "my own country", it is
-    // the same as no country parameter at all.
-    $ics = unfoldIcs(test()->get('http://portal.einundzwanzig.space/stream-calendar?country=zz')->getContent());
+    $unknown = unfoldIcs(test()->get('http://portal.einundzwanzig.space/stream-calendar?country=zz')->getContent());
+    $knownButEmpty = unfoldIcs(test()->get('http://portal.einundzwanzig.space/stream-calendar?country=de')->getContent());
 
-    expect($ics)->toContain('SUMMARY:German Event')->toContain('SUMMARY:Czech Event');
+    /*
+     * Both feeds are empty, and X-WR-CALNAME is the only line a subscriber's client
+     * shows for an empty calendar — so it has to carry the difference between "the
+     * portal did not know the code you typed" and "your country simply has no upcoming
+     * events". Without the marker the two are the same file, and either one reads like
+     * a broken portal.
+     */
+    expect(substr_count($unknown, 'BEGIN:VEVENT'))->toBe(0)
+        ->and(substr_count($knownButEmpty, 'BEGIN:VEVENT'))->toBe(0)
+        ->and($unknown)->toContain('X-WR-CALNAME:EINUNDZWANZIG Portal (unknown country: zz)')
+        ->and($knownButEmpty)->toContain('X-WR-CALNAME:EINUNDZWANZIG Portal')
+        ->and($knownButEmpty)->not->toContain('unknown country');
+});
+
+it('cannot be made to inject or inflate an iCalendar line through the country parameter', function () {
+    $injection = urlencode("zz\r\nSUMMARY:injected;,\\".str_repeat('x', 200));
+
+    $ics = test()->get('http://portal.einundzwanzig.space/stream-calendar?country='.$injection)->getContent();
+    $unfolded = unfoldIcs($ics);
+
+    /*
+     * `country` is user input that now reaches an output property, so it is stripped to
+     * [a-z0-9-] and capped before it gets there — the escaping of the iCalendar
+     * generator is a second line of defense, not the first. Asserting on the RAW ics as
+     * well is deliberate: unfolding would hide a CRLF the value smuggled in, which is
+     * exactly the injection this guards against.
+     */
+    expect($unfolded)->toContain('X-WR-CALNAME:EINUNDZWANZIG Portal (unknown country: zzsummar)')
+        ->and($unfolded)->not->toContain('SUMMARY:injected')
+        ->and(substr_count($ics, 'X-WR-CALNAME'))->toBe(1)
+        ->and(substr_count($ics, 'SUMMARY'))->toBe(0);
+
+    // Nothing survives the strip: the marker still has to say that a country was
+    // requested and not recognized, otherwise this value alone would look like a feed
+    // that was never scoped at all.
+    $stripped = unfoldIcs(test()->get('http://portal.einundzwanzig.space/stream-calendar?country='.urlencode('/// '))->getContent());
+
+    expect($stripped)->toContain('X-WR-CALNAME:EINUNDZWANZIG Portal (unknown country)')
+        ->and(substr_count($stripped, 'BEGIN:VEVENT'))->toBe(0);
 });
 
 it('keeps the UID stable across a rename, bumps SEQUENCE, and drops the event once it is cancelled (D-update/D-cancel)', function () {


### PR DESCRIPTION
Closes #77.

`resolveCountryCode()` returned `null` for a code that matched no country, and the caller then applied no filter at all. Measured on five events, two of them German: `?country=zz` → 5, `?country=d` → 5, `?country=de` → 2. A parameter that states the intent to narrow widened the result to everything.

Same fail-open shape as the casing bug in #78. A calendar subscription is set up once and never looked at again, which is why over-delivery goes unnoticed while an empty feed is reported within a day. Of the two failure directions, the reported one is the one to take.

After: `zz` → 0, `d` → 0, `de` → 2, no parameter → 5.

Both rejected alternatives are now argued in the docblock, not one.

`X-WR-CALNAME` reports the requested code back — `EINUNDZWANZIG Portal (unknown country: zz)` — so an empty feed can be told apart from a broken portal. A recognised code is not echoed; that would rename every working subscription.

The echoed value is user input on an iCalendar property line, so it is whitelisted rather than escaped: everything outside `[a-z0-9-]` stripped, capped at 8 characters. `preg_replace` runs without `/u` deliberately — with it, malformed UTF-8 returns `null` instead of stripping. Three mutation probes each redden the injection test.

The test that stated the old premise was rewritten, not deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XfFQ18DFktM3ewnWo9Zt9X
