### PR TITLE
Tell calendar subscribers when an event is cancelled

### DIFF
--- a/app/Http/Controllers/DownloadMeetupCalendar.php
+++ b/app/Http/Controllers/DownloadMeetupCalendar.php
@@ -14,6 +14,30 @@ use Spatie\IcalendarGenerator\Components\Event;
 use Spatie\IcalendarGenerator\Enums\Display;
 use Spatie\IcalendarGenerator\Enums\EventStatus;
 
+/**
+ * The subscribable .ics feed.
+ *
+ * No METHOD property is emitted, and METHOD:CANCEL in particular is NOT the
+ * mechanism for issue #56 — checked before adding it, because "cancel" appears
+ * in both mechanisms and they are not the same one:
+ *
+ * - METHOD is a property of the CALENDAR object and may appear exactly once in
+ *   it (RFC 5545 §3.7.2). This feed carries every upcoming event of a country in
+ *   one object, so a METHOD:CANCEL on it would declare the whole calendar
+ *   cancelled, not the single event that was called off. There is no per-VEVENT
+ *   METHOD to fall back to.
+ * - A calendar object that carries METHOD is an iTIP message (RFC 5546) — the
+ *   thing an organiser mails to named ATTENDEEs, transported once, per
+ *   recipient. A subscription URL polled by a client is the other case: a
+ *   calendar store, published as-is, whose current contents ARE the statement.
+ *   That is why the generator has no METHOD support at all (grepped: zero
+ *   references in spatie/icalendar-generator).
+ *
+ * STATUS:CANCELLED is the per-component mechanism and the correct one here: it
+ * says this one VEVENT is off, it travels in a PUBLISH-shaped feed without
+ * turning it into an iTIP message, and — unlike a disappearing entry — it
+ * reaches the client on its normal fetch.
+ */
 class DownloadMeetupCalendar extends Controller
 {
     /**
@@ -49,7 +73,7 @@ class DownloadMeetupCalendar extends Controller
                 ->findOrFail($validated['meetup']);
             $events = $meetup->meetupEvents()
                 ->with(['meetup', 'tags'])
-                ->where('start', '>=', now())
+                ->visibleInCalendarFeed()
                 ->when($countryCode, fn (Builder $query) => $this->scopeToCountry($query, $countryCode))
                 ->get();
             $fallbackImageUrl = $meetup->getFirstMediaUrl('logo') ?: null;
@@ -71,7 +95,7 @@ class DownloadMeetupCalendar extends Controller
                     'meetup',
                     'tags',
                 ])
-                ->where('start', '>=', now())
+                ->visibleInCalendarFeed()
                 ->whereHas('meetup', fn ($query) => $query->whereIn('meetups.id', $ids))
                 ->when($countryCode, fn (Builder $query) => $this->scopeToCountry($query, $countryCode))
                 ->get();
@@ -83,7 +107,7 @@ class DownloadMeetupCalendar extends Controller
                     'meetup',
                     'tags',
                 ])
-                ->where('start', '>=', now())
+                ->visibleInCalendarFeed()
                 ->when($countryCode, fn (Builder $query) => $this->scopeToCountry($query, $countryCode))
                 ->get();
             $fallbackImageUrl = asset('img/einundzwanzig-horizontal.png');
@@ -238,11 +262,10 @@ class DownloadMeetupCalendar extends Controller
             // vorher, wo der Meetup-Name Teil der UID war und ein abonnierter Client
             // nach jeder Umbenennung ein Duplikat statt eines Updates saehe.
             ->uniqueIdentifier('meetup-event-'.$event->id.'@einundzwanzig.space')
-            // Es gibt keine eigene Revisionsspalte; updated_at waechst bei jedem
-            // Speichern monoton, was fuer SEQUENCE (RFC 5545) genau die geforderte
-            // Eigenschaft ist — Clients vergleichen nur, ob der Wert gestiegen ist.
-            ->sequence($event->updated_at?->getTimestamp() ?? 0)
-            ->status(EventStatus::Confirmed)
+            ->sequence($this->resolveSequence($event))
+            // The one line issue #56 is about: until now every entry was hard-wired
+            // CONFIRMED, so a called-off event could only leave the feed silently.
+            ->status($event->isCancelled() ? EventStatus::Cancelled : EventStatus::Confirmed)
             ->startsAt($event->start->copy()->setTimezone($timezone));
 
         if ($event->end) {
@@ -274,6 +297,49 @@ class DownloadMeetupCalendar extends Controller
         }
 
         return $entry;
+    }
+
+    /**
+     * SEQUENCE (RFC 5545 §3.8.7.4) — the revision counter a client compares to
+     * decide whether an incoming VEVENT supersedes the copy it already holds.
+     *
+     * Where it comes from: `updated_at`. There is no revision column, and this
+     * needs none — `updated_at` grows monotonically with every save, which is the
+     * only property RFC 5545 demands (clients compare, they do not count), and it
+     * survives a redeploy for the reason that matters here: it is a value on the
+     * row, not process or cache state. A counter kept anywhere else would restart
+     * at zero on the first deploy after a cancellation and the cancelled entry
+     * would then look OLDER than the confirmed copy every subscriber holds. That
+     * part is unchanged by #56; it has been the source since #41.
+     *
+     * What #56 adds is the +1 on a cancelled event, and it is not decoration.
+     * `updated_at` has one-second resolution, so an organiser who saves a change
+     * and calls the event off inside the same second produces the identical
+     * number twice — and a subscriber who fetched in between would keep the
+     * CONFIRMED copy, which is precisely the failure this issue is about. The
+     * offset makes the bump unconditional instead of probable: a cancelled entry
+     * is always strictly above the confirmed entry generated from the same
+     * `updated_at`.
+     *
+     * DTSTAMP cannot cover that gap, which is the obvious objection to the
+     * offset. iTIP breaks an equal SEQUENCE by the later DTSTAMP, but the
+     * generator sets DTSTAMP from `new DateTimeImmutable()` at build time
+     * (Components\Event::__construct) — it is the moment this response was
+     * rendered, not the moment the event was revised, and it therefore differs on
+     * every fetch of an entry nobody touched. A field that changes when nothing
+     * changed cannot tell a client that something did.
+     *
+     * The cost of the offset, written down because it is invisible otherwise:
+     * there is no un-cancel today (the organiser UI offers cancel and delete, and
+     * nothing puts `cancelled_at` back to null). If one is ever added, un-cancelling
+     * inside the same second as the cancellation would produce an EQUAL sequence,
+     * not a higher one, and the client would ignore the reinstatement. Whoever
+     * adds it replaces this offset with a real revision column rather than
+     * widening it.
+     */
+    private function resolveSequence(MeetupEvent $event): int
+    {
+        return ($event->updated_at?->getTimestamp() ?? 0) + ($event->isCancelled() ? 1 : 0);
     }
 
     /**

--- a/app/Models/MeetupEvent.php
+++ b/app/Models/MeetupEvent.php
@@ -24,6 +24,21 @@ class MeetupEvent extends Model
     use NormalizesText;
     use SetsCreatedBy;
 
+    /**
+     * How long a cancelled event stays in the calendar feed, counted from its
+     * own start (issue #56).
+     *
+     * A cancellation has to outlive the moment it is entered: a subscriber's
+     * client only learns about it on its next fetch, and the interval between
+     * fetches is the client's business, not ours (Google, Apple and Outlook all
+     * differ). Keeping every cancellation forever is the other extreme — the
+     * feed would grow without limit and every subscriber would pay for it on
+     * every fetch. Thirty days after the start is the window the repo owner
+     * settled on: it covers even a client that syncs monthly, and once the date
+     * itself is a month past, an entry nobody attended has nothing left to say.
+     */
+    public const CANCELLED_FEED_WINDOW_DAYS = 30;
+
     /** @var list<string> */
     protected array $normalizedLabels = ['title', 'location'];
 
@@ -52,6 +67,9 @@ class MeetupEvent extends Model
         // End of THIS event — not to be confused with recurrence_end_date, which is
         // when a recurring series stops producing occurrences.
         'end' => 'datetime',
+        // When the organiser called this event off. Null means it is on. Not the
+        // same as deleting the row — see MeetupEvent::CANCELLED_FEED_WINDOW_DAYS.
+        'cancelled_at' => 'datetime',
         'recurrence_end_date' => 'datetime',
         /*
          * Dieser Eintrag stand bis P6 in einer Eigenschaft `$enumCasts` — die es in
@@ -89,6 +107,69 @@ class MeetupEvent extends Model
         $query->where(function (Builder $query) use ($userId) {
             $query->where('created_by', $userId)
                 ->orWhereHas('meetup', fn (Builder $meetup) => $meetup->ledBy($userId));
+        });
+    }
+
+    /**
+     * Was this event called off?
+     *
+     * Cancelling and deleting are two different operations from #56 on, and the
+     * organiser form offers both:
+     *
+     * - CANCEL — the event was announced and is not happening. The row stays, the
+     *   calendar feed reports STATUS:CANCELLED for it (see DownloadMeetupCalendar),
+     *   and after CANCELLED_FEED_WINDOW_DAYS it leaves the feed on its own.
+     * - DELETE — the event should never have been there: a duplicate, a typo, a
+     *   wrong meetup. The row goes, and with it every trace. A subscriber is told
+     *   nothing, which is acceptable for an entry that was a mistake and is
+     *   exactly what this operation has always done.
+     *
+     * A cancelled event stays VISIBLE on the website, unchanged. That is the
+     * smaller change and the one the organiser means: the visitor who has the
+     * date in their head looks the meetup up to check, and an entry that silently
+     * vanished from the page answers that question with the same silence the
+     * calendar feed used to. Making the site MARK the entry as cancelled is worth
+     * doing and is not in this issue — it needs the public event views, which #56
+     * does not touch.
+     */
+    public function isCancelled(): bool
+    {
+        return $this->cancelled_at !== null;
+    }
+
+    /**
+     * The events a calendar subscriber must see (issue #56).
+     *
+     * Two disjoint sets, not one date range: an event that is still on belongs in
+     * the feed while it is still ahead (unchanged — this is the `start >= now()`
+     * the feed has always used), and a cancelled one belongs in it until
+     * CANCELLED_FEED_WINDOW_DAYS after its start, because the client that already
+     * materialised the entry needs to be told about the cancellation, and only a
+     * VEVENT it still receives can tell it. A cancelled event whose start is
+     * already past therefore stays for a while, which is exactly the point; a
+     * non-cancelled one does not, which keeps the existing feed unchanged.
+     *
+     * Both halves are wrapped in one group explicitly, and the honest note about
+     * that: it is belt-and-braces, not the thing that holds. Eloquent's
+     * callScope() already wraps whatever wheres a scope adds
+     * (addNewWheresWithinGroup), so the `orWhere` cannot escape into the caller's
+     * WHERE and OR past the country filter — measured by deleting the wrapper,
+     * which left all eight #56 tests green. It stays because the guarantee then
+     * lives in the query builder rather than in this file: the day someone calls
+     * this body from something that is not a scope, the group is what keeps a
+     * one-country subscription from shipping the whole world (the fail-open shape
+     * #78 was about).
+     */
+    public function scopeVisibleInCalendarFeed(Builder $query): void
+    {
+        $query->where(function (Builder $query) {
+            $query
+                ->where(fn (Builder $query) => $query
+                    ->whereNull('cancelled_at')
+                    ->where('start', '>=', now()))
+                ->orWhere(fn (Builder $query) => $query
+                    ->whereNotNull('cancelled_at')
+                    ->where('start', '>=', now()->subDays(self::CANCELLED_FEED_WINDOW_DAYS)));
         });
     }
 

--- a/database/migrations/2026_09_05_003332_add_cancelled_at_to_meetup_events_table.php
+++ b/database/migrations/2026_09_05_003332_add_cancelled_at_to_meetup_events_table.php
@@ -1,0 +1,45 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Issue #56: a cancelled event has to keep existing, or the calendar feed can
+ * never say it was cancelled.
+ *
+ * Until now the organiser's only tool was deletion, and a deleted row cannot be
+ * reported to anybody — the entry just stopped appearing in the next fetch, and
+ * whether a subscriber's client removed it was up to that client. Cancellation
+ * becomes a state the feed can carry; deletion stays deletion.
+ *
+ * A nullable timestamp, not a boolean and not a status enum. Null is "not
+ * cancelled", and a non-null value answers "when", which is the question that
+ * always follows a cancellation. Same shape and same reasoning as `rejected_at`
+ * on webhook_subscriptions.
+ *
+ * Safe on a populated table: a NULLable column with no default writes nothing to
+ * any existing row, so there is no backfill and no lock held while one runs. It
+ * is deliberately appended at the END of the row instead of using ->after() like
+ * the neighbouring meetup_events migrations — on MySQL, adding a column in the
+ * last position is the case that has been ALGORITHM=INSTANT (metadata only, no
+ * table rebuild) the longest, while adding one in the middle only became instant
+ * in a later 8.0 release. Column order is cosmetic; rebuilding every row of a
+ * live table is not.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('meetup_events', function (Blueprint $table) {
+            $table->timestamp('cancelled_at')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('meetup_events', function (Blueprint $table) {
+            $table->dropColumn('cancelled_at');
+        });
+    }
+};

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -893,5 +893,9 @@
     "z.B. Hinterzimmer im Café Mustermann": "např. zadní místnost v Café Mustermann",
     "Freitext für Besucher. Auch Details, die ein Kartenpunkt nicht zeigt.": "Volný text pro návštěvníky. I detaily, které bod na mapě neukáže.",
     "Eine feste Bearbeitungszeit nennen wir nicht — wir könnten sie nicht zusagen. Wenn du nichts hörst, frag per Nostr-DM nach:": "Neslibujeme žádnou lhůtu na vyřízení — nedokázali bychom ji dodržet. Pokud se nikdo neozve, napiš nám přes Nostr DM:",
-    "Profil auf njump öffnen": "Otevřít profil na njump"
+    "Profil auf njump öffnen": "Otevřít profil na njump",
+    "Event absagen": "Zrušit událost",
+    "Abgesagt": "Zrušeno",
+    "Dieses Event wirklich absagen? Kalender-Abonnenten erhalten die Absage.": "Opravdu zrušit tuto událost? Odběratelé kalendáře dostanou informaci o zrušení.",
+    "Event abgesagt. Abonnenten des Kalenders werden informiert.": "Událost zrušena. Odběratelé kalendáře budou informováni."
 }

--- a/lang/de.json
+++ b/lang/de.json
@@ -893,5 +893,9 @@
     "z.B. Hinterzimmer im Café Mustermann": "",
     "Freitext für Besucher. Auch Details, die ein Kartenpunkt nicht zeigt.": "",
     "Eine feste Bearbeitungszeit nennen wir nicht — wir könnten sie nicht zusagen. Wenn du nichts hörst, frag per Nostr-DM nach:": "",
-    "Profil auf njump öffnen": ""
+    "Profil auf njump öffnen": "",
+    "Event absagen": "Event absagen",
+    "Abgesagt": "Abgesagt",
+    "Dieses Event wirklich absagen? Kalender-Abonnenten erhalten die Absage.": "Dieses Event wirklich absagen? Kalender-Abonnenten erhalten die Absage.",
+    "Event abgesagt. Abonnenten des Kalenders werden informiert.": "Event abgesagt. Abonnenten des Kalenders werden informiert."
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -893,5 +893,9 @@
     "z.B. Hinterzimmer im Café Mustermann": "e.g. back room at Cafe Mustermann",
     "Freitext für Besucher. Auch Details, die ein Kartenpunkt nicht zeigt.": "Free text for visitors. Also details a map pin cannot show.",
     "Eine feste Bearbeitungszeit nennen wir nicht — wir könnten sie nicht zusagen. Wenn du nichts hörst, frag per Nostr-DM nach:": "We do not promise a turnaround time — we could not keep one. If you hear nothing, ask by Nostr DM:",
-    "Profil auf njump öffnen": "Open profile on njump"
+    "Profil auf njump öffnen": "Open profile on njump",
+    "Event absagen": "Cancel event",
+    "Abgesagt": "Cancelled",
+    "Dieses Event wirklich absagen? Kalender-Abonnenten erhalten die Absage.": "Really cancel this event? Calendar subscribers will receive the cancellation.",
+    "Event abgesagt. Abonnenten des Kalenders werden informiert.": "Event cancelled. Calendar subscribers will be notified."
 }

--- a/lang/es.json
+++ b/lang/es.json
@@ -893,5 +893,9 @@
     "z.B. Hinterzimmer im Café Mustermann": "p. ej. sala trasera del Café Mustermann",
     "Freitext für Besucher. Auch Details, die ein Kartenpunkt nicht zeigt.": "Texto libre para los visitantes. También detalles que un punto en el mapa no muestra.",
     "Eine feste Bearbeitungszeit nennen wir nicht — wir könnten sie nicht zusagen. Wenn du nichts hörst, frag per Nostr-DM nach:": "No prometemos un plazo de respuesta: no podríamos cumplirlo. Si no recibes noticias, escríbenos por DM en Nostr:",
-    "Profil auf njump öffnen": "Abrir el perfil en njump"
+    "Profil auf njump öffnen": "Abrir el perfil en njump",
+    "Event absagen": "Cancelar evento",
+    "Abgesagt": "Cancelado",
+    "Dieses Event wirklich absagen? Kalender-Abonnenten erhalten die Absage.": "¿Cancelar de verdad este evento? Los suscriptores del calendario recibirán la cancelación.",
+    "Event abgesagt. Abonnenten des Kalenders werden informiert.": "Evento cancelado. Se informará a los suscriptores del calendario."
 }

--- a/lang/hu.json
+++ b/lang/hu.json
@@ -893,5 +893,9 @@
     "z.B. Hinterzimmer im Café Mustermann": "pl. hátsó terem a Café Mustermannban",
     "Freitext für Besucher. Auch Details, die ein Kartenpunkt nicht zeigt.": "Szabad szöveg a látogatóknak. Olyan részletek is, amelyeket a térképpont nem mutat.",
     "Eine feste Bearbeitungszeit nennen wir nicht — wir könnten sie nicht zusagen. Wenn du nichts hörst, frag per Nostr-DM nach:": "Nem ígérünk átfutási időt — nem tudnánk betartani. Ha nem kapsz választ, írj nekünk Nostr DM-ben:",
-    "Profil auf njump öffnen": "Profil megnyitása a njumpon"
+    "Profil auf njump öffnen": "Profil megnyitása a njumpon",
+    "Event absagen": "Esemény lemondása",
+    "Abgesagt": "Lemondva",
+    "Dieses Event wirklich absagen? Kalender-Abonnenten erhalten die Absage.": "Biztosan lemondod ezt az eseményt? A naptárra feliratkozók megkapják a lemondást.",
+    "Event abgesagt. Abonnenten des Kalenders werden informiert.": "Esemény lemondva. A naptár feliratkozói értesítést kapnak."
 }

--- a/lang/lv.json
+++ b/lang/lv.json
@@ -893,5 +893,9 @@
     "z.B. Hinterzimmer im Café Mustermann": "piem., aizmugurējā telpa Café Mustermann",
     "Freitext für Besucher. Auch Details, die ein Kartenpunkt nicht zeigt.": "Brīvs teksts apmeklētājiem. Arī detaļas, ko kartes punkts neparāda.",
     "Eine feste Bearbeitungszeit nennen wir nicht — wir könnten sie nicht zusagen. Wenn du nichts hörst, frag per Nostr-DM nach:": "Mēs nesolām apstrādes termiņu — mēs to nevarētu ievērot. Ja atbildes nav, raksti mums Nostr ziņā:",
-    "Profil auf njump öffnen": "Atvērt profilu vietnē njump"
+    "Profil auf njump öffnen": "Atvērt profilu vietnē njump",
+    "Event absagen": "Atcelt pasākumu",
+    "Abgesagt": "Atcelts",
+    "Dieses Event wirklich absagen? Kalender-Abonnenten erhalten die Absage.": "Tiešām atcelt šo pasākumu? Kalendāra abonenti saņems atcelšanas paziņojumu.",
+    "Event abgesagt. Abonnenten des Kalenders werden informiert.": "Pasākums atcelts. Kalendāra abonenti tiks informēti."
 }

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -893,5 +893,9 @@
     "z.B. Hinterzimmer im Café Mustermann": "bijv. achterzaal in Café Mustermann",
     "Freitext für Besucher. Auch Details, die ein Kartenpunkt nicht zeigt.": "Vrije tekst voor bezoekers. Ook details die een kaartpunt niet toont.",
     "Eine feste Bearbeitungszeit nennen wir nicht — wir könnten sie nicht zusagen. Wenn du nichts hörst, frag per Nostr-DM nach:": "We beloven geen doorlooptijd — die zouden we niet kunnen waarmaken. Hoor je niets, stuur ons dan een Nostr-DM:",
-    "Profil auf njump öffnen": "Profiel openen op njump"
+    "Profil auf njump öffnen": "Profiel openen op njump",
+    "Event absagen": "Evenement annuleren",
+    "Abgesagt": "Geannuleerd",
+    "Dieses Event wirklich absagen? Kalender-Abonnenten erhalten die Absage.": "Dit evenement echt annuleren? Agenda-abonnees ontvangen de annulering.",
+    "Event abgesagt. Abonnenten des Kalenders werden informiert.": "Evenement geannuleerd. Abonnees van de agenda worden geïnformeerd."
 }

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -893,5 +893,9 @@
     "z.B. Hinterzimmer im Café Mustermann": "np. zaplecze w Café Mustermann",
     "Freitext für Besucher. Auch Details, die ein Kartenpunkt nicht zeigt.": "Wolny tekst dla odwiedzających. Także szczegóły, których nie pokaże punkt na mapie.",
     "Eine feste Bearbeitungszeit nennen wir nicht — wir könnten sie nicht zusagen. Wenn du nichts hörst, frag per Nostr-DM nach:": "Nie obiecujemy czasu rozpatrzenia — nie moglibyśmy go dotrzymać. Jeśli nie dostaniesz odpowiedzi, napisz do nas przez DM na Nostr:",
-    "Profil auf njump öffnen": "Otwórz profil na njump"
+    "Profil auf njump öffnen": "Otwórz profil na njump",
+    "Event absagen": "Odwołaj wydarzenie",
+    "Abgesagt": "Odwołane",
+    "Dieses Event wirklich absagen? Kalender-Abonnenten erhalten die Absage.": "Na pewno odwołać to wydarzenie? Subskrybenci kalendarza otrzymają informację o odwołaniu.",
+    "Event abgesagt. Abonnenten des Kalenders werden informiert.": "Wydarzenie odwołane. Subskrybenci kalendarza zostaną poinformowani."
 }

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -893,5 +893,9 @@
     "z.B. Hinterzimmer im Café Mustermann": "p. ex. sala dos fundos no Café Mustermann",
     "Freitext für Besucher. Auch Details, die ein Kartenpunkt nicht zeigt.": "Texto livre para os visitantes. Também detalhes que um ponto no mapa não mostra.",
     "Eine feste Bearbeitungszeit nennen wir nicht — wir könnten sie nicht zusagen. Wenn du nichts hörst, frag per Nostr-DM nach:": "Não prometemos um prazo de resposta: não conseguiríamos cumpri-lo. Se não tiveres notícias, escreve-nos por DM no Nostr:",
-    "Profil auf njump öffnen": "Abrir perfil no njump"
+    "Profil auf njump öffnen": "Abrir perfil no njump",
+    "Event absagen": "Cancelar evento",
+    "Abgesagt": "Cancelado",
+    "Dieses Event wirklich absagen? Kalender-Abonnenten erhalten die Absage.": "Cancelar mesmo este evento? Os subscritores do calendário recebem o cancelamento.",
+    "Event abgesagt. Abonnenten des Kalenders werden informiert.": "Evento cancelado. Os subscritores do calendário serão notificados."
 }

--- a/resources/views/livewire/meetups/create-edit-events.blade.php
+++ b/resources/views/livewire/meetups/create-edit-events.blade.php
@@ -522,6 +522,37 @@ class extends Component
                 navigate: true);
         }
     }
+
+    /**
+     * Call the event off without removing it (issue #56).
+     *
+     * The difference to delete() is who gets told. A deleted event stops appearing
+     * in the calendar feed and nothing announces that, so a subscriber whose client
+     * already materialised the date keeps it — the feed has no way to say "gone".
+     * A cancelled event stays in the feed as STATUS:CANCELLED until
+     * MeetupEvent::CANCELLED_FEED_WINDOW_DAYS after its start, which is what
+     * actually reaches the people who were going to turn up.
+     *
+     * Deletion is therefore for an event that should not exist (duplicate, typo,
+     * wrong meetup); cancellation is for one that existed and is not happening.
+     *
+     * Stays on the form instead of redirecting like delete() does: the event is
+     * still there and still editable, and the organiser's next move is usually to
+     * write into the description WHY it was called off.
+     */
+    public function cancel(): void
+    {
+        $this->authorizeManage();
+
+        if ($this->event && ! $this->event->isCancelled()) {
+            // update(), not a direct assignment plus save(): it is the touch of
+            // `updated_at` that raises SEQUENCE in the feed, which is what makes a
+            // client accept the cancellation over the CONFIRMED copy it holds.
+            $this->event->update(['cancelled_at' => now()]);
+
+            session()->flash('status', __('Event abgesagt. Abonnenten des Kalenders werden informiert.'));
+        }
+    }
 }; ?>
 
 <div class="max-w-4xl mx-auto p-6">
@@ -817,6 +848,21 @@ class extends Component
                 </flux:button>
 
                 @if($event)
+                    {{-- Cancelling and deleting are offered side by side because they are
+                         different answers (issue #56): cancelling keeps the event and tells
+                         calendar subscribers it is off, deleting removes it and tells them
+                         nothing. Only deleting is styled `danger` — the loud variant belongs
+                         to the irreversible one, and two red buttons next to each other would
+                         say the choice does not matter. --}}
+                    @if($event->isCancelled())
+                        <flux:badge color="amber">{{ __('Abgesagt') }}</flux:badge>
+                    @else
+                        <flux:button type="button" wire:click="cancel"
+                                     wire:confirm="{{ __('Dieses Event wirklich absagen? Kalender-Abonnenten erhalten die Absage.') }}">
+                            {{ __('Event absagen') }}
+                        </flux:button>
+                    @endif
+
                     <flux:button variant="danger" type="button" wire:click="delete"
                                  wire:confirm="{{ __('Bist du sicher, dass du dieses Event löschen möchtest?') }}">
                         {{ __('Event löschen') }}

--- a/tests/Feature/DownloadMeetupCalendarCancellationTest.php
+++ b/tests/Feature/DownloadMeetupCalendarCancellationTest.php
@@ -1,0 +1,295 @@
+<?php
+
+use App\Models\City;
+use App\Models\Country;
+use App\Models\Meetup;
+use App\Models\MeetupEvent;
+use Livewire\Livewire;
+
+/*
+|--------------------------------------------------------------------------
+| Issue #56 — a cancelled event is REPORTED, not silently dropped
+|--------------------------------------------------------------------------
+|
+| The behaviour this file guards is a before/after pair on the SAME UID, and
+| that is the whole point: a subscriber's client has already materialised the
+| entry, so an entry that merely stops being delivered tells it nothing. Only a
+| VEVENT it still receives, carrying STATUS:CANCELLED and a higher SEQUENCE, can.
+|
+| Lives beside DownloadMeetupCalendarTest.php rather than inside it: that file is
+| the feed's own suite and defines the shared unfoldIcs()/escapeIcsText() helpers
+| at global scope, which cannot be redeclared here.
+|
+*/
+
+/**
+ * RFC 5545 §3.1 folds any line past 75 octets with "\r\n "; assertions read
+ * logical values, so folded lines are joined back first. Same helper as in
+ * DownloadMeetupCalendarTest, under a name that does not collide with it.
+ */
+function unfoldCancellationIcs(string $ics): string
+{
+    return preg_replace("/\r\n[ \t]/", '', $ics);
+}
+
+/**
+ * The VEVENT block carrying $uid, or null. Assertions have to be made against
+ * ONE component: "the feed contains STATUS:CANCELLED somewhere" would pass even
+ * if the cancellation landed on a different event.
+ */
+function veventFor(string $ics, string $uid): ?string
+{
+    foreach (collect(explode('BEGIN:VEVENT', $ics))->skip(1) as $block) {
+        if (str_contains($block, 'UID:'.$uid)) {
+            return $block;
+        }
+    }
+
+    return null;
+}
+
+beforeEach(function () {
+    $country = Country::factory()->create(['code' => 'de']);
+    $this->city = City::factory()->create(['country_id' => $country->id]);
+    $this->meetup = Meetup::factory()->create(['city_id' => $this->city->id, 'name' => 'Bitcoin Meetup Erfurt']);
+});
+
+/*
+ * DoD 4 — the one the issue is actually about. Two fetches of the same feed, the
+ * same UID in both, CONFIRMED before and CANCELLED after, with SEQUENCE strictly
+ * higher so a client accepts the second as a revision of the first instead of
+ * ignoring it as a stale duplicate.
+ */
+it('re-delivers a previously delivered UID as STATUS:CANCELLED instead of dropping it', function () {
+    $event = MeetupEvent::factory()->create([
+        'meetup_id' => $this->meetup->id,
+        'title' => 'Stammtisch',
+        'start' => now()->addWeek()->setTime(19, 0),
+    ]);
+
+    $before = unfoldCancellationIcs(test()->get('http://portal.einundzwanzig.space/stream-calendar')->getContent());
+    $uid = 'meetup-event-'.$event->id.'@einundzwanzig.space';
+
+    $entryBefore = veventFor($before, $uid);
+    expect($entryBefore)->not->toBeNull()
+        ->and($entryBefore)->toContain('STATUS:CONFIRMED');
+
+    preg_match('/SEQUENCE:(?<sequence>\d+)/', $entryBefore, $sequenceBefore);
+
+    $this->travelTo(now()->addMinute());
+    $event->update(['cancelled_at' => now()]);
+
+    $after = unfoldCancellationIcs(test()->get('http://portal.einundzwanzig.space/stream-calendar')->getContent());
+
+    $entryAfter = veventFor($after, $uid);
+    expect($entryAfter)->not->toBeNull()
+        ->and($entryAfter)->toContain('STATUS:CANCELLED')
+        ->and($entryAfter)->not->toContain('STATUS:CONFIRMED');
+
+    preg_match('/SEQUENCE:(?<sequence>\d+)/', $entryAfter, $sequenceAfter);
+
+    expect((int) $sequenceAfter['sequence'])->toBeGreaterThan((int) $sequenceBefore['sequence']);
+
+    $this->travelBack();
+});
+
+/*
+ * The bump must not depend on the clock ticking over. `updated_at` has
+ * one-second resolution, so an organiser who saves and then cancels inside the
+ * same second would otherwise emit the identical SEQUENCE twice — and a client
+ * that fetched in between keeps its CONFIRMED copy. Same second here on purpose:
+ * no travelTo().
+ */
+it('bumps SEQUENCE even when the cancellation lands in the same second as the previous save', function () {
+    $event = MeetupEvent::factory()->create([
+        'meetup_id' => $this->meetup->id,
+        'start' => now()->addWeek(),
+    ]);
+
+    $uid = 'meetup-event-'.$event->id.'@einundzwanzig.space';
+    $before = unfoldCancellationIcs(test()->get('http://portal.einundzwanzig.space/stream-calendar')->getContent());
+    preg_match('/SEQUENCE:(?<sequence>\d+)/', veventFor($before, $uid), $sequenceBefore);
+
+    // Not travelling: cancelled_at is written while updated_at still holds the
+    // very second the factory wrote.
+    $event->update(['cancelled_at' => now()]);
+    $event->refresh();
+
+    $after = unfoldCancellationIcs(test()->get('http://portal.einundzwanzig.space/stream-calendar')->getContent());
+    preg_match('/SEQUENCE:(?<sequence>\d+)/', veventFor($after, $uid), $sequenceAfter);
+
+    expect($event->updated_at->getTimestamp())->toBe((int) $sequenceBefore['sequence'])
+        ->and((int) $sequenceAfter['sequence'])->toBeGreaterThan((int) $sequenceBefore['sequence']);
+});
+
+/*
+ * DoD 5 — the window is bounded, or the feed grows without limit. Anchored on
+ * the event's own start, so both edges are asserted against the same event.
+ */
+it('keeps a cancelled event in the feed inside the 30-day window and drops it afterwards', function () {
+    $start = now()->addDay()->setTime(19, 0);
+    $event = MeetupEvent::factory()->create([
+        'meetup_id' => $this->meetup->id,
+        'start' => $start,
+    ]);
+    $event->update(['cancelled_at' => now()]);
+
+    $uid = 'meetup-event-'.$event->id.'@einundzwanzig.space';
+
+    // The edges below are hard-coded days, NOT MeetupEvent::CANCELLED_FEED_WINDOW_DAYS.
+    // Measured: with the constant on both sides, widening it from 30 to 3000 left this
+    // test green — it would then assert that the code honours whatever window it
+    // declares, which is not the decision #56 took. The length is the decision, so it
+    // is pinned here and a change to it has to edit this file too.
+    expect(MeetupEvent::CANCELLED_FEED_WINDOW_DAYS)->toBe(30);
+
+    // A day after the event was supposed to happen: past, cancelled, still delivered.
+    $this->travelTo($start->copy()->addDay());
+    $inside = unfoldCancellationIcs(test()->get('http://portal.einundzwanzig.space/stream-calendar')->getContent());
+    expect(veventFor($inside, $uid))->not->toBeNull()
+        ->and(veventFor($inside, $uid))->toContain('STATUS:CANCELLED');
+
+    // Last hours of the window.
+    $this->travelTo($start->copy()->addDays(30)->subHour());
+    $edge = unfoldCancellationIcs(test()->get('http://portal.einundzwanzig.space/stream-calendar')->getContent());
+    expect(veventFor($edge, $uid))->not->toBeNull();
+
+    // One hour past it: gone for good.
+    $this->travelTo($start->copy()->addDays(30)->addHour());
+    $outside = unfoldCancellationIcs(test()->get('http://portal.einundzwanzig.space/stream-calendar')->getContent());
+    expect(veventFor($outside, $uid))->toBeNull()
+        ->and(substr_count($outside, 'BEGIN:VEVENT'))->toBe(0);
+
+    $this->travelBack();
+});
+
+/*
+ * DoD 6, first half. The window is for CANCELLED events only. The scope adds an
+ * OR branch to a query that previously had one condition, and the cheapest way
+ * to get that wrong is a branch that also lets ordinary past events back in —
+ * which would put every meetup's history into every subscription.
+ */
+it('does not let the cancellation window drag ordinary past events back into the feed', function () {
+    $past = MeetupEvent::factory()->create([
+        'meetup_id' => $this->meetup->id,
+        'title' => 'Letzte Woche',
+        'start' => now()->subWeek(),
+    ]);
+    $upcoming = MeetupEvent::factory()->create([
+        'meetup_id' => $this->meetup->id,
+        'title' => 'Nächste Woche',
+        'start' => now()->addWeek(),
+    ]);
+
+    $ics = unfoldCancellationIcs(test()->get('http://portal.einundzwanzig.space/stream-calendar')->getContent());
+
+    expect(substr_count($ics, 'BEGIN:VEVENT'))->toBe(1)
+        ->and(veventFor($ics, 'meetup-event-'.$past->id.'@einundzwanzig.space'))->toBeNull()
+        ->and(veventFor($ics, 'meetup-event-'.$upcoming->id.'@einundzwanzig.space'))->not->toBeNull()
+        ->and($ics)->toContain('STATUS:CONFIRMED')
+        ->and($ics)->not->toContain('STATUS:CANCELLED');
+});
+
+/*
+ * DoD 6, second half. The scope's OR must stay inside its own group. An `orWhere`
+ * that escapes into the caller's WHERE would OR straight past the country filter
+ * and ship every country's events to a subscription that asked for one — the
+ * fail-open shape #78 was about, and the reason the count is the assertion.
+ */
+it('still scopes the feed to the requested country when a cancelled event is in the window', function () {
+    $czechCountry = Country::factory()->create(['code' => 'cz']);
+    $czechCity = City::factory()->create(['country_id' => $czechCountry->id]);
+    $czechMeetup = Meetup::factory()->create(['city_id' => $czechCity->id, 'name' => 'Czech Meetup']);
+
+    $german = MeetupEvent::factory()->create([
+        'meetup_id' => $this->meetup->id,
+        'title' => 'German Event',
+        'start' => now()->addWeek(),
+    ]);
+    $czechCancelled = MeetupEvent::factory()->create([
+        'meetup_id' => $czechMeetup->id,
+        'title' => 'Czech Event',
+        'start' => now()->addWeek(),
+    ]);
+    $czechCancelled->update(['cancelled_at' => now()]);
+
+    $ics = unfoldCancellationIcs(test()->get('http://portal.einundzwanzig.space/stream-calendar?country=de')->getContent());
+
+    expect(substr_count($ics, 'BEGIN:VEVENT'))->toBe(1)
+        ->and(veventFor($ics, 'meetup-event-'.$german->id.'@einundzwanzig.space'))->not->toBeNull()
+        ->and(veventFor($ics, 'meetup-event-'.$czechCancelled->id.'@einundzwanzig.space'))->toBeNull();
+});
+
+/*
+ * DoD 2 — the organiser reaches cancellation where they reach deletion, and the
+ * two do different things to the row.
+ */
+it('lets an organiser cancel an event without removing it', function () {
+    $meetup = Meetup::factory()->create(['city_id' => $this->city->id, 'created_by' => actingAsUser()->id]);
+    $event = MeetupEvent::factory()->create([
+        'meetup_id' => $meetup->id,
+        'start' => now()->addWeek(),
+    ]);
+
+    Livewire::test('meetups.create-edit-events', ['meetup' => $meetup, 'event' => $event])
+        ->call('cancel')
+        ->assertOk();
+
+    expect(MeetupEvent::query()->find($event->id))->not->toBeNull()
+        ->and(MeetupEvent::query()->find($event->id)->isCancelled())->toBeTrue();
+});
+
+it('leaves deletion as deletion — the row is gone and the feed says nothing', function () {
+    $meetup = Meetup::factory()->create(['city_id' => $this->city->id, 'created_by' => actingAsUser()->id]);
+    $event = MeetupEvent::factory()->create([
+        'meetup_id' => $meetup->id,
+        'start' => now()->addWeek(),
+    ]);
+
+    Livewire::test('meetups.create-edit-events', ['meetup' => $meetup, 'event' => $event])
+        ->call('delete');
+
+    $ics = unfoldCancellationIcs(test()->get('http://portal.einundzwanzig.space/stream-calendar')->getContent());
+
+    expect(MeetupEvent::query()->find($event->id))->toBeNull()
+        ->and(veventFor($ics, 'meetup-event-'.$event->id.'@einundzwanzig.space'))->toBeNull();
+});
+
+it('refuses to open the event editor for someone who may not manage the meetup', function () {
+    actingAsUser();
+    $meetup = Meetup::factory()->create(['city_id' => $this->city->id]);
+    $event = MeetupEvent::factory()->create([
+        'meetup_id' => $meetup->id,
+        'start' => now()->addWeek(),
+    ]);
+
+    Livewire::test('meetups.create-edit-events', ['meetup' => $meetup, 'event' => $event])
+        ->assertStatus(403);
+
+    expect(MeetupEvent::query()->find($event->id)->isCancelled())->toBeFalse();
+});
+
+/*
+ * The gate above only proves mount() refuses — it never reaches cancel(). This is
+ * the case that does: the component was mounted by someone entitled to it, and by
+ * the time the button is pressed they are not any more (leader removed, meetup
+ * handed over). save() re-authorizes for exactly this reason, so cancel() has to
+ * as well; a Livewire action is a request of its own, not a continuation of the
+ * one that rendered the page.
+ */
+it('refuses to cancel when the caller lost the right to manage after mounting', function () {
+    $organiser = actingAsUser();
+    $meetup = Meetup::factory()->create(['city_id' => $this->city->id, 'created_by' => $organiser->id]);
+    $event = MeetupEvent::factory()->create([
+        'meetup_id' => $meetup->id,
+        'start' => now()->addWeek(),
+    ]);
+
+    $component = Livewire::test('meetups.create-edit-events', ['meetup' => $meetup, 'event' => $event]);
+
+    actingAsUser();
+
+    $component->call('cancel')->assertStatus(403);
+
+    expect(MeetupEvent::query()->find($event->id)->isCancelled())->toBeFalse();
+});


### PR DESCRIPTION
Closes #56.

The feed hard-wired `EventStatus::Confirmed` on every entry, so a deleted event simply stopped appearing — and the existing test asserted that disappearance, so it was deliberate as built. A client that has already materialised the event has no reason to remove it.

**Window: 30 days** after the event's start, then the entry leaves for good. `MeetupEvent::CANCELLED_FEED_WINDOW_DAYS` holds the number, `scopeVisibleInCalendarFeed()` the rule; three hand-written `where('start','>=',now())` call sites now go through it.

**Deleted and cancelled are two different things now.** `cancelled_at` is a state subscribers hear about; `delete()` is unchanged and still removes the row silently, which is right for a duplicate or a typo.

**`SEQUENCE` bumps — and the issue's premise was stale.** It already came from `updated_at` (added with #41). That source stays, because it is a value *on the row*: a counter kept elsewhere restarts at zero on the first deploy after a cancellation, and the cancelled entry would then look older than the CONFIRMED copy subscribers hold. New is `+1` while cancelled, because `updated_at` has one-second resolution and a save-then-cancel inside one second would otherwise emit the same number twice.

**No `METHOD:CANCEL`.** `METHOD` is a property of the calendar object and may appear once in it (RFC 5545 §3.7.2); this feed carries a whole country in one object, so it would declare the entire calendar cancelled. A calendar carrying `METHOD` is also an iTIP message (RFC 5546), not a polled subscription.

Eight mutation probes. The eighth — widening the window 30 → 3000 days — stayed **green**, because the window test derived its own edges from the constant and so only asserted that the code honours whatever window it declares. Fixed with literal edges plus a pin; re-probed, it fails.

Full non-browser suite: **1966 passed (7229 assertions)**.

Filed rather than fixed: #96 (`delete()` skips the authorization check `save()` and `cancel()` make) and #97 (no un-cancel, and subscribers were already told).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XfFQ18DFktM3ewnWo9Zt9X
