### PR TITLE
Bind only a country the chooser actually offers

### DIFF
--- a/resources/views/livewire/country/chooser.blade.php
+++ b/resources/views/livewire/country/chooser.blade.php
@@ -1,16 +1,72 @@
 <?php
 
 use App\Support\RegionRoutes;
+use Illuminate\Support\Collection;
 use Livewire\Component;
+use WW\Countries\Models\Country;
 
-new class extends Component {
+new class extends Component
+{
     public $currentRouteName;
+
     public $currentRouteParams;
-    public string $currentCountry = 'de';
+
+    public ?string $currentCountry = null;
+
+    /**
+     * The option values this select offers — lowercased ISO codes, in the order the
+     * list renders.
+     *
+     * Read by BOTH mount() and the view, deliberately. Issue #105 was the two sides
+     * disagreeing: the options were lowercased here while the bound value came raw
+     * off the route segment, so `/DE/meetups` bound `DE` against a list holding only
+     * `de` and Flux threw `Could not find option for value "DE"` while rendering.
+     * One source cannot drift from itself.
+     *
+     * @return Collection<int, Country>
+     */
+    public function getCountryOptionsProperty(): Collection
+    {
+        return Country::all();
+    }
+
+    /**
+     * The offered spelling of a route segment, or null when nothing is offered.
+     *
+     * Normalised on the VALUE side rather than by widening the options, for the same
+     * reason #73 chose that side: the option list is the canonical set — it is what
+     * every link this component builds points at — while the route segment is
+     * whatever a visitor typed or a link happened to carry. Since #78 made country
+     * codes case-insensitive, an uppercase segment resolves instead of 404ing, so
+     * this is now reachable rather than theoretical.
+     *
+     * null renders Flux's placeholder. updatedCurrentCountry() only fires on a real
+     * selection, so it can never redirect on the null.
+     */
+    private function offeredCountry(mixed $segment): ?string
+    {
+        if (! is_string($segment) || $segment === '') {
+            return null;
+        }
+
+        $wanted = mb_strtolower($segment);
+
+        foreach ($this->countryOptions as $country) {
+            $value = mb_strtolower((string) $country->iso_code);
+
+            if ($value === $wanted) {
+                return $value;
+            }
+        }
+
+        return null;
+    }
 
     public function mount(): void
     {
-        $this->currentCountry = request()->route('country', config('app.domain_country'));
+        $this->currentCountry = $this->offeredCountry(
+            request()->route('country', config('app.domain_country'))
+        );
         $this->currentRouteName = request()->route()->getName();
         $this->currentRouteParams = request()->route()->parameters();
     }
@@ -55,7 +111,7 @@ new class extends Component {
         <x-slot name="search">
             <flux:select.search class="px-4" placeholder="{{ __('Suche dein Land...') }}"/>
         </x-slot>
-        @foreach(\WW\Countries\Models\Country::all() as $country)
+        @foreach($this->countryOptions as $country)
             <flux:select.option value="{{ str($country->iso_code)->lower() }}">
                 <div class="flex items-center space-x-2">
                     <img alt="{{ str($country->iso_code)->lower() }}"

--- a/tests/Browser/Meetups/CountryChooserCaseTest.php
+++ b/tests/Browser/Meetups/CountryChooserCaseTest.php
@@ -1,0 +1,41 @@
+<?php
+
+use App\Models\City;
+use App\Models\Country;
+use App\Models\Meetup;
+
+/*
+ * Issue #105: the country select's options are lowercased ISO codes while the value
+ * bound to it came raw off the `{country}` route segment. Flux' `ui-selected` compares
+ * with `===`, so an uppercase segment found no option and threw
+ * `Uncaught Could not find option for value "DE"` while rendering.
+ *
+ * It only became reachable with #78: until then an uppercase segment 404'd, so the page
+ * never rendered. Case-insensitive country codes made it resolve — and exposed the select.
+ */
+beforeEach(function () {
+    $this->country = Country::factory()->create(['code' => 'de', 'name' => 'Deutschland']);
+    $this->city = City::factory()->create([
+        'country_id' => $this->country->id,
+        'name' => 'Frankfurt am Main',
+    ]);
+    $this->meetup = Meetup::factory()->create([
+        'city_id' => $this->city->id,
+        'name' => 'Issue 105 Country Chooser Meetup',
+        'slug' => 'issue-105-country-chooser',
+        'visible_on_map' => true,
+    ]);
+});
+
+it('renders the meetup list without JavaScript errors on an uppercase country segment', function (string $segment) {
+    $browser = visit('/'.$segment.'/meetups');
+
+    $browser->assertSee($this->meetup->name);
+
+    // Without this the assertion below would also hold on a page that renders no select
+    // at all — a chooser that stopped rendering must not read as "fixed".
+    expect($browser->script('document.querySelectorAll("ui-select").length'))
+        ->toBeGreaterThan(0);
+
+    $browser->assertNoJavaScriptErrors();
+})->with(['DE', 'de', 'De']);


### PR DESCRIPTION
Closes #105.

`/DE/meetups` rendered 200 and threw `Uncaught Could not find option for value "DE"`. The select's options are lowercased ISO codes; the bound value came raw off the `{country}` route segment, and Flux compares with `===`.

It only became reachable with #78 — until then an uppercase segment 404'd, so the page never rendered. Making country codes case-insensitive was right, and it exposed the select.

Fixed on the **value** side, for the reason #73 chose that side: the option list is the canonical set — it is what every link this component builds points at — while the route segment is whatever a visitor typed or a link happened to carry.

**The deeper fix is that both sides now read one source.** The options were built inline in the view from `Country::all()` while `mount()` went to the route; a `$this->countryOptions` accessor now feeds both. That drift was the defect, not the casing.

An unoffered segment binds `null`, which renders Flux's placeholder. `updatedCurrentCountry()` only fires on a real selection, so it can never redirect on the null.

The test drives a real browser on `/DE/meetups`, `/de/meetups` and `/De/meetups`, with a guard that the page still renders a `ui-select` at all — a chooser that stopped rendering must not read as "fixed". Reverting the normalisation reddens exactly the two uppercase cases and leaves the lowercase one green.

Neighbouring suites: 623 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XfFQ18DFktM3ewnWo9Zt9X
