### PR TITLE
Bind only a language the selector actually offers

### DIFF
--- a/resources/views/livewire/language/selector.blade.php
+++ b/resources/views/livewire/language/selector.blade.php
@@ -2,17 +2,60 @@
 
 use Livewire\Component;
 
-new class extends Component {
+new class extends Component
+{
     public $langCountry;
 
-    public function mount() {
-        $this->langCountry = session('lang_country', config('lang-country.fallback'));
+    public function mount()
+    {
+        $this->langCountry = $this->offeredLangCountry(
+            (string) session('lang_country', config('lang-country.fallback'))
+        );
     }
 
-    public function getLanguagesProperty() {
+    /**
+     * Map the session locale onto the option set this select actually renders.
+     *
+     * The two sides are deliberately NOT the same set. `config('lang-country.allowed')`
+     * lists 33 locales that may legitimately sit in `session('lang_country')` — the
+     * Accept-Language guess in DomainMiddleware and the package's own login listener both
+     * produce them — while the options below are limited to languages that have a
+     * `lang/*.json` file, 17 today. The other 16 (fr-*, it-*, ru-RU, da-DA, ...) are
+     * locales the portal cannot switch its interface to, so widening the options would
+     * offer translations that do not exist. Narrowing `allowed` would take away locale
+     * formats that do work.
+     *
+     * So this side gives way: a value with no matching <ui-option> is never bound. Flux'
+     * `ui-selected` element throws `Could not find option for value "…"` while rendering
+     * one (issue #73), and because the select sits in the sidebar that hits every page —
+     * measured on the meetup list, the meetup page and the event page, one uncaught error
+     * per page load.
+     *
+     * The match is case-insensitive and answers with the OFFERED spelling, which is the
+     * half of #73 that was actually reported: a session still carrying `de-de` now selects
+     * `de-DE` instead of throwing. Casing is the one difference that names the same locale,
+     * so correcting it is not a guess.
+     *
+     * No match at all means no selection: the placeholder is the honest answer for a
+     * locale this portal cannot offer, and `updatedLangCountry()` already treats an empty
+     * selection as "nothing chosen", so nothing redirects off the back of it.
+     */
+    private function offeredLangCountry(string $langCountry): ?string
+    {
+        foreach ($this->languages as $option) {
+            if (mb_strtolower($option['value']) === mb_strtolower($langCountry)) {
+                return $option['value'];
+            }
+        }
+
+        return null;
+    }
+
+    public function getLanguagesProperty()
+    {
         // Scan lang folder for available languages
         $availableLanguages = collect(glob(base_path('lang/*.json')))
-            ->map(fn($file) => pathinfo($file, PATHINFO_FILENAME))
+            ->map(fn ($file) => pathinfo($file, PATHINFO_FILENAME))
             ->toArray();
 
         $allLanguages = config('lang-country.languages');
@@ -30,7 +73,7 @@ new class extends Component {
                 [$lang, $countryCode] = explode('-', $langCountry);
                 $options[] = [
                     'value' => $langCountry,
-                    'label' => $langData['name'] . ' (' . strtoupper($countryCode) . ')',
+                    'label' => $langData['name'].' ('.strtoupper($countryCode).')',
                 ];
             }
         }

--- a/tests/Browser/Meetups/MeetupPagesLanguageSelectorTest.php
+++ b/tests/Browser/Meetups/MeetupPagesLanguageSelectorTest.php
@@ -1,0 +1,92 @@
+<?php
+
+use App\Models\City;
+use App\Models\Country;
+use App\Models\Meetup;
+use App\Models\MeetupEvent;
+use Livewire\Livewire;
+
+/*
+ * Issue #73: the sidebar's language select bound `session('lang_country')` straight to a
+ * `flux:select` whose options are a strict SUBSET of the locales that session key may
+ * legitimately hold. `config('lang-country.allowed')` lists 33 locales; the select only
+ * offers the ones whose language has a `lang/*.json` file — 17 today. For the other 16,
+ * Flux' `ui-selected` element finds no `<ui-option>` for the bound value and throws
+ * `Uncaught Could not find option for value "…"` while rendering, on every page that
+ * draws the sidebar. That is why `assertNoJavascriptErrors()` could not be used on the
+ * meetup pages without an allowance.
+ *
+ * `fr-BE` is the cheapest reachable case: it is in `allowed` (so the switch route accepts
+ * it), it is exactly what `Accept-Language: fr` resolves to (measured), and there is no
+ * `lang/fr.json`, so the select cannot offer it.
+ */
+beforeEach(function () {
+    $this->country = Country::factory()->create(['code' => 'de', 'name' => 'Deutschland']);
+    $this->city = City::factory()->create([
+        'country_id' => $this->country->id,
+        'name' => 'Frankfurt am Main',
+    ]);
+    $this->meetup = Meetup::factory()->create([
+        'city_id' => $this->city->id,
+        'name' => 'Issue 73 Sprachwahl Meetup',
+        'slug' => 'issue-73-language-selector',
+        'visible_on_map' => true,
+    ]);
+    $this->event = MeetupEvent::factory()->create(['meetup_id' => $this->meetup->id]);
+
+    $this->urls = [
+        'meetup list' => route('meetups.index', ['country' => 'de'], absolute: false),
+        'meetup detail' => route('meetups.landingpage', [
+            'country' => 'de',
+            'meetup' => $this->meetup->slug,
+        ], absolute: false),
+        'event detail' => route('meetups.landingpage-event', [
+            'country' => 'de',
+            'meetup' => $this->meetup->slug,
+            'event' => $this->event->id,
+        ], absolute: false),
+    ];
+
+    $this->switchUrl = route('lang_country.switch', ['lang_country' => 'fr-BE'], absolute: false);
+});
+
+it('renders without JavaScript errors on a locale the language select cannot offer', function (string $page) {
+    $url = $this->urls[$page];
+
+    $browser = visit($url);
+    $browser->assertSee($this->meetup->name);
+
+    /*
+     * The switch route answers with `redirect()->back()`, so coming from $url it lands
+     * back on $url: the session locale changes without any other page rendering in
+     * between. That matters — every page with the sidebar (and the welcome page) carries
+     * the same select, and its errors would land in this same console and make the
+     * assertion below pass or fail for the wrong page.
+     */
+    $browser->script('window.location.href = "'.$this->switchUrl.'"');
+    $browser->assertSee($this->meetup->name);
+
+    // Without this the assertion below would also hold on a page that renders no select
+    // at all — a sidebar that stops rendering must not read as "fixed".
+    expect($browser->script('document.querySelectorAll("ui-select").length'))
+        ->toBeGreaterThan(0);
+
+    $browser->assertNoJavaScriptErrors();
+})->with(['meetup list', 'meetup detail', 'event detail']);
+
+it('binds only values it actually offers as options', function (?string $expected, string $sessionValue) {
+    session(['lang_country' => $sessionValue]);
+
+    Livewire::test('language.selector')->assertSet('langCountry', $expected);
+})->with([
+    // The spelling the issue reported. Same locale, different case — the option exists,
+    // so the canonical spelling is selected rather than nothing.
+    ['de-DE', 'de-de'],
+    ['de-DE', 'de-DE'],
+    ['de-AT', 'de-AT'],
+    // Allowed, but no `lang/fr.json`: no option can exist for it, so nothing is selected
+    // and the placeholder shows. `updatedLangCountry()` already treats an empty selection
+    // as "no language chosen", so this cannot trigger a redirect either.
+    [null, 'fr-BE'],
+    [null, 'ru-RU'],
+]);


### PR DESCRIPTION
Closes #73.

Every meetup page logged `Could not find option for value "de-de"`, so `assertNoJavaScriptErrors()` failed there and any browser test on those pages needed a known-failure allowance.

**Measured first, and the issue's guess about lowercasing turned out to be one symptom of a wider cause.** flux-pro's `UISelected.render()` calls `findByValue(picker.value)` and throws on a miss, comparing with `===`. The select's options come from `config('lang-country.languages')` filtered by the `lang/*.json` files that exist: **17 option values against 33 in `config('lang-country.allowed')`**. Sixteen reachable session values therefore have no option at all — `fr-BE`, `it-CH`, `ru-RU` and thirteen more — and `PreferredLanguage` maps `Accept-Language: fr`, `it` and `ru` onto exactly those, with `DomainMiddleware` writing them into the session on a first visit. The select sits in the app sidebar, so it is one uncaught error per page load.

The literal `de-de` could **not** be reproduced from any code path in the tree: `PreferredLanguage` uppercases the region and the switch controller rejects anything not literally in `allowed`. Its origin — a session or `users.lang_country` row predating today's code — stays a hypothesis, not a finding. It fails through the same `===`, so the fix covers it and the test pins it.

**Fixed on the value side.** The option list is deliberately narrower than `allowed`, because it only offers languages the portal has a translation file for; widening it would advertise 16 interface languages that do not exist. `mount()` maps the session value onto the offered set case-insensitively, answering with the offered spelling and `null` when no option can exist, which renders Flux's placeholder. One guard at the reader covers values written before any of the writers.

Filed rather than fixed: #105 — the same defect class in the country chooser, where `/DE/meetups` now renders 200 instead of 404 and throws `Could not find option for value "DE"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XfFQ18DFktM3ewnWo9Zt9X
