### PR TITLE
Keep the event page's right column inside itself

### DIFF
--- a/resources/views/livewire/meetups/landingpage-event.blade.php
+++ b/resources/views/livewire/meetups/landingpage-event.blade.php
@@ -395,11 +395,57 @@ class extends Component {
         </div>
 
         <div class="md:w-1/3">
-            <div class="flex flex-col sm:flex-row items-center space-x-0 sm:space-x-4 space-y-4 sm:space-y-0 mb-8">
-                <flux:avatar class="[:where(&)]:size-32 [:where(&)]:text-base" size="xl"
+            {{-- Issue #66: this header used to overflow its own column silently.
+                 Measured at a 1280px viewport before the fix: the column ended at
+                 x=1232 while its contents ran to x=1290.95 — 58.95px past the column,
+                 10.95px past the viewport, with `documentElement.scrollWidth` still
+                 at 1280, so no scrollbar ever appeared and the name, the city line
+                 and the "Kalender abonnieren" button were cut off.
+
+                 Cause, measured: the text block's min-content width was 213.61px,
+                 dictated by the calendar-stream trigger, which carries Flux' default
+                 `whitespace-nowrap` (button/index.blade.php:65). Beside the 128px
+                 avatar plus a 16px gap that demands 357.61px of column; the column
+                 measured 298.66px at 1280. A flex item cannot shrink below its
+                 min-content, so the surplus left the column instead.
+
+                 Three changes, all of them making the content shrinkable. The column
+                 keeps its `md:w-1/3` and nothing here widens anything:
+
+                 - The trigger overrides `!whitespace-normal` + `!h-auto` + `min-h-11`
+                   let the label wrap instead of forcing one line, which drops the
+                   text block's min-content from 213.61px to 138px. Measured height
+                   stays 44px at every width, wrapped or not, so the touch target
+                   holds (WCAG 2.5.8 / Apple HIG). This is verbatim the pattern the
+                   picker already uses on its own copy buttons.
+                 - `flex-wrap` plus `sm:basis-56 sm:grow` decide WHERE the row breaks
+                   instead of leaving it to the name's max-content: the text block
+                   asks for 224px, so avatar + gap + text need 368px of column. Above
+                   that the two stay side by side, below it the text block moves under
+                   the avatar. Measured: side by side at 1920 (column 490.67px) and
+                   1536 (373.33px) — the two widths the issue reports as sound, so
+                   they are left exactly as they were — wrapped at 1440 (341.33px),
+                   1280 (288px), 1024 (202.67px) and 768 (218.67px), where the row
+                   did not fit. Below `sm` the container is `flex-col` anyway.
+                 - `wrap-anywhere` on the name: a one-word meetup name is one word,
+                   and `overflow-wrap: anywhere` is the only value that lowers the
+                   min-content width (`break-words` does not). Measured with the name
+                   "Bitcoinmeetupfrankfurtammainundumgebung": without it the header
+                   runs 262.95px past the column at 1280 and 266.61px at 375 — the
+                   mobile width the original defect spared — with it, 0 at both.
+
+                 `space-x-*`/`space-y-*` become `gap-4`: identical 16px spacing, but
+                 `space-*` sets margins per sibling and leaves a wrapped row without
+                 vertical spacing.
+
+                 Pinned by tests/Browser/Meetups/EventHeaderFitsColumnTest.php, whose
+                 negative control strips these utilities back off the live DOM and
+                 reproduces the reported 58.95px to the pixel. --}}
+            <div class="flex flex-col sm:flex-row flex-wrap items-center gap-4 mb-8">
+                <flux:avatar class="[:where(&)]:size-32 [:where(&)]:text-base shrink-0" size="xl"
                              src="{{ $event->meetup->getFirstMediaUrl('logo') }}"/>
-                <div class="space-y-2">
-                    <flux:heading size="xl" class="mb-4">{{ $event->meetup->name }}</flux:heading>
+                <div class="space-y-2 sm:basis-56 sm:grow [&_[data-testid$='-trigger']]:!whitespace-normal [&_[data-testid$='-trigger']]:!h-auto [&_[data-testid$='-trigger']]:min-h-11 [&_[data-testid$='-trigger']]:w-full [&_[data-testid$='-trigger']]:text-left">
+                    <flux:heading size="xl" class="mb-4 wrap-anywhere">{{ $event->meetup->name }}</flux:heading>
                     <flux:subheading class="text-gray-600 dark:text-gray-400">
                         {{ $event->meetup->city->name }}, {{ $event->meetup->city->country->name }}
                     </flux:subheading>

--- a/tests/Browser/Meetups/EventHeaderFitsColumnTest.php
+++ b/tests/Browser/Meetups/EventHeaderFitsColumnTest.php
@@ -1,0 +1,250 @@
+<?php
+
+use App\Models\City;
+use App\Models\Country;
+use App\Models\Meetup;
+use App\Models\MeetupEvent;
+
+/*
+ * Issue #66: the right-hand column (`md:w-1/3`) of the event page was narrower
+ * than its own contents. Measured at a 1280px viewport before the fix: the
+ * column ended at x=1232, its contents ran to x=1290.95 — 58.95px past the
+ * column and 10.95px past the viewport — while `documentElement.scrollWidth`
+ * stayed at 1280. No scrollbar, so the meetup name, the city line and the
+ * "Kalender abonnieren" button were silently cut off. Content loss, not a
+ * tight fit, which is why a CSS-class assertion cannot stand in for this test:
+ * only real geometry catches it.
+ */
+beforeEach(function () {
+    $this->country = Country::factory()->create(['code' => 'de', 'name' => 'Deutschland']);
+    $this->city = City::factory()->create([
+        'country_id' => $this->country->id,
+        'name' => 'Frankfurt am Main',
+    ]);
+    // The long meetup name and the mapped venue are the load case, not
+    // decoration: the name drives the header's max-content width, and the
+    // venue map is the other block sharing the column.
+    $this->meetup = Meetup::factory()->create([
+        'city_id' => $this->city->id,
+        'name' => 'Bitcoin Meetup Frankfurt am Main 21',
+        'slug' => 'issue-66-frankfurt',
+        'visible_on_map' => true,
+    ]);
+    $this->event = MeetupEvent::factory()->create([
+        'meetup_id' => $this->meetup->id,
+        'location' => 'Hauptbahnhof 1, 60329 Frankfurt am Main',
+        'osm_name' => 'Frankfurt Hauptbahnhof',
+        'osm_lat' => 50.107,
+        'osm_lon' => 8.6636,
+    ]);
+
+    $this->eventUrl = route('meetups.landingpage-event', [
+        'country' => 'de',
+        'meetup' => $this->meetup->slug,
+        'event' => $this->event->id,
+    ], absolute: false);
+
+    /*
+     * Clipped geometry, deliberately: Leaflet lays its tile images out beyond
+     * the map pane and hides the surplus with `overflow: hidden`. Their raw
+     * rects sit up to 326px past the column (measured at 1280) and would fail
+     * every assertion here on invisible boxes. So each rect is clipped against
+     * every ancestor whose `overflow-x` is not `visible` before it is compared
+     * — the same thing the eye does. The column itself is never a clipper here
+     * (it has no overflow of its own), which the negative control below
+     * verifies by making the probe report the defect again.
+     */
+    $this->probe = <<<'JS'
+        (() => {
+          const col = Array.from(document.querySelectorAll('div')).find(
+            (d) => typeof d.className === 'string' && d.className.split(/\s+/).includes('md:w-1/3')
+          );
+          if (! col) { return {error: 'right column not found'}; }
+          const c = col.getBoundingClientRect();
+          const clippedRight = (el) => {
+            let right = el.getBoundingClientRect().right;
+            let p = el.parentElement;
+            while (p && p !== col.parentElement) {
+              if (getComputedStyle(p).overflowX !== 'visible') {
+                right = Math.min(right, p.getBoundingClientRect().right);
+              }
+              p = p.parentElement;
+            }
+            return right;
+          };
+          const items = [];
+          for (const child of col.querySelectorAll('*')) {
+            const r = child.getBoundingClientRect();
+            if (r.width === 0 && r.height === 0) { continue; }
+            items.push({
+              tag: child.tagName,
+              right: Math.round(clippedRight(child) * 100) / 100,
+              text: (child.textContent || '').replace(/\s+/g, ' ').trim().slice(0, 30),
+            });
+          }
+          const maxRight = Math.max(...items.map((i) => i.right));
+          const trigger = col.querySelector('[data-testid$="-trigger"]');
+          const tr = trigger.getBoundingClientRect();
+          return {
+            viewport: window.innerWidth,
+            colWidth: Math.round(c.width * 100) / 100,
+            colRight: Math.round(c.right * 100) / 100,
+            maxRight: maxRight,
+            overhang: Math.round((maxRight - c.right) * 100) / 100,
+            scrollWidth: document.documentElement.scrollWidth,
+            clientWidth: document.documentElement.clientWidth,
+            trigger: {
+              width: Math.round(tr.width * 100) / 100,
+              height: Math.round(tr.height * 100) / 100,
+              // A wrapped label that no longer fits its own button would be cut
+              // just as silently as the button was cut from the column.
+              clipped: trigger.scrollWidth > trigger.clientWidth + 1
+                || trigger.scrollHeight > trigger.clientHeight + 1,
+            },
+            worst: items.filter((i) => i.right > c.right + 0.5)
+              .sort((a, b) => b.right - a.right).slice(0, 3),
+          };
+        })()
+    JS;
+
+    /*
+     * `resize()` returns before the layout has reflowed — measuring straight
+     * after it reads the previous viewport (known trap in this repo). Read a
+     * layout property to force the reflow, then measure.
+     */
+    $this->measureAt = function ($page, int $width, int $height) {
+        $page->resize($width, $height)->wait(1.2);
+        $page->script('document.documentElement.getBoundingClientRect().width');
+        $page->wait(0.5);
+
+        return $page->script($this->probe);
+    };
+});
+
+it('keeps the right column contents inside the column from 1440 down to 375', function () {
+    $page = visit($this->eventUrl);
+
+    // 1280 is the width the issue was filed at; 1440 overflowed by 5.63px per
+    // its own sweep; 1024 is the narrowest the column ever gets while the
+    // two-column layout is on (202.67px measured), so it is the worst case for
+    // the calendar button; 375 is the narrow end.
+    foreach ([[1440, 900], [1280, 900], [1024, 900], [375, 812]] as [$width, $height]) {
+        $m = ($this->measureAt)($page, $width, $height);
+
+        expect($m['error'] ?? null)->toBeNull();
+
+        // The defect itself: contents ending past the column's right edge.
+        expect($m['overhang'])->toBeLessThanOrEqual(0.5, sprintf(
+            'viewport %s: contents end at x=%s, %spx past the column edge at x=%s — %s',
+            $m['viewport'], $m['maxRight'], $m['overhang'], $m['colRight'], json_encode($m['worst'])
+        ));
+
+        // ... and its nastiest property: it produced no scrollbar, so nothing
+        // on screen announced that anything was missing.
+        expect($m['scrollWidth'])->toBeLessThanOrEqual(
+            $m['clientWidth'],
+            sprintf('viewport %s: document scrolls horizontally', $m['viewport'])
+        );
+
+        // The calendar trigger may wrap its label, not swallow it, and it keeps
+        // the 44px touch target while wrapping (WCAG 2.5.8, Apple HIG).
+        expect($m['trigger']['clipped'])->toBeFalse(
+            sprintf('viewport %s: the calendar button clips its own label', $m['viewport'])
+        );
+        expect($m['trigger']['height'])->toBeGreaterThanOrEqual(
+            44,
+            sprintf('viewport %s: calendar button is %spx high', $m['viewport'], $m['trigger']['height'])
+        );
+    }
+
+    $page->assertNoJavaScriptErrors();
+});
+
+/*
+ * The name is the other content that can outgrow the column, and it is the
+ * worse case: a one-word name is one unbreakable word. Measured at 1280 with
+ * `wrap-anywhere` removed, the header ran 262.95px past the column — and
+ * 266.61px at 375, the mobile width the reported defect spared. `break-words`
+ * would not help: `overflow-wrap: break-word` does not lower an element's
+ * min-content width, `overflow-wrap: anywhere` does.
+ */
+it('keeps a single-word meetup name inside the column', function () {
+    $meetup = Meetup::factory()->create([
+        'city_id' => $this->city->id,
+        'name' => 'Bitcoinmeetupfrankfurtammainundumgebung',
+        'slug' => 'issue-66-longword',
+        'visible_on_map' => true,
+    ]);
+    $event = MeetupEvent::factory()->create([
+        'meetup_id' => $meetup->id,
+        'location' => 'Hauptbahnhof 1, 60329 Frankfurt am Main',
+    ]);
+
+    $page = visit(route('meetups.landingpage-event', [
+        'country' => 'de',
+        'meetup' => $meetup->slug,
+        'event' => $event->id,
+    ], absolute: false));
+
+    foreach ([[1280, 900], [375, 812]] as [$width, $height]) {
+        $m = ($this->measureAt)($page, $width, $height);
+
+        expect($m['overhang'])->toBeLessThanOrEqual(0.5, sprintf(
+            'viewport %s: the one-word name ends at x=%s, %spx past the column edge at x=%s',
+            $m['viewport'], $m['maxRight'], $m['overhang'], $m['colRight']
+        ));
+        expect($m['scrollWidth'])->toBeLessThanOrEqual($m['clientWidth']);
+    }
+});
+
+/*
+ * Negative control. Without it the test above proves nothing — a probe that
+ * cannot report overflow is green whether the page is broken or not. Here the
+ * three utilities that carry the fix are stripped off the live DOM, which is
+ * exactly what reverting the Blade file would do, and the very same probe has
+ * to see the defect again.
+ *
+ * Injecting `!important` CSS instead does NOT work in this project: Tailwind v4
+ * emits its utilities inside a cascade layer, and for important declarations
+ * the layer order is reversed — an unlayered `!important` rule loses against a
+ * layered one. Measured: the injected `white-space: nowrap !important` left the
+ * computed value at `normal`, and the control passed while proving nothing.
+ */
+it('would catch the overflow again if the fix were reverted', function () {
+    $page = visit($this->eventUrl);
+
+    $healthy = ($this->measureAt)($page, 1280, 900);
+    expect($healthy['overhang'])->toBeLessThanOrEqual(0.5);
+
+    $stripped = $page->script(<<<'JS'
+        (() => {
+          const col = Array.from(document.querySelectorAll('div')).find(
+            (d) => typeof d.className === 'string' && d.className.split(/\s+/).includes('md:w-1/3')
+          );
+          const row = col.firstElementChild;
+          row.classList.remove('flex-wrap');
+          const textBlock = row.children[1];
+          textBlock.className = textBlock.className
+            .split(/\s+/)
+            .filter((c) => ! c.includes('data-testid') && c !== 'sm:basis-56' && c !== 'sm:grow')
+            .join(' ');
+          return {row: row.className, textBlock: textBlock.className};
+        })()
+    JS);
+
+    // The strip has to have hit something — a silent no-op would make the
+    // control pass for the wrong reason.
+    expect($stripped['row'])->not->toContain('flex-wrap');
+    expect($stripped['textBlock'])->not->toContain('data-testid');
+
+    $page->wait(0.5);
+    $page->script('document.documentElement.getBoundingClientRect().width');
+    $page->wait(0.5);
+
+    $reverted = $page->script($this->probe);
+
+    expect($reverted['overhang'])->toBeGreaterThan(1.0, sprintf(
+        'the probe reports %spx overhang on the reverted markup — it cannot see the defect it is meant to pin',
+        $reverted['overhang']
+    ));
+});


### PR DESCRIPTION
Closes #66.

At 1280px the right column ended at x=1232 while its contents ran to 1290.95 — **58.95px past the column**, 10.95px past the viewport. `documentElement.scrollWidth` stayed at 1280, so no scrollbar appeared and the meetup name, the city line and the Subscribe button were simply cut. Content loss with no affordance.

**Cause, measured:** the text block's min-content width was 213.61px, set by the calendar-stream trigger carrying Flux's default `whitespace-nowrap`. Beside the 128px avatar and a 16px gap it demanded 357.61px of a 298.66px column, and a flex item cannot shrink below min-content.

The content is made shrinkable: `flex-wrap` and `gap-4` on the row, `shrink-0` on the avatar, `sm:basis-56 sm:grow` plus scoped trigger overrides on the text block — the same `!whitespace-normal / !h-auto / min-h-11` pattern the picker already applies to its own copy buttons. The picker component itself is untouched; #55 owns it.

Trigger min-content 213.61 → 138px; `sm:basis-56` states the wrap threshold explicitly at 368px of column instead of letting the meetup name's max-content decide it, which is what leaves 1536 and 1920 unchanged.

**After: overhang 0 at 1920, 1536, 1440, 1280, 1024, 768 and 375.**

A second defect surfaced while measuring and is fixed in the same diff, because it is the same overflow on the same element: a single-word meetup name overhung by 262.95px at 1280 **and** 266.61px at 375 — it breaks the mobile width the reported case spared, and the fix for the reported case does not touch it. `wrap-anywhere` takes both to 0; `break-words` would not, because `overflow-wrap: break-word` does not lower an element's min-content width.

The test measures rects and carries a negative control that strips the fix off the live DOM and reproduces exactly 58.95px. Two traps are documented in it, both of which made an earlier version pass while proving nothing: Leaflet tiles laid up to 326px past the column behind `overflow: hidden`, and a `!important` injection that loses to Tailwind v4's reversed cascade-layer order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XfFQ18DFktM3ewnWo9Zt9X
