### PR TITLE
Pay off four of the five UI debts on the webhook and picker pages

### DIFF
--- a/resources/views/components/calendar-stream-picker.blade.php
+++ b/resources/views/components/calendar-stream-picker.blade.php
@@ -35,15 +35,34 @@
     $baseUrl = route('ics', $meetupId ? ['meetup' => $meetupId] : []);
 
     /*
-     * Eindeutig je Instanz, aber STABIL ueber Re-Renders: landingpage.blade.php
-     * rendert die Komponente zweimal auf derselben Seite, ein statisches
-     * data-testid waere dort mehrdeutig. Vorher stand hier Str::random(8) — auf
-     * meetups/index.blade.php sitzt die Komponente neben wire:model.live="search",
-     * also erzeugte jeder Tastendruck neue Test-IDs und jede selektor-basierte
-     * Messung lief ins Leere. Ein Zaehler pro Request leistet dasselbe und bleibt.
+     * Two properties at once, and they pull against each other.
+     *
+     * STABLE across renders: on meetups/index.blade.php the component sits next
+     * to wire:model.live="search", so every keystroke re-renders it. With the
+     * Str::random(8) that used to stand here, every keystroke produced new ids
+     * and every selector-based measurement of this component addressed a node
+     * that no longer existed.
+     *
+     * UNIQUE within one page: meetups/landingpage.blade.php renders the
+     * component twice (lines 69 and 122), so a fixed literal would make every
+     * selector on that page ambiguous.
+     *
+     * A `static` in this block satisfies neither, and looks like it satisfies
+     * both — which is why it is worth naming: Laravel evaluates a view inside a
+     * closure literal that is re-created on every single render
+     * (Filesystem::getRequire(), framework/src/Illuminate/Filesystem/Filesystem.php:120),
+     * so the static is re-initialised each time and the counter never leaves 1.
+     * Measured on the landing page before this change: 14 data-testid values,
+     * 7 distinct — both instances answered to `calendar-stream-1`.
+     *
+     * The request is the object with exactly the right lifetime. It is one per
+     * render pass, and a Livewire round trip is its own request, so the
+     * numbering restarts at the same place and yields the same ids.
      */
-    static $calendarStreamPickerInstance = 0;
-    $testIdPrefix = 'calendar-stream-'.(++$calendarStreamPickerInstance);
+    $calendarStreamPickerInstance = (int) request()->attributes->get('calendar-stream-picker-count', 0) + 1;
+    request()->attributes->set('calendar-stream-picker-count', $calendarStreamPickerInstance);
+
+    $testIdPrefix = 'calendar-stream-'.$calendarStreamPickerInstance;
 @endphp
 
 {{-- `triggerLabel` carries the language and the timezone, deliberately NOT the

--- a/resources/views/livewire/admin/webhooks.blade.php
+++ b/resources/views/livewire/admin/webhooks.blade.php
@@ -149,15 +149,40 @@ new class extends Component
      * Whether an approved subscription would actually deliver right now —
      * an operator approving one the owner has paused, or the system has
      * auto-disabled, should not be told that flipped a switch it did not.
+     *
+     * The state comes back as a scannable label AND the sentence that
+     * explains it, split on purpose (Issue #55). The two used to be one
+     * string rendered inside a `flux:badge`, and a badge carries
+     * `whitespace-nowrap` (flux/badge/index.blade.php:32), so that sentence
+     * could not wrap at any width. Measured at a 375px viewport: the badge
+     * ran to x=541.02 while its own card ended at x=335 — 206.02px of the
+     * sentence outside the card and past the viewport, with
+     * `documentElement.scrollWidth` still at 375, so nothing scrolled and
+     * the text was simply gone.
+     *
+     * Label and colour are the ones settings/webhooks.blade.php shows the
+     * subscription's owner for the same two states (statusFor(): 'paused',
+     * 'disabled'), so the board and the owner read the same word for the
+     * same condition.
+     *
+     * @return array{label: string, explanation: string, color: string}|null
      */
-    public function stillBlocked(WebhookSubscription $subscription): ?string
+    public function stillBlocked(WebhookSubscription $subscription): ?array
     {
         if (! $subscription->active) {
-            return __('Vom Besitzer pausiert — erhält trotz Freigabe keine Zustellungen.');
+            return [
+                'label' => __('Pausiert'),
+                'explanation' => __('Vom Besitzer pausiert — erhält trotz Freigabe keine Zustellungen.'),
+                'color' => 'zinc',
+            ];
         }
 
         if ($subscription->disabled_at !== null) {
-            return __('Automatisch deaktiviert nach wiederholten Zustellungsfehlern.');
+            return [
+                'label' => __('Deaktiviert'),
+                'explanation' => __('Automatisch deaktiviert nach wiederholten Zustellungsfehlern.'),
+                'color' => 'red',
+            ];
         }
 
         return null;
@@ -179,10 +204,17 @@ new class extends Component
         {{ __('Wartet auf Freigabe (:count)', ['count' => $this->pending->count()]) }}
     </flux:heading>
 
+    {{-- Both empty states on this page are the same kind of message and now use
+         the same component (Issue #55). This one was a `flux:callout`, which is
+         an attention device — a bordered, iconised block that says "look here".
+         An empty approval queue is the good outcome, not an alert, and the
+         approved list two headings down already stated it as quiet `flux:text`.
+         The callout stays where it belongs: the flash above, which reports what
+         just changed. --}}
     @if ($this->pending->isEmpty())
-        <flux:callout data-testid="admin-webhooks-pending-empty">
+        <flux:text class="text-zinc-500 dark:text-zinc-400" data-testid="admin-webhooks-pending-empty">
             {{ __('Keine offenen Anfragen.') }}
-        </flux:callout>
+        </flux:text>
     @else
         <div class="flex flex-col gap-4" data-testid="admin-webhooks-pending-list">
             @foreach ($this->pending as $subscription)
@@ -245,7 +277,7 @@ new class extends Component
                 <div wire:key="approved-{{ $subscription->id }}"
                      class="rounded-lg border border-zinc-200 p-4 dark:border-zinc-700">
                     <div class="flex items-start justify-between gap-4">
-                        <div class="min-w-0">
+                        <div class="min-w-0" data-testid="admin-webhooks-approved-info-{{ $subscription->id }}">
                             <p class="truncate font-mono text-sm">{{ $subscription->url }}</p>
                             <p class="mt-1 text-xs text-zinc-500 dark:text-zinc-400">
                                 {{ __('Besitzer') }}: {{ $subscription->user?->name ?? '#'.$subscription->user_id }}
@@ -254,8 +286,21 @@ new class extends Component
                                 {{ implode(', ', $subscription->resources) }}
                             </p>
 
+                            {{-- One word in the badge, the sentence beside it. The badge
+                                 is what an operator scans a list for; the sentence is
+                                 what they read once they have found it, and only the
+                                 second one may wrap. `flex-wrap` lets the sentence drop
+                                 under the badge when the column gets narrow instead of
+                                 pushing it sideways; `items-baseline` sits the badge on
+                                 the sentence's first line. --}}
                             @if ($blocked = $this->stillBlocked($subscription))
-                                <flux:badge size="sm" color="amber" class="mt-2">{{ $blocked }}</flux:badge>
+                                <div class="mt-2 flex flex-wrap items-baseline gap-x-2 gap-y-1"
+                                     data-testid="admin-webhooks-blocked-{{ $subscription->id }}">
+                                    <flux:badge size="sm" :color="$blocked['color']">{{ $blocked['label'] }}</flux:badge>
+                                    <flux:text class="min-w-0 text-zinc-600 dark:text-zinc-300">
+                                        {{ $blocked['explanation'] }}
+                                    </flux:text>
+                                </div>
                             @endif
                         </div>
 

--- a/tests/Browser/Admin/WebhookApprovalLayoutTest.php
+++ b/tests/Browser/Admin/WebhookApprovalLayoutTest.php
@@ -1,0 +1,206 @@
+<?php
+
+use App\Models\User;
+use App\Models\WebhookSubscription;
+
+/*
+|--------------------------------------------------------------------------
+| Issue #55, item 2 — a full sentence inside a flux:badge
+|--------------------------------------------------------------------------
+|
+| The "still blocked" notice on an approved subscription was one 65-character
+| sentence rendered inside a `flux:badge`. A badge carries `whitespace-nowrap`
+| (flux/badge/index.blade.php:32), so that sentence could not wrap at any
+| width, and it sat in a `min-w-0` column that is supposed to shrink.
+|
+| Measured on the rendered page before the change, 1280px viewport: the row's
+| information cell had a min-content width of 484.02px, all of it the badge
+| (badge min-content 484.02px), and its natural width had already collapsed
+| onto that floor. At 375px the badge ran to x=541.02 while its own card ended
+| at x=335 — 206.02px of the sentence outside the card and past the viewport —
+| with `documentElement.scrollWidth` still equal to clientWidth, so no
+| scrollbar appeared and the text was simply gone. Same silent-overflow
+| signature as Issue #66, and the reason a CSS-class assertion cannot stand in
+| for this test.
+|
+*/
+beforeEach(function () {
+    $this->board = User::factory()->create(['nostr' => config('einundzwanzig.board_members')[0]]);
+    $this->actingAs($this->board);
+
+    $owner = User::factory()->create(['name' => 'Satoshi']);
+
+    $this->subscription = WebhookSubscription::factory()->create([
+        'user_id' => $owner->id,
+        'url' => 'https://1.1.1.1/hooks/incoming',
+        'resources' => ['meetup', 'meetup-event'],
+        'approved_at' => now(),
+        'active' => false,
+    ]);
+});
+
+$measureScript = <<<'JS'
+    (() => {
+        const round = (n) => Math.round(n * 100) / 100;
+        const minContent = (el) => {
+            const previous = el.style.width;
+            el.style.width = 'min-content';
+            void el.getBoundingClientRect().width;
+            const value = el.getBoundingClientRect().width;
+            el.style.width = previous;
+            void el.getBoundingClientRect().width;
+            return round(value);
+        };
+
+        const cell = document.querySelector('[data-testid^="admin-webhooks-approved-info-"]');
+        const notice = cell.querySelector('[data-testid^="admin-webhooks-blocked-"]');
+        const badge = notice.querySelector('[data-flux-badge]');
+        const explanation = notice.querySelector('[data-flux-text]');
+        const card = cell.parentElement.parentElement;
+
+        return {
+            cellMinContent: minContent(cell),
+            badgeMinContent: minContent(badge),
+            badgeText: badge.textContent.trim(),
+            explanationWhiteSpace: getComputedStyle(explanation).whiteSpace,
+            explanationMinContent: minContent(explanation),
+            noticeRight: round(notice.getBoundingClientRect().right),
+            cardRight: round(card.getBoundingClientRect().right),
+            overhangPastCard: round(notice.getBoundingClientRect().right - card.getBoundingClientRect().right),
+            viewportWidth: document.documentElement.clientWidth,
+        };
+    })()
+JS;
+
+it('does not let the blocked notice set a rigid minimum width on the approved row', function () use ($measureScript) {
+    $page = visit('/de/admin/webhooks');
+    $page->resize(1280, 900)->wait(1.2);
+
+    $measured = $page->script($measureScript);
+
+    // The badge holds one word now, and that word is the same one the owner
+    // sees for this state on settings/webhooks.blade.php.
+    expect($measured['badgeText'])->toBe('Pausiert');
+
+    // 73.61px measured for "Pausiert" — the old sentence measured 484.02px.
+    // 150px is the ceiling any of the two labels may reach, in any locale,
+    // before it is a sentence again.
+    expect($measured['badgeMinContent'])->toBeLessThan(150);
+
+    // The cell's floor is now the URL line (`truncate` implies
+    // `white-space: nowrap`), measured at 252.05px, not the notice. The badge
+    // is no longer the binding constraint, which is the whole point.
+    expect($measured['cellMinContent'])->toBeLessThan(300)
+        ->and($measured['badgeMinContent'])->toBeLessThan($measured['cellMinContent']);
+
+    // The sentence itself has to be able to wrap.
+    expect($measured['explanationWhiteSpace'])->not->toBe('nowrap');
+    expect($measured['explanationMinContent'])->toBeLessThan(150);
+});
+
+it('keeps the blocked notice inside its card at 375px', function () use ($measureScript) {
+    $page = visit('/de/admin/webhooks');
+    $page->resize(375, 812)->wait(1.2);
+
+    $measured = $page->script($measureScript);
+
+    expect($measured['viewportWidth'])->toBe(375);
+    expect($measured['overhangPastCard'])->toBeLessThanOrEqual(0);
+    expect($measured['noticeRight'])->toBeLessThanOrEqual(375);
+});
+
+/*
+ * Negative control. Putting the sentence back into the badge on the live DOM
+ * has to reproduce the reported geometry — otherwise the two tests above are
+ * measuring something that was never able to fail.
+ */
+it('reproduces the reported overflow when the sentence is put back into the badge', function () {
+    $page = visit('/de/admin/webhooks');
+    $page->resize(375, 812)->wait(1.2);
+
+    $reproduced = $page->script(<<<'JS'
+        (() => {
+            const round = (n) => Math.round(n * 100) / 100;
+            const cell = document.querySelector('[data-testid^="admin-webhooks-approved-info-"]');
+            const notice = cell.querySelector('[data-testid^="admin-webhooks-blocked-"]');
+            const badge = notice.querySelector('[data-flux-badge]');
+            const explanation = notice.querySelector('[data-flux-text]');
+            const card = cell.parentElement.parentElement;
+
+            const sentence = explanation.textContent.trim();
+            explanation.remove();
+            badge.textContent = sentence;
+            void badge.getBoundingClientRect().width;
+
+            const previous = badge.style.width;
+            badge.style.width = 'min-content';
+            void badge.getBoundingClientRect().width;
+            const badgeMinContent = round(badge.getBoundingClientRect().width);
+            badge.style.width = previous;
+            void badge.getBoundingClientRect().width;
+
+            return {
+                badgeMinContent: badgeMinContent,
+                badgeWidth: round(badge.getBoundingClientRect().width),
+                badgeWhiteSpace: getComputedStyle(badge).whiteSpace,
+                overhangPastCard: round(badge.getBoundingClientRect().right - card.getBoundingClientRect().right),
+                documentOverflow: document.documentElement.scrollWidth - document.documentElement.clientWidth,
+            };
+        })()
+    JS);
+
+    // The badge cannot shrink below the whole sentence — `min-content` and its
+    // laid-out width are the same number, which is what "rigid" means here.
+    expect($reproduced['badgeWhiteSpace'])->toBe('nowrap');
+    expect($reproduced['badgeMinContent'])->toBeGreaterThan(400)
+        ->and($reproduced['badgeMinContent'])->toBe($reproduced['badgeWidth']);
+
+    // 206.02px past the card was the number measured on the real page before
+    // the fix, at this exact viewport.
+    expect($reproduced['overhangPastCard'])->toBeGreaterThan(150);
+
+    // And the reason nobody saw it: a nowrap child overflowing its block does
+    // not grow the document, so no scrollbar ever appears.
+    expect($reproduced['documentOverflow'])->toBe(0);
+});
+
+/*
+|--------------------------------------------------------------------------
+| Issue #55, item 3 — one empty-state component, not two
+|--------------------------------------------------------------------------
+|
+| The page used `flux:callout` for the empty pending queue and `flux:text` for
+| the empty approved list. A callout is an attention device; an empty approval
+| queue is the good outcome. Both are `flux:text` now. The success flash above
+| them stays a callout — that one does report something that just changed.
+|
+*/
+it('renders both empty states with the same component', function () {
+    WebhookSubscription::query()->delete();
+
+    $page = visit('/de/admin/webhooks');
+    $page->resize(1280, 900)->wait(1.2);
+
+    $emptyStates = $page->script(<<<'JS'
+        (() => {
+            const pending = document.querySelector('[data-testid="admin-webhooks-pending-empty"]');
+            const approved = Array.from(document.querySelectorAll('[data-flux-text]'))
+                .find((el) => el.textContent.includes('Noch keine Subscription freigeschaltet'));
+
+            return {
+                pendingTag: pending ? pending.tagName.toLowerCase() : null,
+                pendingIsFluxText: pending ? pending.hasAttribute('data-flux-text') : false,
+                pendingIsCallout: pending ? pending.closest('[data-flux-callout]') !== null : false,
+                approvedTag: approved ? approved.tagName.toLowerCase() : null,
+                calloutsOnPage: document.querySelectorAll('[data-flux-callout]').length,
+            };
+        })()
+    JS);
+
+    expect($emptyStates['pendingIsFluxText'])->toBeTrue()
+        ->and($emptyStates['pendingIsCallout'])->toBeFalse()
+        ->and($emptyStates['pendingTag'])->toBe($emptyStates['approvedTag']);
+
+    // No flash is in play here, so the page should carry no callout at all.
+    expect($emptyStates['calloutsOnPage'])->toBe(0);
+});

--- a/tests/Browser/CalendarStreamPickerTest.php
+++ b/tests/Browser/CalendarStreamPickerTest.php
@@ -147,3 +147,154 @@ it('keeps the calendar trigger on one line at every width', function () {
         expect($measured)->toBeLessThanOrEqual(56, "trigger wrapped at {$width}px: {$measured}px");
     }
 });
+
+/*
+ * Issue #55, item 1: 419 timezone identifiers behind a plain <select> inside a
+ * 320px popover. The component now uses the repo's own house pattern for these
+ * lists (`variant="listbox" searchable` with a search slot — same as
+ * livewire/timezone/chooser.blade.php and livewire/country/chooser.blade.php).
+ *
+ * "Searchable" is a claim about a rendered layer, not about markup: the option
+ * list is a separate `popover="manual"` element (flux-pro
+ * select/options.blade.php), positioned outside the picker's own panel, so it
+ * can sit off-screen while every CSS assertion on the page still passes. This
+ * measures it on the narrowest phone width the project cares about.
+ */
+it('keeps the 419-entry timezone list searchable and inside its container at 375px', function () {
+    $page = visit('/de/meetups');
+
+    // resize() returns before the layout has reflowed; measuring straight after
+    // it reads mid-reflow geometry (see EventHeaderFitsColumnTest).
+    $page->resize(375, 812)->wait(1.2);
+
+    $page->click('[data-testid^="calendar-stream-"][data-testid$="-trigger"]')
+        ->assertVisible('[data-testid^="calendar-stream-"][data-testid$="-panel"]')
+        ->wait(0.5);
+
+    $page->click('[data-testid^="calendar-stream-"][data-testid$="-timezone"]')->wait(0.8);
+
+    $measured = $page->script(<<<'JS'
+        (() => {
+            const round = (n) => Math.round(n * 100) / 100;
+            const box = (el) => {
+                const r = el.getBoundingClientRect();
+                return { left: round(r.left), right: round(r.right), top: round(r.top), bottom: round(r.bottom), width: round(r.width), height: round(r.height) };
+            };
+
+            const panel = document.querySelector('[data-testid^="calendar-stream-"][data-testid$="-panel"]');
+            const select = document.querySelector('[data-testid^="calendar-stream-"][data-testid$="-timezone"]');
+            const options = select.querySelector('[data-flux-options]');
+            const search = options ? options.querySelector('[data-flux-select-search] input') : null;
+            const list = options ? options.querySelector('ui-options') : null;
+            const all = list ? Array.from(list.querySelectorAll('ui-option')) : [];
+            const visible = all.filter((el) => el.getBoundingClientRect().height > 0);
+
+            const widest = visible.reduce((max, el) => Math.max(max, el.getBoundingClientRect().right), 0);
+
+            return {
+                panel: box(panel),
+                options: options ? box(options) : null,
+                optionsOpen: options ? options.matches(':popover-open') : false,
+                search: search ? box(search) : null,
+                searchVisible: search ? search.checkVisibility({ checkVisibilityCSS: true }) : false,
+                list: list ? box(list) : null,
+                listScrollHeight: list ? list.scrollHeight : null,
+                optionCountTotal: all.length,
+                optionCountVisible: visible.length,
+                widestOptionRight: round(widest),
+                optionOverflowPastList: list ? round(widest - list.getBoundingClientRect().right) : null,
+                viewport: { width: document.documentElement.clientWidth, height: document.documentElement.clientHeight },
+                documentOverflow: document.documentElement.scrollWidth - document.documentElement.clientWidth,
+            };
+        })()
+    JS);
+
+    // The 419 identifiers really are all in the DOM — otherwise "searchable"
+    // would be measuring an empty list.
+    expect($measured['optionCountTotal'])->toBe(count(DateTimeZone::listIdentifiers()));
+
+    // The search field is the whole point of item 1: it has to be on screen.
+    expect($measured['searchVisible'])->toBeTrue();
+    expect($measured['search']['left'])->toBeGreaterThanOrEqual(0);
+    expect($measured['search']['right'])->toBeLessThanOrEqual($measured['viewport']['width']);
+    expect($measured['search']['top'])->toBeGreaterThanOrEqual(0);
+    expect($measured['search']['bottom'])->toBeLessThanOrEqual($measured['viewport']['height']);
+
+    // The list itself must not run past its own popover, and the popover must
+    // not run past the viewport — a floating layer does not grow scrollWidth,
+    // so document overflow cannot stand in for this.
+    expect($measured['optionOverflowPastList'])->toBeLessThanOrEqual(1);
+    expect($measured['options']['left'])->toBeGreaterThanOrEqual(0);
+    expect($measured['options']['right'])->toBeLessThanOrEqual($measured['viewport']['width']);
+    expect($measured['documentOverflow'])->toBe(0);
+
+    // And it filters: typing has to cut the list down, otherwise the search box
+    // is decoration.
+    $page->type('[data-testid$="-timezone"] [data-flux-select-search] input', 'Berlin')->wait(0.6);
+
+    $filtered = $page->script(<<<'JS'
+        (() => {
+            const select = document.querySelector('[data-testid^="calendar-stream-"][data-testid$="-timezone"]');
+            const list = select.querySelector('[data-flux-options] ui-options');
+            const visible = Array.from(list.querySelectorAll('ui-option'))
+                .filter((el) => el.getBoundingClientRect().height > 0);
+
+            return {
+                visibleCount: visible.length,
+                labels: visible.slice(0, 5).map((el) => el.textContent.trim()),
+            };
+        })()
+    JS);
+
+    expect($filtered['visibleCount'])->toBeGreaterThan(0)
+        ->and($filtered['visibleCount'])->toBeLessThan(10)
+        ->and($filtered['labels'])->toContain('Europe/Berlin');
+});
+
+/*
+ * Issue #55, item 4: the component used to build its `data-testid` values from
+ * Str::random(8). On /{country}/meetups it sits next to `wire:model.live="search"`
+ * (meetups/index.blade.php:76-81), so every keystroke re-rendered the component
+ * with fresh ids and every selector-based measurement of it silently addressed a
+ * node that no longer existed.
+ *
+ * Reading the Blade cannot prove the fix — a per-request counter, a component id
+ * and a random string all look equally stable in source. This renders the
+ * component twice, with a real Livewire round trip in between, and compares.
+ */
+it('keeps its test ids across a Livewire re-render of the meetups search field', function () {
+    Meetup::factory()->create([
+        'city_id' => City::query()->firstOrFail()->id,
+        'name' => 'Issue 55 Stable Ids Meetup',
+        'visible_on_map' => true,
+    ]);
+
+    $page = visit('/de/meetups');
+    $page->resize(1280, 900)->wait(1.2);
+
+    $collectIds = <<<'JS'
+        Array.from(document.querySelectorAll('[data-testid^="calendar-stream-"]'))
+            .map((el) => el.getAttribute('data-testid'))
+            .sort()
+    JS;
+
+    $before = $page->script($collectIds);
+
+    // The component ships six ids per instance (trigger, panel, the three
+    // selects, the two copy buttons); asserting on an empty array would pass
+    // vacuously.
+    expect($before)->not->toBeEmpty();
+
+    $page->type('input[placeholder^="Suche nach Meetups"]', 'Zzz')->wait(1.5);
+
+    // Positive control: the round trip really happened. Without this the
+    // comparison below could be comparing a page that never re-rendered.
+    $reRendered = $page->script(
+        "document.body.innerText.includes('Issue 55 Stable Ids Meetup') === false"
+    );
+    expect($reRendered)->toBeTrue();
+
+    $after = $page->script($collectIds);
+
+    expect($after)->toBe($before);
+});

--- a/tests/Feature/Meetups/CalendarStreamPickerTestIdsTest.php
+++ b/tests/Feature/Meetups/CalendarStreamPickerTestIdsTest.php
@@ -1,0 +1,104 @@
+<?php
+
+use App\Models\City;
+use App\Models\Country;
+use App\Models\Meetup;
+
+/*
+|--------------------------------------------------------------------------
+| Issue #55, item 4 — the picker's data-testid prefix has to be stable
+|--------------------------------------------------------------------------
+|
+| The component used to build its ids from Str::random(8). Two properties have
+| to hold at once, and they pull in opposite directions:
+|
+|  - STABLE across renders, because on /{country}/meetups the picker sits next
+|    to `wire:model.live="search"`, so every keystroke re-renders it;
+|  - UNIQUE within one page, because meetups/landingpage.blade.php renders the
+|    component twice (lines 69 and 122) and a fixed literal would make every
+|    selector on that page ambiguous.
+|
+| A per-request counter satisfies both. The Livewire round trip itself is
+| covered in tests/Browser/CalendarStreamPickerTest.php with a real browser;
+| this file pins the two properties cheaply, plus the one thing the browser
+| test cannot see — that a SECOND request in the same PHP process starts the
+| numbering over rather than continuing it.
+|
+*/
+
+/**
+ * @return array<int, string>
+ */
+function issue55CalendarStreamTestIds(string $html): array
+{
+    preg_match_all('/data-testid="(calendar-stream-[^"]+)"/', $html, $matches);
+
+    sort($matches[1]);
+
+    return $matches[1];
+}
+
+beforeEach(function () {
+    $this->country = Country::factory()->create(['code' => 'de']);
+    $this->city = City::factory()->create(['country_id' => $this->country->id]);
+    $this->meetup = Meetup::factory()->create([
+        'city_id' => $this->city->id,
+        'name' => 'Bitcoin Meetup Testhausen',
+        'visible_on_map' => true,
+    ]);
+});
+
+it('renders the same calendar-stream test ids on two requests for the meetups index', function () {
+    $first = issue55CalendarStreamTestIds(
+        $this->get(route('meetups.index', ['country' => 'de']))->assertSuccessful()->getContent()
+    );
+
+    $second = issue55CalendarStreamTestIds(
+        $this->get(route('meetups.index', ['country' => 'de']))->assertSuccessful()->getContent()
+    );
+
+    // Seven ids per instance: trigger, panel, three selects, two copy buttons.
+    // Without this the comparison below would pass on two empty arrays.
+    expect($first)->toHaveCount(7)
+        ->and($second)->toBe($first);
+});
+
+it('gives the two picker instances on one meetup landing page different test ids', function () {
+    $ids = issue55CalendarStreamTestIds(
+        $this->get(route('meetups.landingpage', ['country' => 'de', 'meetup' => $this->meetup]))
+            ->assertSuccessful()
+            ->getContent()
+    );
+
+    // Two instances, seven ids each, none of them shared.
+    expect($ids)->toHaveCount(14)
+        ->and(array_unique($ids))->toHaveCount(14);
+
+    // `beforeLast('-')` would not do here: `calendar-stream-1-copy-all` would
+    // yield `calendar-stream-1-copy` and count as a prefix of its own.
+    $prefixes = array_values(array_unique(array_map(
+        static fn (string $id): string => preg_replace('/^(calendar-stream-\d+)-.*$/', '$1', $id),
+        $ids
+    )));
+
+    sort($prefixes);
+
+    expect($prefixes)->toBe(['calendar-stream-1', 'calendar-stream-2']);
+});
+
+it('keeps the -trigger suffix the event page scopes its overflow fix to', function () {
+    // meetups/landingpage-event.blade.php pins the header's shrinkability with
+    // `[&_[data-testid$='-trigger']]:…` overrides (Issue #66). Renaming the
+    // suffix here would silently un-fix that column, so it is asserted from
+    // the side that would break.
+    $html = $this->get(route('meetups.landingpage', ['country' => 'de', 'meetup' => $this->meetup]))
+        ->assertSuccessful()
+        ->getContent();
+
+    $triggers = array_filter(
+        issue55CalendarStreamTestIds($html),
+        static fn (string $id): bool => str_ends_with($id, '-trigger')
+    );
+
+    expect($triggers)->toHaveCount(2);
+});


### PR DESCRIPTION
Closes #55. Items 1–4; item 5 deferred as the issue asks.

**1 — the 419-timezone select** was already done by `a8b2b99`. Measured at 375px rather than taken on trust: popover 320px, options layer 286px fully inside the viewport, search field 284×40 visible, list capped at 320px against a `scrollHeight` of 13418 so it scrolls internally, 419 of 419 options in the DOM, widest option ending 5px inside the container, document overflow 0. Typing "Berlin" narrows 419 → 1.

**2 — the sentence out of the badge.** Cell min-content **484.02 → 252.05px**, badge min-content **484.02 → 73.61px**. The remaining floor was measured per child and is the URL line (`truncate` implies nowrap). At 375px the notice previously ended 206.02px outside its card with `scrollWidth == clientWidth` — cut with no scrollbar. Now 204.39px inside.

The colours changed with it: `amber-700` on `amber-400/25` measures **4.37:1** at 12px against a 4.5:1 requirement, and 12px is not large text. The badge now uses the zinc/red pair the owner-facing page already uses for the same two states — 9.18:1 / 5.20:1 light, 5.83:1 / 5.44:1 dark, read back off the rendered pixels.

**3 — one empty-state component.** `flux:callout` → `flux:text`; the test asserts zero callouts on the page in the empty state.

**4 — stable `data-testid`, and this one was NOT already fixed**, whatever the code's own comment claimed. A `static` in a Blade `@php` block is per render, not per request: Laravel evaluates every view inside a closure literal created fresh per render. Measured on the landing page: **14 values, 7 distinct** — both instances called themselves `calendar-stream-1`. Now 14 distinct, with the counter on the request.

Proven by a real Livewire roundtrip (type into `wire:model.live="search"`), with a positive control that the roundtrip happened and a negative control that restoring `Str::random(8)` fails.

`EventHeaderFitsColumn` (#66's fix) still measures 0 overhang at 1280, 1440, 1024 and 375 — the `-trigger` suffix its overrides select on is pinned from this side too.

Filed rather than fixed: #98 (the amber badge is still on the settings page) and #99 (sweep for other `static` uses in views).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XfFQ18DFktM3ewnWo9Zt9X
