### PR TITLE
Make the copy-to-clipboard control operable by keyboard

### DIFF
--- a/resources/js/app.js
+++ b/resources/js/app.js
@@ -1,4 +1,5 @@
 import nostrLogin from "./nostrLogin.js";
+import registerCopyToClipboard from "./copyToClipboard.js";
 
 import L from 'leaflet';
 import 'leaflet/dist/leaflet.css';
@@ -6,3 +7,4 @@ import 'leaflet/dist/leaflet.css';
 window.L = L;
 
 Alpine.data('nostrLogin', nostrLogin);
+registerCopyToClipboard(Alpine);

--- a/resources/js/copyToClipboard.js
+++ b/resources/js/copyToClipboard.js
@@ -1,0 +1,73 @@
+/*
+ * `x-copy-to-clipboard="<expression>"` — copy the evaluated expression and confirm
+ * with a Flux toast.
+ *
+ * Issue #80: this used to exist as three literal copies, one in each of the app and
+ * auth layouts, and every one of them bound `click` only. The elements that carry the
+ * directive are marked `role="button" tabindex="0"` (see
+ * `resources/views/components/nostr-calendar-address.blade.php`), so the keyboard can
+ * focus them — WCAG 2.1.1 then requires the keyboard to operate them too. Focus landed
+ * there and Enter and Space did nothing.
+ *
+ * One definition, in one file, handling `click`, Enter and Space for every layout.
+ */
+
+/**
+ * The two keys the WAI-ARIA button pattern requires. `Spacebar` is the legacy
+ * `KeyboardEvent.key` value some engines still emit for the space bar.
+ */
+const ACTIVATION_KEYS = ['Enter', ' ', 'Spacebar'];
+
+/**
+ * Controls the browser already activates from the keyboard on its own: a real
+ * `<button>` turns both Enter and Space into a `click`. Adding our own `keydown`
+ * handler there would copy twice and raise two toasts — `webhooks.blade.php` uses the
+ * directive on exactly such a `<button>`.
+ *
+ * @param {Element} el
+ * @return {boolean}
+ */
+const activatesItself = (el) => el.matches('button, input, select, textarea, a[href]');
+
+/**
+ * Registers the directive on the given Alpine instance.
+ *
+ * @param {object} Alpine
+ */
+export default function registerCopyToClipboard(Alpine) {
+    Alpine.directive('copy-to-clipboard', (el, {expression}, {evaluate}) => {
+        const copy = () => {
+            // Read lazily: the messages are written by `partials/clipboard-toast-messages`,
+            // which is a classic script in the body while this module is deferred. The
+            // fallbacks are the untranslated source strings, so a layout that forgets the
+            // partial still copies — it only loses the translation.
+            const messages = window.clipboardToastMessages ?? {};
+
+            navigator.clipboard.writeText(evaluate(expression)).then(() => {
+                Flux.toast({
+                    heading: messages.heading ?? 'Success!',
+                    text: messages.text ?? 'Copied into clipboard',
+                    variant: 'success',
+                    duration: 3000,
+                });
+            }).catch((err) => console.error(err));
+        };
+
+        el.addEventListener('click', copy);
+
+        if (activatesItself(el)) {
+            return;
+        }
+
+        el.addEventListener('keydown', (event) => {
+            if (!ACTIVATION_KEYS.includes(event.key)) {
+                return;
+            }
+
+            // Space scrolls the page down by default. On a control that is not a real
+            // button nothing cancels that, so the page would jump while copying.
+            event.preventDefault();
+            copy();
+        });
+    });
+}

--- a/resources/views/components/layouts/app/header.blade.php
+++ b/resources/views/components/layouts/app/header.blade.php
@@ -136,24 +136,8 @@
     if (!localStorage.getItem('flux.appearance')) {
         localStorage.setItem('flux.appearance', 'dark');
     }
-    document.addEventListener('alpine:init', () => {
-        Alpine.directive('copy-to-clipboard', (el, {expression}, {evaluate}) => {
-            el.addEventListener('click', () => {
-                const text = evaluate(expression);
-                console.log(text);
-
-                navigator.clipboard.writeText(text).then(() => {
-                    Flux.toast({
-                        heading: '{{ __('Success!') }}',
-                        text: '{{ __('Copied into clipboard') }}',
-                        variant: 'success',
-                        duration: 3000
-                    });
-                }).catch(err => console.error(err));
-            });
-        });
-    });
 </script>
+@include('partials.clipboard-toast-messages')
 <script>
     window.wnjParams = {
         position: 'bottom',

--- a/resources/views/components/layouts/app/sidebar.blade.php
+++ b/resources/views/components/layouts/app/sidebar.blade.php
@@ -350,24 +350,8 @@
     if (!localStorage.getItem('flux.appearance')) {
         localStorage.setItem('flux.appearance', 'dark');
     }
-    document.addEventListener('alpine:init', () => {
-        Alpine.directive('copy-to-clipboard', (el, {expression}, {evaluate}) => {
-            el.addEventListener('click', () => {
-                const text = evaluate(expression);
-                console.log(text);
-
-                navigator.clipboard.writeText(text).then(() => {
-                    Flux.toast({
-                        heading: '{{ __('Success!') }}',
-                        text: '{{ __('Copied into clipboard') }}',
-                        variant: 'success',
-                        duration: 3000
-                    });
-                }).catch(err => console.error(err));
-            });
-        });
-    });
 </script>
+@include('partials.clipboard-toast-messages')
 <script>
     window.wnjParams = {
         position: 'bottom',

--- a/resources/views/components/layouts/auth/simple.blade.php
+++ b/resources/views/components/layouts/auth/simple.blade.php
@@ -13,24 +13,8 @@
     if (!localStorage.getItem('flux.appearance')) {
         localStorage.setItem('flux.appearance', 'dark');
     }
-    document.addEventListener('alpine:init', () => {
-        Alpine.directive('copy-to-clipboard', (el, {expression}, {evaluate}) => {
-            el.addEventListener('click', () => {
-                const text = evaluate(expression);
-                console.log(text);
-
-                navigator.clipboard.writeText(text).then(() => {
-                    Flux.toast({
-                        heading: '{{ __('Success!') }}',
-                        text: '{{ __('Copied into clipboard') }}',
-                        variant: 'success',
-                        duration: 3000
-                    });
-                }).catch(err => console.error(err));
-            });
-        });
-    });
 </script>
+@include('partials.clipboard-toast-messages')
 <script>
     window.wnjParams = {
         position: 'bottom',

--- a/resources/views/livewire/settings/webhooks.blade.php
+++ b/resources/views/livewire/settings/webhooks.blade.php
@@ -278,9 +278,12 @@ class extends Component
                     {{-- The address is the control: clicking the npub copies the npub,
                          so there is no separate copy button and no icon to explain.
                          A real <button> rather than the <code role="button"> used by
-                         x-nostr-calendar-address — that Alpine directive binds `click`
-                         only, so on a non-button element Enter and Space do nothing
-                         (WCAG 2.1.1). A button gets both for free.
+                         x-nostr-calendar-address. When this was written, that Alpine
+                         directive bound `click` only, so on a non-button element Enter
+                         and Space did nothing (WCAG 2.1.1). #80 has since given the
+                         directive keyboard handling, so that is no longer the reason —
+                         a button still gets focus, role and keyboard semantics for free
+                         rather than by declaration, which is why this one stays a button.
 
                          `break-all` because an npub is 63 characters with no break
                          opportunity. Measured 2026-09-04: unwrapped it is 555px wide,

--- a/resources/views/partials/clipboard-toast-messages.blade.php
+++ b/resources/views/partials/clipboard-toast-messages.blade.php
@@ -1,0 +1,19 @@
+{{--
+    Toast copy for the shared clipboard directive in `resources/js/copyToClipboard.js`.
+
+    The directive is JavaScript and therefore cannot call `__()`. Handing the two
+    translated strings over on `window` from this one partial is what lets the directive
+    itself live in a single file: the layouts that used to carry a full copy of it
+    (issue #80) now carry neither the behaviour nor the strings.
+
+    Included AFTER `@fluxScripts`, alongside the other bottom-of-body scripts, so the
+    layouts keep their existing script order. The directive reads the object when a copy
+    actually happens, not at registration time, so this classic script and the deferred
+    module can load in either order.
+--}}
+<script>
+    window.clipboardToastMessages = {
+        heading: @js(__('Success!')),
+        text: @js(__('Copied into clipboard')),
+    };
+</script>

--- a/tests/Browser/CopyToClipboardKeyboardTest.php
+++ b/tests/Browser/CopyToClipboardKeyboardTest.php
@@ -1,0 +1,205 @@
+<?php
+
+use App\Models\City;
+use App\Models\Country;
+use App\Models\Meetup;
+use App\Support\NostrCalendarAddress;
+use Pest\Browser\Api\PendingAwaitablePage;
+
+/*
+|--------------------------------------------------------------------------
+| #80 — the clipboard directive has to answer the keyboard
+|--------------------------------------------------------------------------
+|
+| The directive used to bind `click` only, in three literal copies. The
+| elements carrying it are marked `role="button" tabindex="0"`, so focus lands
+| on them and then nothing happens — WCAG 2.1.1. The existing coverage clicks,
+| which is exactly why it survived, so every assertion below drives the control
+| with a key press and never with `click()`.
+|
+| Two shapes are covered because they take different paths through the
+| directive:
+|
+|   <code role="button" tabindex="0">   no native activation — the directive's
+|                                       own keydown handler must copy
+|   <button> (flux:button)              the browser turns Enter/Space into a
+|                                       click itself, so the directive must NOT
+|                                       handle keydown as well, or one key
+|                                       press copies twice
+|
+| They also sit on the two layouts a route can actually reach:
+| components.layouts.app.sidebar (meetup landing page) and
+| components.layouts.auth.simple (/ki-assistent). The third former copy,
+| components.layouts.app.header, has no route in this application — the last
+| test guards it by source instead.
+|
+| The pubkey is a throwaway, used only to build a syntactically valid
+| coordinate (the same one as tests/Feature/Meetups/NostrCalendarAddressDisplayTest).
+*/
+
+const KEYBOARD_PUBKEY = '45df061ee03c855bdd2c3ecea528d5725e3331e465cd38f14bfe403422952a03';
+
+/**
+ * Replaces the clipboard sink and records what the directive hands it.
+ *
+ * The real clipboard needs a permission grant this headless run does not have, and
+ * asserting on the system clipboard would test the browser rather than the directive.
+ * What is under test is whether a key press reaches the handler at all.
+ */
+function withRecordingClipboard(PendingAwaitablePage $page): PendingAwaitablePage
+{
+    $page->script(<<<'JS'
+        (() => {
+            window.__clipboardWrites = [];
+            window.__lastKeydownDefaultPrevented = {};
+
+            Object.defineProperty(navigator, 'clipboard', {
+                configurable: true,
+                value: {
+                    writeText: (text) => {
+                        window.__clipboardWrites.push(text);
+
+                        return Promise.resolve();
+                    },
+                },
+            });
+
+            // Bubble phase, so this runs after the element's own handler and reports
+            // whether the directive cancelled the browser default (Space scrolls).
+            document.addEventListener('keydown', (event) => {
+                window.__lastKeydownDefaultPrevented[event.key] = event.defaultPrevented;
+            });
+        })()
+    JS);
+
+    return $page;
+}
+
+/**
+ * A published meetup, so <x-nostr-calendar-address> renders its copyable address.
+ */
+function meetupWithNostrAddress(): Meetup
+{
+    $country = Country::factory()->create(['code' => 'de']);
+    $city = City::factory()->create(['country_id' => $country->id]);
+
+    return Meetup::factory()->create([
+        'city_id' => $city->id,
+        'visible_on_map' => true,
+        'nostr_publishing_enabled' => true,
+        'nostr_coordinate' => '31924:'.KEYBOARD_PUBKEY.':meetup-80',
+    ]);
+}
+
+it('copies with Enter on the role=button address', function () {
+    $meetup = meetupWithNostrAddress();
+    $expected = NostrCalendarAddress::fromCoordinate($meetup->nostr_coordinate)->naddr();
+
+    $page = withRecordingClipboard(visit("/de/meetup/{$meetup->slug}"));
+
+    $page->assertVisible('[data-testid="nostr-calendar-address"] code')
+        ->keys('[data-testid="nostr-calendar-address"] code', 'Enter');
+
+    expect($page->script('window.__clipboardWrites'))->toBe([$expected]);
+
+    $page->assertNoJavaScriptErrors();
+});
+
+it('copies with Space on the role=button address without scrolling the page', function () {
+    $meetup = meetupWithNostrAddress();
+    $expected = NostrCalendarAddress::fromCoordinate($meetup->nostr_coordinate)->naddr();
+
+    $page = withRecordingClipboard(visit("/de/meetup/{$meetup->slug}"));
+
+    $page->assertVisible('[data-testid="nostr-calendar-address"] code')
+        ->keys('[data-testid="nostr-calendar-address"] code', 'Space');
+
+    expect($page->script('window.__clipboardWrites'))->toBe([$expected]);
+
+    // Space scrolls by default. Without preventDefault() the page jumps a viewport
+    // while copying, which is why the directive cancels it.
+    expect($page->script("window.__lastKeydownDefaultPrevented[' ']"))->toBeTrue();
+    expect($page->script('window.scrollY'))->toBe(0);
+
+    $page->assertNoJavaScriptErrors();
+});
+
+it('copies exactly once per key press on a real button and leaves its native activation alone', function (string $key, string $eventKey) {
+    $page = withRecordingClipboard(visit('/ki-assistent'));
+
+    $page->assertVisible('button[x-copy-to-clipboard]')
+        ->keys('button[x-copy-to-clipboard]', $key);
+
+    $writes = $page->script('window.__clipboardWrites');
+
+    expect($writes)->toHaveCount(1)
+        ->and($writes[0])->toEndWith('/mcp');
+
+    /*
+     * A native <button> already turns Enter and Space into a click on its own, so the
+     * directive skips its keydown handler here. That the browser default survived
+     * untouched is what proves the skip happened: the handler's first act is
+     * preventDefault(), so without the guard this would read true — and the copy above
+     * would then be the handler's, not the button's.
+     */
+    expect($page->script(sprintf('window.__lastKeydownDefaultPrevented[%s]', json_encode($eventKey))))
+        ->toBeFalse();
+
+    $page->assertNoJavaScriptErrors();
+})->with([
+    // [key sent to Playwright, resulting KeyboardEvent.key]
+    ['Enter', 'Enter'],
+    ['Space', ' '],
+]);
+
+it('hands the translated toast copy to the directive on the sidebar layout', function () {
+    $meetup = meetupWithNostrAddress();
+
+    $page = visit("/de/meetup/{$meetup->slug}");
+
+    // The strings used to be inlined per layout; they now come from one partial. If a
+    // layout loses the include, the toast silently falls back to English.
+    expect($page->script('typeof window.clipboardToastMessages'))->toBe('object')
+        ->and($page->script('typeof window.clipboardToastMessages.heading'))->toBe('string')
+        ->and($page->script('typeof window.clipboardToastMessages.text'))->toBe('string');
+});
+
+it('hands the translated toast copy to the directive on the auth layout', function () {
+    $page = visit('/ki-assistent');
+
+    expect($page->script('typeof window.clipboardToastMessages'))->toBe('object')
+        ->and($page->script('typeof window.clipboardToastMessages.heading'))->toBe('string')
+        ->and($page->script('typeof window.clipboardToastMessages.text'))->toBe('string');
+});
+
+it('keeps the directive in one place and every layout wired to it', function () {
+    /*
+     * components.layouts.app.header has no route in this application, so no browser
+     * test can reach it — and it was one of the three copies. A source guard is the
+     * only thing that stops the next edit from re-inlining a fourth copy that then
+     * drifts, which is the failure mode the issue describes.
+     */
+    $layouts = [
+        base_path('resources/views/components/layouts/app/sidebar.blade.php'),
+        base_path('resources/views/components/layouts/app/header.blade.php'),
+        base_path('resources/views/components/layouts/auth/simple.blade.php'),
+    ];
+
+    foreach ($layouts as $layout) {
+        $contents = file_get_contents($layout);
+
+        // str_contains() rather than expect()->not->toContain(): that matcher is
+        // variadic, so a second argument becomes another needle instead of a message
+        // and the negated assertion passes on the message alone.
+        expect(str_contains($contents, "Alpine.directive('copy-to-clipboard'"))
+            ->toBeFalse($layout.' inlines its own copy of the clipboard directive again.');
+
+        expect(str_contains($contents, "@include('partials.clipboard-toast-messages')"))
+            ->toBeTrue($layout.' no longer includes the clipboard toast copy.');
+    }
+
+    expect(str_contains(
+        file_get_contents(base_path('resources/js/copyToClipboard.js')),
+        "Alpine.directive('copy-to-clipboard'",
+    ))->toBeTrue('The shared clipboard directive is gone from resources/js/copyToClipboard.js.');
+});


### PR DESCRIPTION
Closes #80.

`x-copy-to-clipboard` rendered `<code role="button" tabindex="0">` — which tells assistive technology and the keyboard that this is an operable control — and then bound `click` only. Focus landed there and Enter and Space did nothing, with no way for the user to know why. WCAG 2.1.1, and worse than an unfocusable element.

It existed as three literal copies, none pointing at the other two.

There is now one definition, `resources/js/copyToClipboard.js`, registered from `app.js`. It handles click and keydown (Enter, Space, legacy `Spacebar`), calls `preventDefault()` on the keyboard path so Space does not scroll, and guards against double delivery on elements that are already native controls.

The copies carried two translated toast strings and a `.js` file has no `__()`, so those live once in a partial the three layouts `@include`. `@js()` replaces the previous raw interpolation, under which a translation containing an apostrophe would have broken the script.

`CopyToClipboardKeyboardTest` drives the control with `keys()` only, never `click()`. Four mutation probes — the fourth, removing the native-control guard, was **green** at first because `preventDefault()` already suppresses the native click. The assertion now also requires that the directive does not cancel the browser default on a native button, and the probe is red.

Not measured: `components/layouts/app/header.blade.php` has no route in this application, so it is covered by the source guard rather than by a loaded page.

Filed rather than fixed: #86, `lang/de.json` carries empty values for both toast strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XfFQ18DFktM3ewnWo9Zt9X
