### PR TITLE
Authorise deletion the way saving and cancelling already are

### DIFF
--- a/resources/views/livewire/meetups/create-edit-events.blade.php
+++ b/resources/views/livewire/meetups/create-edit-events.blade.php
@@ -588,8 +588,20 @@ class extends Component
         );
     }
 
+    /**
+     * Authorised here as well as in mount(), and that is not belt-and-braces
+     * (issue #96).
+     *
+     * A Livewire action is a request of its own. mount() guards the page at the
+     * moment it is opened; a component left open across a role change still
+     * dispatches this method, and deletion is the least reversible thing on this
+     * form -- exactly the one that most needs the check save() and cancel()
+     * already make.
+     */
     public function delete(): void
     {
+        $this->authorizeManage();
+
         if ($this->event) {
             $this->event->delete();
             session()->flash('status', __('Event erfolgreich gelöscht!'));

--- a/tests/Feature/DownloadMeetupCalendarCancellationTest.php
+++ b/tests/Feature/DownloadMeetupCalendarCancellationTest.php
@@ -277,6 +277,26 @@ it('refuses to open the event editor for someone who may not manage the meetup',
  * as well; a Livewire action is a request of its own, not a continuation of the
  * one that rendered the page.
  */
+it('refuses to delete when the caller lost the right to manage after mounting', function () {
+    // Issue #96. mount() guards the page, but a Livewire action is a request of
+    // its own -- a component left open across a role change still dispatches
+    // delete(), and deletion is the least reversible action on this form.
+    $organiser = actingAsUser();
+    $meetup = Meetup::factory()->create(['city_id' => $this->city->id, 'created_by' => $organiser->id]);
+    $event = MeetupEvent::factory()->create([
+        'meetup_id' => $meetup->id,
+        'start' => now()->addWeek(),
+    ]);
+
+    $component = Livewire::test('meetups.create-edit-events', ['meetup' => $meetup, 'event' => $event]);
+
+    actingAsUser();
+
+    $component->call('delete')->assertStatus(403);
+
+    expect(MeetupEvent::query()->find($event->id))->not->toBeNull();
+});
+
 it('refuses to cancel when the caller lost the right to manage after mounting', function () {
     $organiser = actingAsUser();
     $meetup = Meetup::factory()->create(['city_id' => $this->city->id, 'created_by' => $organiser->id]);


### PR DESCRIPTION
Closes #96.

`delete()` went straight to `$this->event->delete()` while `save()` and `cancel()` both call `authorizeManage()` first.

`mount()` guards the page, and that is not the same thing: a Livewire action is a request of its own, so a component left open across a role change still dispatches `delete()`. Someone removed as a meetup leader while the edit page was open could still remove the event — and the page does not need reloading for the button to work, which is the whole point of the pattern.

Deletion is the least reversible action on this form. It was the one without the check.

The test asserts the case that distinguishes the defect — authorised at mount, unauthorised at the moment of the call. Asserting the happy path would have stayed green throughout. Mutation probe: removing the guard turns it red (`1 failed`), restoring it turns it green (`1 passed`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XfFQ18DFktM3ewnWo9Zt9X
