### PR TITLE
Expose meetup event tags through the MCP tools

### DIFF
--- a/app/Mcp/Servers/EinundzwanzigServer.php
+++ b/app/Mcp/Servers/EinundzwanzigServer.php
@@ -25,6 +25,7 @@ use App\Mcp\Tools\MeetupEvent\ListMyMeetupEventsTool;
 use App\Mcp\Tools\MeetupEvent\ShowMyMeetupEventTool;
 use App\Mcp\Tools\MeetupEvent\UpdateMeetupEventTool;
 use App\Mcp\Tools\Search\ListCountriesTool;
+use App\Mcp\Tools\Search\ListEventTagsTool;
 use App\Mcp\Tools\Search\SearchCitiesTool;
 use App\Mcp\Tools\Search\SearchCoursesTool;
 use App\Mcp\Tools\Search\SearchLecturersTool;
@@ -151,6 +152,7 @@ class EinundzwanzigServer extends Server
         SearchLecturersTool::class,
         SearchCoursesTool::class,
         ListCountriesTool::class,
+        ListEventTagsTool::class,
 
         // Super-Admin: generische Tools für ALLE Models (nur für Super-Admins sichtbar,
         // via shouldRegister; created_by/Ownership-Beschränkungen entfallen hier bewusst).

--- a/app/Mcp/Tools/Concerns/ResolvesEventTags.php
+++ b/app/Mcp/Tools/Concerns/ResolvesEventTags.php
@@ -1,0 +1,193 @@
+<?php
+
+namespace App\Mcp\Tools\Concerns;
+
+use App\Models\MeetupEvent;
+use App\Models\Tag;
+use App\Models\User;
+use App\Support\TagLocales;
+use Illuminate\Contracts\Auth\Authenticatable;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Collection;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+
+/**
+ * Resolves meetup-event tags by NAME for the MCP write tools (issue #117).
+ *
+ * Three rules hold this together, and all three are load-bearing.
+ *
+ * 1. NOTHING IS EVER CREATED. Every spatie write path — attachTags(), syncTags(),
+ *    syncTagsWithType(), even the `tags` mass-assignment mutator on HasTags — routes
+ *    unknown strings through Tag::findOrCreate() and invents a tag for anything it
+ *    cannot find. An LLM caller guessing at names would be a duplicate generator no
+ *    approval queue catches, and creating a tag is the one irreversible move in this
+ *    feature. So names are resolved HERE and handed on as Tag MODELS; findOrCreate()
+ *    returns a model it was given untouched, which is what makes the sync in the
+ *    calling tool incapable of creating.
+ * 2. ONLY WHAT THE PICKER OFFERS. The lookup runs through Tag::scopeSelectableBy(),
+ *    the same scope resources/views/livewire/tags/picker.blade.php uses, for the
+ *    reason that file states: a crafted request must not be able to attach someone
+ *    else's unapproved suggestion. An MCP call is exactly such a request path. A tag
+ *    outside the scope therefore reads as "not found" rather than "not allowed" —
+ *    the caller could not have picked it either way, and the wording does not
+ *    disclose another user's pending suggestion.
+ * 3. ALL OR NOTHING. A list is resolved completely before the caller writes anything.
+ *    Half an applied tag list is worse than a rejected one, because the caller has no
+ *    way to tell which half arrived.
+ *
+ * Matching is case-insensitive across all nine tag locales and scoped to the
+ * `meetup_event` type — the shape of findByAnyLocale() in the picker. It deliberately
+ * does NOT go through Tag::displayName(): since a tag may legitimately carry only one
+ * locale, displayName() would answer with a fallback language, and a name the tag does
+ * not actually have would start matching.
+ */
+trait ResolvesEventTags
+{
+    /**
+     * The tag group an event's tags belong to. A tag never crosses groups, so this is
+     * also what keeps the 35 cross-type name collisions in the curated vocabulary
+     * (`Einsteiger` in meetup_event vs. library_item, `Bitcoin` in meetup_event vs.
+     * course) out of the way: within meetup_event there are none.
+     */
+    protected const EVENT_TAG_TYPE = 'meetup_event';
+
+    /**
+     * The `tags` argument in the three states #117 defines.
+     *
+     * - key absent  → null, "leave the tags alone"
+     * - `null`      → null as well, see below
+     * - `[]`        → an empty collection, "remove every tag"
+     * - `["a","b"]` → the resolved tags, to be applied as the complete new set
+     *
+     * An explicit `null` reads as "not given", never as "no tags". That is the rule
+     * this repo already carries on `links` ({@see MeetupEvent::booted()}),
+     * and issue #70 is the reason it is spelled out rather than assumed: Laravel's
+     * `sometimes` counts an explicitly sent null as PRESENT, so a null sailed through
+     * validation and emptied a stored list of five labelled entries. MCP has no
+     * FormRequest in the path at all and its JSON schema makes `null` reachable for
+     * any property, so the same input has to be answered here — and answered in the
+     * non-destructive direction.
+     *
+     * @return Collection<int, Tag>|Response|null
+     */
+    protected function resolveTagArgument(Request $request): Collection|Response|null
+    {
+        $arguments = $request->toArray();
+
+        if (! array_key_exists('tags', $arguments) || $arguments['tags'] === null) {
+            return null;
+        }
+
+        $names = $arguments['tags'];
+
+        if (! is_array($names)) {
+            return Response::error('"tags" muss eine Liste von Tag-Namen sein, z. B. ["Vortrag", "Einsteiger"]. Die verfügbaren Namen liefert list-event-tags.');
+        }
+
+        return $this->resolveEventTags($names, $request->user());
+    }
+
+    /**
+     * Turns a list of names into the tags they name, or into the error that says why
+     * it could not be done. Never returns a partial list.
+     *
+     * @param  array<array-key, mixed>  $names
+     * @return Collection<int, Tag>|Response
+     */
+    protected function resolveEventTags(array $names, ?Authenticatable $user): Collection|Response
+    {
+        /** @var array<int, array{given: string, needle: string}> $requested */
+        $requested = [];
+
+        foreach ($names as $name) {
+            if (! is_string($name)) {
+                return Response::error('"tags" muss eine Liste von Tag-Namen (Text) sein, z. B. ["Vortrag", "Einsteiger"]. Die verfügbaren Namen liefert list-event-tags.');
+            }
+
+            $given = $this->normalisedTagName($name);
+
+            if ($given === '') {
+                return Response::error('Ein leerer Eintrag in "tags" ist kein Tag. Bitte den Eintrag weglassen — oder [] senden, um alle Tags zu entfernen.');
+            }
+
+            $requested[] = ['given' => $given, 'needle' => mb_strtolower($given)];
+        }
+
+        $candidates = $this->selectableEventTags($user)->get();
+
+        /** @var Collection<int, Tag> $resolved */
+        $resolved = collect();
+
+        foreach ($requested as ['given' => $given, 'needle' => $needle]) {
+            $matches = $candidates
+                ->filter(fn (Tag $tag): bool => $this->tagCarriesName($tag, $needle))
+                ->values();
+
+            if ($matches->isEmpty()) {
+                return Response::error("Tag \"{$given}\" wurde nicht gefunden. Es wurde NICHTS geändert und es wird kein Tag neu angelegt — bitte list-event-tags aufrufen und einen der dort genannten Namen verwenden (jede der neun Sprachen wird erkannt).");
+            }
+
+            if ($matches->count() > 1) {
+                /*
+                 * Never a silent first hit. Today the vocabulary has no collision
+                 * inside meetup_event (0 across 112 distinct name strings for 16 tags),
+                 * so this branch is unreachable through the seeded data — but a tag is
+                 * user-editable, and the day two of them share a word in any of the
+                 * nine languages, picking whichever the database returned first would
+                 * attach a tag nobody asked for.
+                 */
+                $kandidaten = $matches
+                    ->map(fn (Tag $tag): string => '#'.$tag->getKey().' '.$tag->displayName())
+                    ->join('; ');
+
+                return Response::error("Mehrere Tags passen zu \"{$given}\": {$kandidaten}. Es wurde NICHTS geändert — bitte den Namen in einer Sprache angeben, in der er eindeutig ist (siehe list-event-tags).");
+            }
+
+            $resolved->push($matches->first());
+        }
+
+        return $resolved->unique(fn (Tag $tag) => $tag->getKey())->values();
+    }
+
+    /**
+     * Every tag this user may attach to an event: the `meetup_event` group, filtered
+     * by the picker's own scope. Shared with list-event-tags so the tool that offers
+     * the vocabulary and the resolver that accepts it can never drift apart.
+     */
+    protected function selectableEventTags(?Authenticatable $user): Builder
+    {
+        return Tag::query()
+            ->where('type', self::EVENT_TAG_TYPE)
+            // Anything that is not a User is treated as nobody, which yields the
+            // approved tags only — the restrictive answer, not the permissive one.
+            ->selectableBy($user instanceof User ? $user : null);
+    }
+
+    /**
+     * Whether the tag carries this (already lower-cased and whitespace-normalised)
+     * name in any of the nine tag locales.
+     */
+    private function tagCarriesName(Tag $tag, string $needle): bool
+    {
+        foreach (TagLocales::all() as $locale) {
+            $name = (string) $tag->getTranslation('name', $locale, false);
+
+            if ($name !== '' && mb_strtolower($this->normalisedTagName($name)) === $needle) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Trimmed, with runs of whitespace collapsed — the same normalisation the picker
+     * applies before it stores a name, so what an organiser typed there and what an
+     * agent sends here compare equal.
+     */
+    private function normalisedTagName(string $name): string
+    {
+        return trim(preg_replace('/\s+/u', ' ', $name) ?? '');
+    }
+}

--- a/app/Mcp/Tools/MeetupEvent/CreateMeetupEventTool.php
+++ b/app/Mcp/Tools/MeetupEvent/CreateMeetupEventTool.php
@@ -6,6 +6,7 @@ use App\Actions\MeetupEvents\CreateMeetupEventSeries;
 use App\Http\Requests\Api\StoreMeetupEventRequest;
 use App\Http\Resources\MeetupEventResource;
 use App\Mcp\Tools\Concerns\ResolvesEntities;
+use App\Mcp\Tools\Concerns\ResolvesEventTags;
 use App\Models\Meetup;
 use App\Models\MeetupEvent;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
@@ -20,6 +21,7 @@ use Laravel\Mcp\Server\Tool;
 class CreateMeetupEventTool extends Tool
 {
     use ResolvesEntities;
+    use ResolvesEventTags;
 
     public function __construct(private readonly CreateMeetupEventSeries $createSeries) {}
 
@@ -63,6 +65,25 @@ class CreateMeetupEventTool extends Tool
         );
 
         /*
+         * Tags are resolved BEFORE anything is written, and they are resolved in the
+         * tool rather than in StoreMeetupEventRequest (issue #117).
+         *
+         * The request object is shared with the public REST API, so a `tags` rule there
+         * would hand that API a new write capability as a side effect of an MCP ticket.
+         * Keeping it out also means `tags` never appears in $validated — Validator only
+         * returns keys it has a rule for — and that is what keeps the name list away
+         * from MeetupEvent::create() below. It matters: HasTags::setTagsAttribute()
+         * would queue the raw strings and the `created` hook would push them through
+         * Tag::findOrCreate() with a null type, inventing a tag per unknown name. This
+         * feature must never create a tag.
+         */
+        $tags = $this->resolveTagArgument($request);
+
+        if ($tags instanceof Response) {
+            return $tags;
+        }
+
+        /*
          * Serie oder Einzeltermin — dieselbe Weiche wie in
          * {@see \App\Http\Controllers\Api\MeetupEventController::store()}.
          *
@@ -78,12 +99,30 @@ class CreateMeetupEventTool extends Tool
         if (! empty($validated['recurrence_type']) && ! empty($validated['recurrence_end_date'])) {
             $events = $this->createSeries->handle($validated);
 
+            // Every occurrence of a series carries the same tags — the same rule the
+            // Livewire editor follows, where one selection is applied to the whole
+            // series rather than to its first date only.
+            $events->each(function (MeetupEvent $event) use ($tags): void {
+                if ($tags !== null) {
+                    $event->syncTagsWithType($tags->all(), self::EVENT_TAG_TYPE);
+                }
+
+                $event->load('tags');
+            });
+
             return Response::json(MeetupEventResource::collection($events)->resolve());
         }
 
         $meetupEvent = MeetupEvent::create($validated);
 
-        return Response::json(MeetupEventResource::make($meetupEvent->fresh())->resolve());
+        if ($tags !== null) {
+            $meetupEvent->syncTagsWithType($tags->all(), self::EVENT_TAG_TYPE);
+        }
+
+        // load('tags') so the answer shows what was actually attached: the resource
+        // emits tags under whenLoaded(), so without it the key would be absent and the
+        // caller could not tell "no tags" from "this tool does not do tags".
+        return Response::json(MeetupEventResource::make($meetupEvent->fresh()->load('tags'))->resolve());
     }
 
     /**
@@ -100,6 +139,7 @@ class CreateMeetupEventTool extends Tool
             'location' => $schema->string()->description('Veranstaltungsort.'),
             'description' => $schema->string()->description('Beschreibung des Termins.'),
             'link' => $schema->string()->description('Link zum Termin (URL).'),
+            'tags' => $schema->array()->items($schema->string())->description('Themen-Tags dieses Termins, als NAMEN (z. B. ["Vortrag", "Einsteiger"]). Zulässig sind ausschließlich die Namen aus list-event-tags; erkannt wird jede der neun Sprachen, Groß-/Kleinschreibung egal. Ein unbekannter oder mehrdeutiger Name wird abgelehnt und es wird NIE ein Tag neu angelegt — dann bricht der ganze Aufruf ab, es entsteht kein Termin. Bei einer Serie erhalten alle Vorkommen dieselben Tags.'),
             'recurrence_type' => $schema->string()->description('Wiederholungstyp.'),
             'recurrence_day_of_week' => $schema->string()->description('Wochentag der Wiederholung.'),
             'recurrence_day_position' => $schema->string()->description('Position des Wochentags im Monat.'),

--- a/app/Mcp/Tools/MeetupEvent/ListMyMeetupEventsTool.php
+++ b/app/Mcp/Tools/MeetupEvent/ListMyMeetupEventsTool.php
@@ -23,7 +23,15 @@ class ListMyMeetupEventsTool extends Tool
             return Response::error('Nicht authentifiziert.');
         }
 
+        /*
+         * `with('tags')` is what makes the tags appear at all (issue #117).
+         * MeetupEventResource emits them under whenLoaded(), so an unloaded relation
+         * is not an empty list on the wire -- the key is absent entirely, and a caller
+         * cannot tell "no tags" from "tags were never fetched". Eager-loading here also
+         * keeps this a two-query read instead of one per event.
+         */
         $meetupEvents = MeetupEvent::query()
+            ->with('tags')
             ->editableBy((int) $user->getAuthIdentifier())
             ->orderByDesc('start')
             ->get();

--- a/app/Mcp/Tools/MeetupEvent/ShowMyMeetupEventTool.php
+++ b/app/Mcp/Tools/MeetupEvent/ShowMyMeetupEventTool.php
@@ -31,7 +31,10 @@ class ShowMyMeetupEventTool extends Tool
             return Response::error('Nur der Ersteller oder ein Super-Admin darf diesen Meetup-Termin sehen.');
         }
 
-        return Response::json(MeetupEventResource::make($meetupEvent)->resolve());
+        // load('tags') is what makes the tags appear at all (issue #117):
+        // MeetupEventResource emits them under whenLoaded(), so without it the key is
+        // absent rather than empty, and a caller cannot tell "no tags" from "not fetched".
+        return Response::json(MeetupEventResource::make($meetupEvent->load('tags'))->resolve());
     }
 
     /**

--- a/app/Mcp/Tools/MeetupEvent/UpdateMeetupEventTool.php
+++ b/app/Mcp/Tools/MeetupEvent/UpdateMeetupEventTool.php
@@ -5,6 +5,7 @@ namespace App\Mcp\Tools\MeetupEvent;
 use App\Http\Requests\Api\UpdateMeetupEventRequest;
 use App\Http\Resources\MeetupEventResource;
 use App\Mcp\Tools\Concerns\ResolvesEntities;
+use App\Mcp\Tools\Concerns\ResolvesEventTags;
 use App\Models\Meetup;
 use App\Models\MeetupEvent;
 use Illuminate\Contracts\JsonSchema\JsonSchema;
@@ -19,6 +20,7 @@ use Laravel\Mcp\Server\Tool;
 class UpdateMeetupEventTool extends Tool
 {
     use ResolvesEntities;
+    use ResolvesEventTags;
 
     public function handle(Request $request): Response
     {
@@ -40,9 +42,36 @@ class UpdateMeetupEventTool extends Tool
 
         $validated = $request->validate((new UpdateMeetupEventRequest)->rules());
 
+        /*
+         * Resolved BEFORE the update, so a name that cannot be resolved leaves the
+         * event exactly as it was — a half-applied tag list is worse than a rejected
+         * one, and so is an event whose other fields moved while its tags did not.
+         *
+         * Resolution lives here and not in UpdateMeetupEventRequest because that
+         * request is shared with the public REST API: a `tags` rule there would give
+         * that API a new write capability as a side effect of an MCP ticket. The REST
+         * API therefore still cannot write tags.
+         *
+         * null means "leave the tags alone" — both when the key is missing and when it
+         * is explicitly null. See {@see ResolvesEventTags::resolveTagArgument()} for
+         * why the null case is spelled out rather than left to `sometimes` (issue #70).
+         */
+        $tags = $this->resolveTagArgument($request);
+
+        if ($tags instanceof Response) {
+            return $tags;
+        }
+
         $meetupEvent->update($validated);
 
-        return Response::json(MeetupEventResource::make($meetupEvent->fresh())->resolve());
+        if ($tags !== null) {
+            // Replaces the whole set in one step, scoped to the event tag group so
+            // tags of any other type on this event stay untouched. An empty collection
+            // is therefore "remove every tag", not "do nothing".
+            $meetupEvent->syncTagsWithType($tags->all(), self::EVENT_TAG_TYPE);
+        }
+
+        return Response::json(MeetupEventResource::make($meetupEvent->fresh()->load('tags'))->resolve());
     }
 
     /**
@@ -60,6 +89,7 @@ class UpdateMeetupEventTool extends Tool
             'location' => $schema->string()->description('Veranstaltungsort.'),
             'description' => $schema->string()->description('Beschreibung des Termins.'),
             'link' => $schema->string()->description('Link zum Termin (URL).'),
+            'tags' => $schema->array()->items($schema->string())->description('Ersetzt die Themen-Tags des Termins VOLLSTÄNDIG, als NAMEN (z. B. ["Vortrag", "Einsteiger"]). Weglassen lässt die bestehenden Tags unverändert; [] entfernt alle. Zulässig sind ausschließlich die Namen aus list-event-tags; erkannt wird jede der neun Sprachen, Groß-/Kleinschreibung egal. Ein unbekannter oder mehrdeutiger Name wird abgelehnt, der Termin bleibt dabei unverändert, und es wird NIE ein Tag neu angelegt.'),
             'recurrence_type' => $schema->string()->description('Wiederholungstyp.'),
             'recurrence_day_of_week' => $schema->string()->description('Wochentag der Wiederholung.'),
             'recurrence_day_position' => $schema->string()->description('Position des Wochentags im Monat.'),

--- a/app/Mcp/Tools/Search/ListEventTagsTool.php
+++ b/app/Mcp/Tools/Search/ListEventTagsTool.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Mcp\Tools\Search;
+
+use App\Http\Resources\TagResource;
+use App\Mcp\Tools\Concerns\ResolvesEventTags;
+use Illuminate\Contracts\JsonSchema\JsonSchema;
+use Illuminate\JsonSchema\Types\Type;
+use Laravel\Mcp\Request;
+use Laravel\Mcp\Response;
+use Laravel\Mcp\Server\Attributes\Description;
+use Laravel\Mcp\Server\Tool;
+use Laravel\Mcp\Server\Tools\Annotations\IsReadOnly;
+
+/**
+ * The whole event-tag vocabulary in one call (issue #117).
+ *
+ * A FLAT LIST, NOT A SEARCH. The `meetup_event` group holds sixteen tags; a search
+ * parameter would cost a round trip and could still answer with a name the caller then
+ * has to guess a spelling for. {@see ListCountriesTool} is the existing precedent for
+ * a lookup tool that simply hands over its list.
+ *
+ * Every entry carries `translations`, the tag's name in each language it has, because
+ * that is what create-meetup-event and update-meetup-event match against — any of the
+ * nine, case-insensitively. An agent that read this list can therefore always pick a
+ * name that resolves, which is the point: unknown names are refused, never created.
+ *
+ * The list is the picker's list. It runs through the same scope the resolver uses
+ * ({@see ResolvesEventTags::selectableEventTags()}), so a tag offered here is by
+ * construction a tag that can be attached, and one that cannot be attached is not
+ * offered.
+ */
+#[IsReadOnly]
+#[Description('Listet alle Tags, die einem Meetup-Termin zugeordnet werden können (Gruppe "meetup_event", 16 Einträge, keine Suche nötig). Jeder Eintrag enthält id, name, locale, featured, approved und unter "translations" den Namen in jeder vorhandenen der neun Sprachen. Genau diese Namen akzeptieren create-meetup-event und update-meetup-event im Feld "tags"; ein anderer Name wird abgelehnt und NIE neu angelegt.')]
+class ListEventTagsTool extends Tool
+{
+    use ResolvesEventTags;
+
+    public function handle(Request $request): Response
+    {
+        $tags = $this->selectableEventTags($request->user())
+            // `ordered()` is the moderation screen's sequence (tags.order_column) and
+            // sortByDesc('featured') lifts the curated block to the top — the same two
+            // steps the picker takes, so an agent sees the vocabulary in the order a
+            // human organiser does. PHP's sort is stable, so the sequence survives
+            // inside each block.
+            ->ordered()
+            ->get()
+            ->sortByDesc('featured')
+            ->values();
+
+        return Response::json(TagResource::collection($tags)->resolve());
+    }
+
+    /**
+     * No parameters: sixteen entries are the whole answer.
+     *
+     * @return array<string, Type>
+     */
+    public function schema(JsonSchema $schema): array
+    {
+        return [];
+    }
+}

--- a/app/Support/TagLocales.php
+++ b/app/Support/TagLocales.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace App\Support;
+
+/**
+ * The languages a tag can carry, and which one the current request writes into.
+ *
+ * The list itself lives in config/einundzwanzig.tag_locales. What this class adds is
+ * the resolution rule: the request's locale is only usable as a tag locale if the tag
+ * vocabulary actually has that language. Without the check a visitor browsing in a
+ * language outside the nine would write a name into a locale the picker never reads —
+ * invisible everywhere, and impossible to find again.
+ *
+ * Extracted from tags.moderation, which already resolved it this way for the
+ * description field; the picker needs the same answer for `tags.source_locale`, and
+ * two copies of a rule like this drift.
+ */
+class TagLocales
+{
+    /**
+     * @return array<int, string>
+     */
+    public static function all(): array
+    {
+        return array_values(array_filter(
+            (array) config('einundzwanzig.tag_locales', []),
+            static fn ($locale): bool => is_string($locale) && $locale !== ''
+        ));
+    }
+
+    /**
+     * The tag locale this request reads and writes: the current language when the
+     * vocabulary has it, the app's fallback when it has that, else the first configured.
+     */
+    public static function current(): string
+    {
+        $locales = self::all();
+        $current = app()->getLocale();
+
+        if (in_array($current, $locales, true)) {
+            return $current;
+        }
+
+        $fallback = (string) config('app.fallback_locale');
+
+        return in_array($fallback, $locales, true) ? $fallback : (string) ($locales[0] ?? 'de');
+    }
+}

--- a/database/migrations/2026_09_05_155536_add_source_locale_to_tags_table.php
+++ b/database/migrations/2026_09_05_155536_add_source_locale_to_tags_table.php
@@ -1,0 +1,53 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Records the language a tag name was actually written in.
+ *
+ * The picker used to write the typed name into all nine tag locales, which made
+ * `Tag::isDisplayNameSubstituted()` permanently false for every tag created that way:
+ * the tag carried a name in the reader's language, so nothing looked substituted, and
+ * the picker's "only available in :lang" line could never fire. Measured on production
+ * on 2026-09-05, three of the ninety-four tags were in that state — among them the
+ * Czech `Rodiny s dětmi`, stored as the German, English, Spanish, Hungarian, Latvian,
+ * Dutch, Polish and Portuguese name too.
+ *
+ * WHAT NULL MEANS HERE, AND WHY EVERY EXISTING ROW KEEPS IT: null is "no source
+ * language was recorded", nothing more. It is deliberately NOT backfilled.
+ *
+ *   - A seeded row (`created_by` is null) carries nine curated translations from
+ *     database/seeders/data/tags.php. Its source language is German by construction,
+ *     but no code reads the column for those rows, so writing it would only add a
+ *     claim nobody checks.
+ *   - A runtime row (`created_by` is set) carries nine copies of one string, and which
+ *     of the nine languages that string is in exists nowhere in the database — the
+ *     picker never recorded it. That is the defect itself. Any backfill would have to
+ *     guess, and the guess is not silent: `displayLocale()` shows the recorded language
+ *     to every reader ("only available in DE"), so a wrong guess turns today's missing
+ *     warning into a confident false one.
+ *
+ * The eight copied names on those runtime rows are therefore left alone too. They are
+ * repaired by a human through the per-locale name editor in tags.moderation, which is
+ * the only place the missing fact — which language the word is in — is available.
+ */
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('tags', function (Blueprint $table) {
+            $table->string('source_locale', 8)
+                ->nullable()
+                ->after('type');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('tags', function (Blueprint $table) {
+            $table->dropColumn('source_locale');
+        });
+    }
+};

--- a/lang/cs.json
+++ b/lang/cs.json
@@ -901,5 +901,10 @@
     "Event absagen": "Zrušit událost",
     "Abgesagt": "Zrušeno",
     "Dieses Event wirklich absagen? Kalender-Abonnenten erhalten die Absage.": "Opravdu zrušit tuto událost? Odběratelé kalendáře dostanou informaci o zrušení.",
-    "Event abgesagt. Abonnenten des Kalenders werden informiert.": "Událost zrušena. Odběratelé kalendáře budou informováni."
+    "Event abgesagt. Abonnenten des Kalenders werden informiert.": "Událost zrušena. Odběratelé kalendáře budou informováni.",
+    "Name (:lang)": "Název (:lang)",
+    "Leer lassen heißt: in dieser Sprache nicht vorhanden.": "Prázdné pole znamená: v tomto jazyce název neexistuje.",
+    "Fehlt in: :langs": "Chybí v: :langs",
+    "Mindestens eine Sprache muss einen Namen tragen.": "Alespoň jeden jazyk musí mít název.",
+    "Alle Sprachen tragen denselben Namen — vermutlich vom alten Picker kopiert. Lösche die Sprachen, in denen er nicht steht.": "Všechny jazyky mají stejný název — pravděpodobně jej zkopíroval starý výběr. Smaž jazyky, ve kterých takto nezní."
 }

--- a/lang/de.json
+++ b/lang/de.json
@@ -901,5 +901,10 @@
     "Event absagen": "Event absagen",
     "Abgesagt": "Abgesagt",
     "Dieses Event wirklich absagen? Kalender-Abonnenten erhalten die Absage.": "Dieses Event wirklich absagen? Kalender-Abonnenten erhalten die Absage.",
-    "Event abgesagt. Abonnenten des Kalenders werden informiert.": "Event abgesagt. Abonnenten des Kalenders werden informiert."
+    "Event abgesagt. Abonnenten des Kalenders werden informiert.": "Event abgesagt. Abonnenten des Kalenders werden informiert.",
+    "Name (:lang)": "",
+    "Leer lassen heißt: in dieser Sprache nicht vorhanden.": "",
+    "Fehlt in: :langs": "",
+    "Mindestens eine Sprache muss einen Namen tragen.": "",
+    "Alle Sprachen tragen denselben Namen — vermutlich vom alten Picker kopiert. Lösche die Sprachen, in denen er nicht steht.": ""
 }

--- a/lang/en.json
+++ b/lang/en.json
@@ -901,5 +901,10 @@
     "Event absagen": "Cancel event",
     "Abgesagt": "Cancelled",
     "Dieses Event wirklich absagen? Kalender-Abonnenten erhalten die Absage.": "Really cancel this event? Calendar subscribers will receive the cancellation.",
-    "Event abgesagt. Abonnenten des Kalenders werden informiert.": "Event cancelled. Calendar subscribers will be notified."
+    "Event abgesagt. Abonnenten des Kalenders werden informiert.": "Event cancelled. Calendar subscribers will be notified.",
+    "Name (:lang)": "Name (:lang)",
+    "Leer lassen heißt: in dieser Sprache nicht vorhanden.": "Leave it empty to say the tag has no name in that language.",
+    "Fehlt in: :langs": "Missing in: :langs",
+    "Mindestens eine Sprache muss einen Namen tragen.": "At least one language must carry a name.",
+    "Alle Sprachen tragen denselben Namen — vermutlich vom alten Picker kopiert. Lösche die Sprachen, in denen er nicht steht.": "Every language carries the same name — probably copied by the old picker. Delete the languages it is not written in."
 }

--- a/lang/es.json
+++ b/lang/es.json
@@ -901,5 +901,10 @@
     "Event absagen": "Cancelar evento",
     "Abgesagt": "Cancelado",
     "Dieses Event wirklich absagen? Kalender-Abonnenten erhalten die Absage.": "¿Cancelar de verdad este evento? Los suscriptores del calendario recibirán la cancelación.",
-    "Event abgesagt. Abonnenten des Kalenders werden informiert.": "Evento cancelado. Se informará a los suscriptores del calendario."
+    "Event abgesagt. Abonnenten des Kalenders werden informiert.": "Evento cancelado. Se informará a los suscriptores del calendario.",
+    "Name (:lang)": "Nombre (:lang)",
+    "Leer lassen heißt: in dieser Sprache nicht vorhanden.": "Dejarlo vacío significa: no existe en ese idioma.",
+    "Fehlt in: :langs": "Falta en: :langs",
+    "Mindestens eine Sprache muss einen Namen tragen.": "Al menos un idioma debe tener un nombre.",
+    "Alle Sprachen tragen denselben Namen — vermutlich vom alten Picker kopiert. Lösche die Sprachen, in denen er nicht steht.": "Todos los idiomas tienen el mismo nombre — probablemente copiado por el selector antiguo. Borra los idiomas en los que no se escribe así."
 }

--- a/lang/hu.json
+++ b/lang/hu.json
@@ -901,5 +901,10 @@
     "Event absagen": "Esemény lemondása",
     "Abgesagt": "Lemondva",
     "Dieses Event wirklich absagen? Kalender-Abonnenten erhalten die Absage.": "Biztosan lemondod ezt az eseményt? A naptárra feliratkozók megkapják a lemondást.",
-    "Event abgesagt. Abonnenten des Kalenders werden informiert.": "Esemény lemondva. A naptár feliratkozói értesítést kapnak."
+    "Event abgesagt. Abonnenten des Kalenders werden informiert.": "Esemény lemondva. A naptár feliratkozói értesítést kapnak.",
+    "Name (:lang)": "Név (:lang)",
+    "Leer lassen heißt: in dieser Sprache nicht vorhanden.": "Az üresen hagyott mező azt jelenti: ezen a nyelven nincs név.",
+    "Fehlt in: :langs": "Hiányzik: :langs",
+    "Mindestens eine Sprache muss einen Namen tragen.": "Legalább egy nyelven meg kell adni a nevet.",
+    "Alle Sprachen tragen denselben Namen — vermutlich vom alten Picker kopiert. Lösche die Sprachen, in denen er nicht steht.": "Minden nyelven ugyanaz a név szerepel — valószínűleg a régi választó másolta be. Töröld azokat a nyelveket, amelyeken nem így hangzik."
 }

--- a/lang/lv.json
+++ b/lang/lv.json
@@ -901,5 +901,10 @@
     "Event absagen": "Atcelt pasākumu",
     "Abgesagt": "Atcelts",
     "Dieses Event wirklich absagen? Kalender-Abonnenten erhalten die Absage.": "Tiešām atcelt šo pasākumu? Kalendāra abonenti saņems atcelšanas paziņojumu.",
-    "Event abgesagt. Abonnenten des Kalenders werden informiert.": "Pasākums atcelts. Kalendāra abonenti tiks informēti."
+    "Event abgesagt. Abonnenten des Kalenders werden informiert.": "Pasākums atcelts. Kalendāra abonenti tiks informēti.",
+    "Name (:lang)": "Nosaukums (:lang)",
+    "Leer lassen heißt: in dieser Sprache nicht vorhanden.": "Tukšs lauks nozīmē: šajā valodā nosaukuma nav.",
+    "Fehlt in: :langs": "Trūkst: :langs",
+    "Mindestens eine Sprache muss einen Namen tragen.": "Vismaz vienā valodā jābūt nosaukumam.",
+    "Alle Sprachen tragen denselben Namen — vermutlich vom alten Picker kopiert. Lösche die Sprachen, in denen er nicht steht.": "Visās valodās ir viens un tas pats nosaukums — visticamāk, to nokopēja vecais atlasītājs. Dzēs valodas, kurās tas tā neskan."
 }

--- a/lang/nl.json
+++ b/lang/nl.json
@@ -901,5 +901,10 @@
     "Event absagen": "Evenement annuleren",
     "Abgesagt": "Geannuleerd",
     "Dieses Event wirklich absagen? Kalender-Abonnenten erhalten die Absage.": "Dit evenement echt annuleren? Agenda-abonnees ontvangen de annulering.",
-    "Event abgesagt. Abonnenten des Kalenders werden informiert.": "Evenement geannuleerd. Abonnees van de agenda worden geïnformeerd."
+    "Event abgesagt. Abonnenten des Kalenders werden informiert.": "Evenement geannuleerd. Abonnees van de agenda worden geïnformeerd.",
+    "Name (:lang)": "Naam (:lang)",
+    "Leer lassen heißt: in dieser Sprache nicht vorhanden.": "Leeg laten betekent: niet aanwezig in die taal.",
+    "Fehlt in: :langs": "Ontbreekt in: :langs",
+    "Mindestens eine Sprache muss einen Namen tragen.": "Minstens één taal moet een naam hebben.",
+    "Alle Sprachen tragen denselben Namen — vermutlich vom alten Picker kopiert. Lösche die Sprachen, in denen er nicht steht.": "Alle talen dragen dezelfde naam — waarschijnlijk gekopieerd door de oude kiezer. Verwijder de talen waarin hij niet zo luidt."
 }

--- a/lang/pl.json
+++ b/lang/pl.json
@@ -901,5 +901,10 @@
     "Event absagen": "Odwołaj wydarzenie",
     "Abgesagt": "Odwołane",
     "Dieses Event wirklich absagen? Kalender-Abonnenten erhalten die Absage.": "Na pewno odwołać to wydarzenie? Subskrybenci kalendarza otrzymają informację o odwołaniu.",
-    "Event abgesagt. Abonnenten des Kalenders werden informiert.": "Wydarzenie odwołane. Subskrybenci kalendarza zostaną poinformowani."
+    "Event abgesagt. Abonnenten des Kalenders werden informiert.": "Wydarzenie odwołane. Subskrybenci kalendarza zostaną poinformowani.",
+    "Name (:lang)": "Nazwa (:lang)",
+    "Leer lassen heißt: in dieser Sprache nicht vorhanden.": "Puste pole oznacza: w tym języku nazwa nie istnieje.",
+    "Fehlt in: :langs": "Brakuje w: :langs",
+    "Mindestens eine Sprache muss einen Namen tragen.": "Przynajmniej jeden język musi mieć nazwę.",
+    "Alle Sprachen tragen denselben Namen — vermutlich vom alten Picker kopiert. Lösche die Sprachen, in denen er nicht steht.": "Wszystkie języki mają tę samą nazwę — prawdopodobnie skopiował ją stary selektor. Usuń języki, w których tak nie brzmi."
 }

--- a/lang/pt.json
+++ b/lang/pt.json
@@ -901,5 +901,10 @@
     "Event absagen": "Cancelar evento",
     "Abgesagt": "Cancelado",
     "Dieses Event wirklich absagen? Kalender-Abonnenten erhalten die Absage.": "Cancelar mesmo este evento? Os subscritores do calendário recebem o cancelamento.",
-    "Event abgesagt. Abonnenten des Kalenders werden informiert.": "Evento cancelado. Os subscritores do calendário serão notificados."
+    "Event abgesagt. Abonnenten des Kalenders werden informiert.": "Evento cancelado. Os subscritores do calendário serão notificados.",
+    "Name (:lang)": "Nome (:lang)",
+    "Leer lassen heißt: in dieser Sprache nicht vorhanden.": "Deixar vazio significa: não existe nesse idioma.",
+    "Fehlt in: :langs": "Falta em: :langs",
+    "Mindestens eine Sprache muss einen Namen tragen.": "Pelo menos um idioma tem de ter um nome.",
+    "Alle Sprachen tragen denselben Namen — vermutlich vom alten Picker kopiert. Lösche die Sprachen, in denen er nicht steht.": "Todos os idiomas têm o mesmo nome — provavelmente copiado pelo seletor antigo. Apaga os idiomas em que não se escreve assim."
 }

--- a/resources/views/livewire/tags/moderation.blade.php
+++ b/resources/views/livewire/tags/moderation.blade.php
@@ -2,6 +2,7 @@
 
 use App\Models\Tag;
 use App\Support\TagEditorGate;
+use App\Support\TagLocales;
 use App\Traits\SeoTrait;
 use Illuminate\Support\Collection;
 use Illuminate\Validation\Rule;
@@ -65,6 +66,22 @@ new class extends Component
     public string $editIcon = 'tag';
 
     public string $editDescription = '';
+
+    /**
+     * locale => name, one entry per tag locale, empty where the tag has no name.
+     *
+     * All nine at once, unlike `editDescription`, which edits only the request's
+     * language. A description is prose somebody has to write; a name is the thing the
+     * picker matches on in every language, and filling the eight missing ones is the
+     * job this screen exists for — the owner's "Übersetzungen sollen ausfüllbar sein,
+     * für all unsere Sprachen".
+     *
+     * Not #[Locked]: the inputs write to it. Only keys from TagLocales::all() are ever
+     * read back out, so an extra key in a crafted snapshot reaches no translation.
+     *
+     * @var array<string, string>
+     */
+    public array $editNames = [];
 
     /**
      * What just happened to the order, announced politely.
@@ -172,16 +189,47 @@ new class extends Component
      */
     public function getEditLocaleProperty(): string
     {
-        $locales = (array) config('einundzwanzig.tag_locales', []);
-        $current = app()->getLocale();
+        return TagLocales::current();
+    }
 
-        if (in_array($current, $locales, true)) {
-            return $current;
+    /**
+     * The languages the open editor has no name for — what is left to fill.
+     *
+     * Read from the form, not from the stored tag, so it answers for what the
+     * moderator is looking at right now.
+     *
+     * @return array<int, string>
+     */
+    public function getMissingNameLocalesProperty(): array
+    {
+        return collect(TagLocales::all())
+            ->filter(fn (string $locale): bool => trim((string) ($this->editNames[$locale] ?? '')) === '')
+            ->values()
+            ->all();
+    }
+
+    /**
+     * Whether the open editor shows the fingerprint of the old picker: one string
+     * copied into every language, and no source language recorded.
+     *
+     * Three production rows were in that state on 2026-09-05 (`Poker`, `Pubkvíz`,
+     * `Rodiny s dětmi`). No migration repairs them, because which of the nine
+     * identical strings is the original is recorded nowhere — the missing fact lives
+     * with the person reading the word, and this is where that person works. Seeded
+     * tags are excluded by `created_by`: their nine identical names are a deliberate
+     * proper noun (Bitcoin, Nostr, Lightning), not damage.
+     */
+    public function looksLikeCopiedNames(Tag $tag): bool
+    {
+        if ($tag->created_by === null || $tag->source_locale !== null) {
+            return false;
         }
 
-        $fallback = (string) config('app.fallback_locale');
+        $names = collect(TagLocales::all())
+            ->map(fn (string $locale): string => (string) $tag->getTranslation('name', $locale, false))
+            ->filter();
 
-        return in_array($fallback, $locales, true) ? $fallback : (string) ($locales[0] ?? 'de');
+        return $names->count() === count(TagLocales::all()) && $names->unique()->count() === 1;
     }
 
     /**
@@ -269,6 +317,12 @@ new class extends Component
 
         $this->editDescription = (string) $tag->getTranslation('description', $this->editLocale, false);
 
+        $this->editNames = collect(TagLocales::all())
+            ->mapWithKeys(fn (string $locale): array => [
+                $locale => (string) $tag->getTranslation('name', $locale, false),
+            ])
+            ->all();
+
         $this->resetValidation();
     }
 
@@ -277,7 +331,24 @@ new class extends Component
         $this->editingId = null;
         $this->editIcon = 'tag';
         $this->editDescription = '';
+        $this->editNames = [];
         $this->resetValidation();
+    }
+
+    /**
+     * Collapse runs of whitespace and trim, exactly as the picker does before it
+     * stores a typed name. Without it "Vortrag " and "Vortrag" are two different
+     * names to every comparison in the codebase, including the duplicate guard.
+     *
+     * @return array<string, string>
+     */
+    private function normalisedEditNames(): array
+    {
+        return collect(TagLocales::all())
+            ->mapWithKeys(fn (string $locale): array => [
+                $locale => trim(preg_replace('/\s+/u', ' ', (string) ($this->editNames[$locale] ?? '')) ?? ''),
+            ])
+            ->all();
     }
 
     public function save(): void
@@ -286,10 +357,49 @@ new class extends Component
 
         $this->authorize('update', $tag);
 
+        $names = $this->normalisedEditNames();
+        $this->editNames = $names;
+
         $this->validate([
             'editIcon' => ['required', 'string', Rule::in((array) config('einundzwanzig.tag_icons', []))],
             'editDescription' => ['nullable', 'string', 'max:280'],
+            /*
+             * A tag with no name at all cannot be saved — `tags.slug` is NOT NULL and
+             * a slug is derived from a name — and it would read as a blank row in every
+             * picker. The bound rule is on the array rather than the fields, because the
+             * requirement is about the set: any one of the nine will do.
+             */
+            'editNames' => ['array', function (string $attribute, mixed $value, Closure $fail) use ($names): void {
+                if (collect($names)->filter()->isEmpty()) {
+                    $fail(__('Mindestens eine Sprache muss einen Namen tragen.'));
+                }
+            }],
+            'editNames.*' => ['nullable', 'string', 'min:2', 'max:60'],
         ]);
+
+        /*
+         * One locale at a time, and an emptied field forgets that language rather than
+         * storing "" — the same rule the description follows. Measured 2026-09-05:
+         * Spatie's readers (getTranslations, getTranslatedLocales, hasTranslation, and
+         * therefore displayLocale) already filter an empty value out, so this is about
+         * the stored row, not about behaviour: without it the JSON column collects a
+         * dead `"en":""` for every language a moderator ever cleared.
+         *
+         * The SLUG is deliberately untouched here. Tag::bootHasSlug() adds one for a
+         * locale that has a name and no slug yet and never rewrites an existing one
+         * (commit fd48fa7), so renaming keeps the public URL and a forgotten name
+         * leaves its slug behind. Dropping that slug would let a later, different name
+         * in the same language take over a URL that is already in the wild.
+         */
+        foreach ($names as $locale => $name) {
+            if ($name === '') {
+                $tag->forgetTranslation('name', $locale);
+
+                continue;
+            }
+
+            $tag->setTranslation('name', $locale, $name);
+        }
 
         $tag->icon = $this->editIcon;
 

--- a/resources/views/livewire/tags/partials/editor.blade.php
+++ b/resources/views/livewire/tags/partials/editor.blade.php
@@ -1,13 +1,59 @@
 {{--
-    The two describing fields of one tag: its icon and its description.
+    The editable parts of one tag: its names, its icon and its description.
 
-    Both sit in the row itself rather than in a modal. A modal would put the tag you
-    are fixing behind an overlay and hand you a focus trap to get right; editing in
+    All of it sits in the row itself rather than in a modal. A modal would put the tag
+    you are fixing behind an overlay and hand you a focus trap to get right; editing in
     place keeps the neighbours visible, which is what tells you whether a description
     is worth writing at all.
 
+    The names come first and come in all nine languages, unlike the description, which
+    is edited only in the reader's own language. A name is what the picker matches on
+    in every language; leaving eight of them unreachable is what made a Czech tag read
+    as noise to a Dutch organiser.
+
     @param App\Models\Tag $tag
 --}}
+<div class="mb-4">
+    <flux:text class="text-xs">
+        {{ __('Leer lassen heißt: in dieser Sprache nicht vorhanden.') }}
+    </flux:text>
+
+    @if ($this->looksLikeCopiedNames($tag))
+        {{-- The fingerprint of the picker before #117: one typed word copied into all
+             nine languages, which also switched off the "only available in" marker.
+             Named here because the language the word is really in is not in the
+             database — only the person reading it knows. --}}
+        <flux:callout variant="warning" icon="exclamation-triangle" class="mt-2"
+                      data-testid="copied-names-{{ $tag->id }}">
+            {{ __('Alle Sprachen tragen denselben Namen — vermutlich vom alten Picker kopiert. Lösche die Sprachen, in denen er nicht steht.') }}
+        </flux:callout>
+    @endif
+
+    @if ($this->missingNameLocales !== [])
+        <flux:text class="mt-1 text-xs" data-testid="missing-name-locales">
+            {{ __('Fehlt in: :langs', ['langs' => mb_strtoupper(implode(', ', $this->missingNameLocales))]) }}
+        </flux:text>
+    @endif
+
+    <div class="mt-2 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {{-- The same list the component reads back on save; a second source here
+             would silently give the form a different set of fields. --}}
+        @foreach (\App\Support\TagLocales::all() as $nameLocale)
+            <flux:field>
+                <flux:label>{{ __('Name (:lang)', ['lang' => mb_strtoupper($nameLocale)]) }}</flux:label>
+
+                <flux:input wire:model="editNames.{{ $nameLocale }}"
+                            maxlength="60"
+                            data-testid="name-input-{{ $nameLocale }}" />
+
+                <flux:error name="editNames.{{ $nameLocale }}" />
+            </flux:field>
+        @endforeach
+    </div>
+
+    <flux:error name="editNames" />
+</div>
+
 <div class="grid gap-4 sm:grid-cols-2">
     <flux:field>
         <flux:label>{{ __('Symbol') }}</flux:label>

--- a/resources/views/livewire/tags/picker.blade.php
+++ b/resources/views/livewire/tags/picker.blade.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Models\Tag;
+use App\Support\TagLocales;
 use Illuminate\Support\Collection;
 use Livewire\Attributes\Locked;
 use Livewire\Attributes\Modelable;
@@ -17,7 +18,8 @@ use Livewire\Component;
  * The visible label is set through `selected-label`; without it Flux would put all
  * nine translations into the chip.
  */
-new class extends Component {
+new class extends Component
+{
     /**
      * Selected tag ids, bound to the parent form via wire:model.
      *
@@ -66,7 +68,6 @@ new class extends Component {
             ->all();
     }
 
-
     /**
      * Everything selectable: approved tags plus the current user's own pending
      * suggestions, so a suggester can re-select what they just proposed.
@@ -112,10 +113,23 @@ new class extends Component {
      * still selected here and now — otherwise a mandatory-tag country would be a dead
      * end for them.
      *
-     * The name is written to every locale rather than only the current one. A tag that
-     * exists in one language is invisible to the other eight, and an unfindable tag is
-     * the very thing that produced the duplicate sprawl in the existing data. An editor
-     * can refine the translations afterwards.
+     * ONE LOCALE, NOT NINE. This used to copy the typed name into all nine tag locales
+     * so the other eight could find it. The copy was not a translation, and it disabled
+     * the very mechanism built to make that visible: with a name present in every
+     * language, `Tag::isDisplayNameSubstituted()` is false for every reader, so the
+     * picker's "only available in :lang" line could never fire. Measured on production
+     * on 2026-09-05: three tags in that state, among them the Czech `Rodiny s dětmi`
+     * stored as the German, English, Spanish, Hungarian, Latvian, Dutch, Polish and
+     * Portuguese name.
+     *
+     * `source_locale` records what is actually known — the tag locale in force while the
+     * name was typed. It is a statement about the interface the author was using, not a
+     * detected language of the string; nothing here inspects the text.
+     *
+     * Cross-language findability is unchanged for tags that carry real translations
+     * (aliasesFor() still feeds every locale to Flux's matcher), and a moderator fills
+     * the remaining eight in tags.moderation. Until then the tag reads as what it is: a
+     * label in one language, marked as such.
      */
     public function createTag(?string $name = null): void
     {
@@ -144,11 +158,11 @@ new class extends Component {
             return;
         }
 
-        $tag = new Tag(['type' => $this->type]);
+        $locale = TagLocales::current();
 
-        foreach (config('einundzwanzig.tag_locales') as $locale) {
-            $tag->setTranslation('name', $locale, $name);
-        }
+        $tag = new Tag(['type' => $this->type]);
+        $tag->source_locale = $locale;
+        $tag->setTranslation('name', $locale, $name);
 
         $tag->icon = 'tag';
         $tag->featured = false;

--- a/tests/Browser/Tags/TagVocabularyScreenTest.php
+++ b/tests/Browser/Tags/TagVocabularyScreenTest.php
@@ -197,3 +197,38 @@ it('offers the sixteen names in use at rest and the rest on typing', function ()
 
     expect($found)->toContain('wallet');
 });
+
+it('lays the nine name fields out in one column on a narrow screen', function () {
+    /*
+     * The fifth question only a browser answers: nine inputs in one editor panel are
+     * a grid, and a grid is CSS. A server-side test sees nine fields either way — it
+     * cannot see whether they fall out of the viewport on a phone.
+     *
+     * Measured through resize() rather than device emulation: no Livewire round trip
+     * survives the plugin's mobile emulation on this page (measured 2026-09-05,
+     * $wire.set() does not even stick), and the wrap itself is pure CSS. Reading a
+     * rect straight after resize() catches the reflow, hence the wait.
+     */
+    $tag = Tag::query()->approved()->where('type', 'meetup_event')->firstOrFail();
+
+    $page = visit('/de/tags/moderation');
+    $page->wait(1);
+    $page->click('[data-testid=edit-'.$tag->id.']');
+    $page->wait(0.8);
+
+    $rowsOf = "new Set([...document.querySelectorAll('[data-testid^=name-input-]')]
+        .map(i => Math.round(i.getBoundingClientRect().y))).size";
+
+    expect($page->script("document.querySelectorAll('[data-testid^=name-input-]').length"))->toBe(9)
+        ->and($page->script($rowsOf))->toBe(3);
+
+    $page->resize(375, 900);
+    $page->wait(1);
+
+    $page->assertNoJavaScriptErrors();
+
+    expect($page->script($rowsOf))->toBe(9)
+        // Nothing pushed past the viewport edge: the panel wraps instead of scrolling.
+        ->and($page->script('document.documentElement.scrollWidth'))
+        ->toBe($page->script('document.documentElement.clientWidth'));
+});

--- a/tests/Feature/Mcp/EinundzwanzigServerTest.php
+++ b/tests/Feature/Mcp/EinundzwanzigServerTest.php
@@ -3,6 +3,7 @@
 use App\Mcp\Servers\EinundzwanzigServer;
 use App\Mcp\Tools\CourseEvent\UpdateCourseEventTool;
 use App\Mcp\Tools\Meetup\CreateMeetupTool;
+use App\Mcp\Tools\Search\ListEventTagsTool;
 use App\Mcp\Tools\Search\SearchCitiesTool;
 
 it('rejects unauthenticated requests to the mcp endpoint', function () {
@@ -18,11 +19,16 @@ it('registers every domain tool on the server', function () {
     $tools = $property->getDefaultValue();
 
     // 38 until the venue was removed, which took four venue tools and SearchVenuesTool
-    // with it. The exact count is the point: a tool dropped by accident shows up here.
-    expect($tools)->toHaveCount(33)
+    // with it; 34 since list-event-tags joined for #117. The exact count is the point:
+    // a tool dropped by accident shows up here.
+    expect($tools)->toHaveCount(34)
         ->and($tools)->toContain(CreateMeetupTool::class)
         ->and($tools)->toContain(UpdateCourseEventTool::class)
-        ->and($tools)->toContain(SearchCitiesTool::class);
+        ->and($tools)->toContain(SearchCitiesTool::class)
+        // A tool a test drives directly is still invisible to a client until it is
+        // registered here, and the count above would happily stay at 34 if a different
+        // tool were dropped in its place.
+        ->and($tools)->toContain(ListEventTagsTool::class);
 });
 
 it('serves every tool on a single tools/list page', function () {

--- a/tests/Feature/Mcp/MeetupEventTagsMcpTest.php
+++ b/tests/Feature/Mcp/MeetupEventTagsMcpTest.php
@@ -1,0 +1,61 @@
+<?php
+
+use App\Mcp\Servers\EinundzwanzigServer;
+use App\Mcp\Tools\MeetupEvent\ListMyMeetupEventsTool;
+use App\Mcp\Tools\MeetupEvent\ShowMyMeetupEventTool;
+use App\Models\MeetupEvent;
+use App\Models\Tag;
+use App\Models\User;
+
+/*
+ * Issue #117: the MCP read tools returned no tag-related field at all.
+ *
+ * The cause was not a missing field in the resource -- MeetupEventResource has emitted
+ * `tags` since #39 -- but that it emits them under whenLoaded(), and neither tool loaded
+ * the relation. So the key was ABSENT rather than empty, which is worse than either:
+ * a caller cannot tell "this event has no tags" from "this endpoint does not do tags".
+ *
+ * These tests therefore assert the tag's name is on the wire, not merely that a `tags`
+ * key exists -- an empty array would satisfy the weaker assertion while the defect stood.
+ */
+function taggedEventFor(User $user): MeetupEvent
+{
+    $tag = Tag::findOrCreate('Vortrag', 'meetup_event');
+    $tag->forceFill(['approved_at' => now()])->save();
+
+    $event = MeetupEvent::factory()->create(['created_by' => $user->id]);
+    $event->syncTagsWithType([$tag], 'meetup_event');
+
+    return $event;
+}
+
+it('returns the tags of an event from show-my-meetup-event', function () {
+    $user = User::factory()->create();
+    $event = taggedEventFor($user);
+
+    EinundzwanzigServer::actingAs($user)
+        ->tool(ShowMyMeetupEventTool::class, ['id' => $event->id])
+        ->assertOk()
+        ->assertSee('Vortrag');
+});
+
+it('returns the tags of an event from list-my-meetup-events', function () {
+    $user = User::factory()->create();
+    taggedEventFor($user);
+
+    EinundzwanzigServer::actingAs($user)
+        ->tool(ListMyMeetupEventsTool::class, [])
+        ->assertOk()
+        ->assertSee('Vortrag');
+});
+
+it('lists an untagged event with an empty tag list rather than no tag field', function () {
+    // The distinction the defect erased: an event without tags must still say so.
+    $user = User::factory()->create();
+    MeetupEvent::factory()->create(['created_by' => $user->id]);
+
+    EinundzwanzigServer::actingAs($user)
+        ->tool(ListMyMeetupEventsTool::class, [])
+        ->assertOk()
+        ->assertSee('"tags":[]');
+});

--- a/tests/Feature/Mcp/MeetupEventTagsMcpTest.php
+++ b/tests/Feature/Mcp/MeetupEventTagsMcpTest.php
@@ -343,6 +343,34 @@ it('matches a tag name in any of the nine locales, case-insensitively', function
     expect(tagIdsOf($event))->toBe([$tag->id]);
 });
 
+it('matches a name the tag carries in a locale other than the active one', function () {
+    /*
+     * The counter-example the gate on #117 constructed, which the implementation's own
+     * report said it could not build. It is not exotic: it needs no single-locale tag,
+     * only an app locale that differs from the locale of the name being looked up.
+     *
+     * With app.locale = 'de', Tag::displayName() answers 'Vortrag'. A resolver written
+     * against displayName() would therefore NOT match 'Talk', even though the tag plainly
+     * carries it. ResolvesEventTags compares every locale value directly, so it does.
+     *
+     * This pins the choice rather than the outcome: swap the resolver to displayName()
+     * and this test is the one that notices.
+     */
+    app()->setLocale('de');
+
+    $user = User::factory()->create();
+    $event = mcpEventFor($user);
+    $tag = mcpEventTag(['de' => 'Vortrag', 'en' => 'Talk']);
+
+    expect($tag->displayName())->toBe('Vortrag');
+
+    EinundzwanzigServer::actingAs($user)
+        ->tool(UpdateMeetupEventTool::class, ['id' => $event->id, 'tags' => ['Talk']])
+        ->assertOk();
+
+    expect(tagIdsOf($event))->toBe([$tag->id]);
+});
+
 it('does not match a tag of another type', function () {
     // Every lookup is scoped to the meetup_event group. The curated vocabulary has 35
     // name collisions and every one of them is across types -- "Einsteiger" exists in

--- a/tests/Feature/Mcp/MeetupEventTagsMcpTest.php
+++ b/tests/Feature/Mcp/MeetupEventTagsMcpTest.php
@@ -1,8 +1,12 @@
 <?php
 
 use App\Mcp\Servers\EinundzwanzigServer;
+use App\Mcp\Tools\MeetupEvent\CreateMeetupEventTool;
 use App\Mcp\Tools\MeetupEvent\ListMyMeetupEventsTool;
 use App\Mcp\Tools\MeetupEvent\ShowMyMeetupEventTool;
+use App\Mcp\Tools\MeetupEvent\UpdateMeetupEventTool;
+use App\Mcp\Tools\Search\ListEventTagsTool;
+use App\Models\Meetup;
 use App\Models\MeetupEvent;
 use App\Models\Tag;
 use App\Models\User;
@@ -58,4 +62,351 @@ it('lists an untagged event with an empty tag list rather than no tag field', fu
         ->tool(ListMyMeetupEventsTool::class, [])
         ->assertOk()
         ->assertSee('"tags":[]');
+});
+
+/*
+|--------------------------------------------------------------------------
+| Writing tags (issue #117, second half)
+|--------------------------------------------------------------------------
+|
+| create-meetup-event and update-meetup-event take tags BY NAME. Three rules are
+| under test throughout and each has its own case below:
+|
+|   - only a tag Tag::scopeSelectableBy() offers may be attached, the same rule the
+|     web picker states ("a crafted request must not attach someone else's unapproved
+|     suggestion") -- an MCP call is such a request path;
+|   - an unknown or ambiguous name is REFUSED, never created and never half-applied;
+|   - on update, an omitted `tags` preserves, `[]` removes, a list replaces.
+|
+| The tag count is asserted alongside almost every case on purpose. Every spatie write
+| path routes unknown strings through Tag::findOrCreate(), so "the right tags are
+| attached" and "no tag was invented" are two different claims, and only the second one
+| catches the failure mode this feature exists to prevent.
+*/
+
+/**
+ * @param  array<string, string>  $names  locale => name
+ */
+function mcpEventTag(array $names): Tag
+{
+    return Tag::factory()->ofType('meetup_event')->named($names)->create();
+}
+
+function mcpEventFor(User $user, array $attributes = []): MeetupEvent
+{
+    return MeetupEvent::factory()->create([
+        'created_by' => $user->id,
+        'title' => 'Original',
+        'location' => 'Marktplatz',
+        ...$attributes,
+    ]);
+}
+
+/**
+ * @return array<int, int>
+ */
+function tagIdsOf(MeetupEvent $event): array
+{
+    return $event->fresh()->tags->pluck('id')->sort()->values()->all();
+}
+
+it('attaches tags by name when creating a meetup event', function () {
+    $user = User::factory()->create();
+    $meetup = Meetup::factory()->create(['created_by' => $user->id]);
+    $tag = mcpEventTag(['de' => 'Vortrag', 'en' => 'Talk']);
+
+    EinundzwanzigServer::actingAs($user)->tool(CreateMeetupEventTool::class, [
+        'meetup_id' => $meetup->id,
+        'start' => '2026-08-01 18:00:00',
+        'location' => 'Marktplatz',
+        'tags' => ['Vortrag'],
+    ])->assertOk()->assertSee('Vortrag');
+
+    $event = MeetupEvent::query()->where('location', 'Marktplatz')->sole();
+
+    expect(tagIdsOf($event))->toBe([$tag->id])
+        // Nothing was invented alongside the match: the one tag in the fixture is
+        // still the only tag in the database.
+        ->and(Tag::query()->count())->toBe(1);
+});
+
+it('gives every occurrence of a created series the same tags', function () {
+    $user = User::factory()->create();
+    $meetup = Meetup::factory()->create(['created_by' => $user->id]);
+    $tag = mcpEventTag(['de' => 'Stammtisch', 'en' => 'Meetup']);
+
+    EinundzwanzigServer::actingAs($user)->tool(CreateMeetupEventTool::class, [
+        'meetup_id' => $meetup->id,
+        'start' => '2026-08-01 18:00:00',
+        'recurrence_type' => 'weekly',
+        'recurrence_interval' => 1,
+        'recurrence_end_date' => '2026-08-22 18:00:00',
+        'tags' => ['Meetup'],
+    ])->assertOk();
+
+    $events = MeetupEvent::query()->where('meetup_id', $meetup->id)->get();
+
+    expect($events)->toHaveCount(4);
+
+    // A series whose first date carries the selection and whose others do not is the
+    // failure the Livewire editor already guards against; the same must hold here.
+    $events->each(fn (MeetupEvent $event) => expect(tagIdsOf($event))->toBe([$tag->id]));
+});
+
+it('refuses an unknown tag name on create and creates neither event nor tag', function () {
+    $user = User::factory()->create();
+    $meetup = Meetup::factory()->create(['created_by' => $user->id]);
+    mcpEventTag(['de' => 'Vortrag', 'en' => 'Talk']);
+
+    EinundzwanzigServer::actingAs($user)->tool(CreateMeetupEventTool::class, [
+        'meetup_id' => $meetup->id,
+        'start' => '2026-08-01 18:00:00',
+        'location' => 'Marktplatz',
+        'tags' => ['Vortrag', 'Gaming'],
+    ])->assertHasErrors(['Gaming']);
+
+    expect(MeetupEvent::query()->count())->toBe(0)
+        ->and(Tag::query()->count())->toBe(1);
+});
+
+it('replaces the whole tag set on update', function () {
+    $user = User::factory()->create();
+    $event = mcpEventFor($user);
+    $before = mcpEventTag(['de' => 'Vortrag', 'en' => 'Talk']);
+    $after = mcpEventTag(['de' => 'Workshop', 'en' => 'Workshop']);
+    $event->syncTagsWithType([$before], 'meetup_event');
+
+    EinundzwanzigServer::actingAs($user)
+        ->tool(UpdateMeetupEventTool::class, ['id' => $event->id, 'tags' => ['Workshop']])
+        ->assertOk()
+        ->assertSee('Workshop');
+
+    // Replaced, not merged: the previous tag is gone.
+    expect(tagIdsOf($event))->toBe([$after->id]);
+});
+
+it('preserves the existing tags when tags is omitted', function () {
+    $user = User::factory()->create();
+    $event = mcpEventFor($user);
+    $tag = mcpEventTag(['de' => 'Vortrag', 'en' => 'Talk']);
+    $event->syncTagsWithType([$tag], 'meetup_event');
+
+    EinundzwanzigServer::actingAs($user)
+        ->tool(UpdateMeetupEventTool::class, ['id' => $event->id, 'location' => 'Rathaus'])
+        ->assertOk();
+
+    expect(tagIdsOf($event))->toBe([$tag->id])
+        ->and($event->fresh()->location)->toBe('Rathaus');
+});
+
+it('preserves the existing tags when tags is explicitly null', function () {
+    /*
+     * The trap #70 fell into, on a different field. Laravel's `sometimes` counts an
+     * explicitly sent null as PRESENT, so `links: null` reached update() and destroyed
+     * a stored list of five labelled entries; nine mutation probes missed it because no
+     * test sent that input. MCP has no FormRequest in the path and its JSON schema
+     * makes null reachable for any property, so the input is sent here on purpose.
+     */
+    $user = User::factory()->create();
+    $event = mcpEventFor($user);
+    $tag = mcpEventTag(['de' => 'Vortrag', 'en' => 'Talk']);
+    $event->syncTagsWithType([$tag], 'meetup_event');
+
+    EinundzwanzigServer::actingAs($user)
+        ->tool(UpdateMeetupEventTool::class, ['id' => $event->id, 'tags' => null])
+        ->assertOk();
+
+    expect(tagIdsOf($event))->toBe([$tag->id]);
+});
+
+it('removes every tag when tags is an empty list', function () {
+    $user = User::factory()->create();
+    $event = mcpEventFor($user);
+    $tag = mcpEventTag(['de' => 'Vortrag', 'en' => 'Talk']);
+    $event->syncTagsWithType([$tag], 'meetup_event');
+
+    EinundzwanzigServer::actingAs($user)
+        ->tool(UpdateMeetupEventTool::class, ['id' => $event->id, 'tags' => []])
+        ->assertOk()
+        ->assertSee('"tags":[]');
+
+    expect(tagIdsOf($event))->toBe([])
+        // Removing it from the event does not remove it from the vocabulary.
+        ->and(Tag::query()->count())->toBe(1);
+});
+
+it('leaves every unrelated field alone on a tags-only update', function () {
+    $user = User::factory()->create();
+    $event = mcpEventFor($user, ['description' => 'Wie immer im Hinterzimmer.']);
+    $tag = mcpEventTag(['de' => 'Vortrag', 'en' => 'Talk']);
+
+    EinundzwanzigServer::actingAs($user)
+        ->tool(UpdateMeetupEventTool::class, ['id' => $event->id, 'tags' => ['Talk']])
+        ->assertOk();
+
+    $fresh = $event->fresh();
+
+    // Fields that were never sent must read exactly as they did before.
+    expect($fresh->title)->toBe('Original')
+        ->and($fresh->location)->toBe('Marktplatz')
+        ->and($fresh->description)->toBe('Wie immer im Hinterzimmer.')
+        ->and($fresh->start->equalTo($event->start))->toBeTrue()
+        ->and(tagIdsOf($event))->toBe([$tag->id]);
+});
+
+it('refuses an unknown tag name on update and leaves the event untouched', function () {
+    $user = User::factory()->create();
+    $event = mcpEventFor($user);
+    $tag = mcpEventTag(['de' => 'Vortrag', 'en' => 'Talk']);
+    $event->syncTagsWithType([$tag], 'meetup_event');
+
+    EinundzwanzigServer::actingAs($user)->tool(UpdateMeetupEventTool::class, [
+        'id' => $event->id,
+        'location' => 'Rathaus',
+        'tags' => ['Vortrag', 'Gaming'],
+    ])->assertHasErrors(['Gaming']);
+
+    // Not partially applied: neither the tag that WOULD have resolved nor the field
+    // that travelled with it may have landed.
+    $fresh = $event->fresh();
+
+    expect($fresh->location)->toBe('Marktplatz')
+        ->and(tagIdsOf($event))->toBe([$tag->id])
+        ->and(Tag::query()->count())->toBe(1);
+});
+
+it('refuses an ambiguous tag name instead of picking the first hit', function () {
+    // Two tags carrying the same word in different languages. There is no such
+    // collision inside meetup_event today, but a tag is user-editable and the day one
+    // appears, silently attaching whichever row came back first is the wrong answer.
+    $user = User::factory()->create();
+    $event = mcpEventFor($user);
+    $german = mcpEventTag(['de' => 'Gaming']);
+    $english = mcpEventTag(['en' => 'Gaming']);
+
+    EinundzwanzigServer::actingAs($user)
+        ->tool(UpdateMeetupEventTool::class, ['id' => $event->id, 'tags' => ['Gaming']])
+        ->assertHasErrors(['#'.$german->id, '#'.$english->id]);
+
+    expect(tagIdsOf($event))->toBe([]);
+});
+
+it('refuses someone elses unapproved suggestion', function () {
+    $user = User::factory()->create();
+    $event = mcpEventFor($user);
+    $stranger = User::factory()->create();
+
+    $suggestion = Tag::factory()
+        ->ofType('meetup_event')
+        ->named(['de' => 'Geheimtipp'])
+        ->pending($stranger)
+        ->create();
+
+    EinundzwanzigServer::actingAs($user)
+        ->tool(UpdateMeetupEventTool::class, ['id' => $event->id, 'tags' => ['Geheimtipp']])
+        ->assertHasErrors(['Geheimtipp']);
+
+    expect(tagIdsOf($event))->toBe([])
+        // Refused, not created a second time under the caller's own name.
+        ->and(Tag::query()->count())->toBe(1)
+        ->and($suggestion->fresh()->approved_at)->toBeNull();
+});
+
+it('accepts the callers own unapproved suggestion', function () {
+    // The other half of scopeSelectableBy(): a suggester can use what they proposed,
+    // which is what makes the refusal above about ownership rather than about approval.
+    $user = User::factory()->create();
+    $event = mcpEventFor($user);
+
+    $ownSuggestion = Tag::factory()
+        ->ofType('meetup_event')
+        ->named(['de' => 'Geheimtipp'])
+        ->pending($user)
+        ->create();
+
+    EinundzwanzigServer::actingAs($user)
+        ->tool(UpdateMeetupEventTool::class, ['id' => $event->id, 'tags' => ['Geheimtipp']])
+        ->assertOk();
+
+    expect(tagIdsOf($event))->toBe([$ownSuggestion->id]);
+});
+
+it('matches a tag name in any of the nine locales, case-insensitively', function () {
+    $user = User::factory()->create();
+    $event = mcpEventFor($user);
+    $tag = mcpEventTag(['de' => 'Vortrag', 'cs' => 'Přednáška', 'pl' => 'Prelekcja']);
+
+    EinundzwanzigServer::actingAs($user)
+        ->tool(UpdateMeetupEventTool::class, ['id' => $event->id, 'tags' => ['  přednáška ']])
+        ->assertOk();
+
+    expect(tagIdsOf($event))->toBe([$tag->id]);
+});
+
+it('does not match a tag of another type', function () {
+    // Every lookup is scoped to the meetup_event group. The curated vocabulary has 35
+    // name collisions and every one of them is across types -- "Einsteiger" exists in
+    // meetup_event and in library_item -- so an unscoped lookup would be ambiguous by
+    // construction rather than by accident.
+    $user = User::factory()->create();
+    $event = mcpEventFor($user);
+    Tag::factory()->ofType('library_item')->named(['de' => 'Einsteiger'])->create();
+
+    EinundzwanzigServer::actingAs($user)
+        ->tool(UpdateMeetupEventTool::class, ['id' => $event->id, 'tags' => ['Einsteiger']])
+        ->assertHasErrors(['Einsteiger']);
+
+    expect(tagIdsOf($event))->toBe([])
+        ->and(Tag::query()->count())->toBe(1);
+});
+
+it('refuses to tag someone elses event', function () {
+    // The gate is the one the tool already applied; `tags` must not be a way past it.
+    $owner = User::factory()->create();
+    $event = mcpEventFor($owner);
+    mcpEventTag(['de' => 'Vortrag']);
+
+    EinundzwanzigServer::actingAs(User::factory()->create())
+        ->tool(UpdateMeetupEventTool::class, ['id' => $event->id, 'tags' => ['Vortrag']])
+        ->assertHasErrors();
+
+    expect(tagIdsOf($event))->toBe([]);
+});
+
+it('lists the event tag vocabulary with every name a tag carries', function () {
+    $user = User::factory()->create();
+
+    $names = [
+        'de' => 'Vortrag', 'en' => 'Talk', 'cs' => 'Přednáška', 'es' => 'Charla',
+        'hu' => 'Előadás', 'lv' => 'Lekcija', 'nl' => 'Lezing', 'pl' => 'Prelekcja',
+        'pt' => 'Palestra',
+    ];
+
+    mcpEventTag($names);
+
+    // All nine, so an agent can pick a name in its user's language without guessing --
+    // and every one of them is a name update-meetup-event will resolve.
+    EinundzwanzigServer::actingAs($user)
+        ->tool(ListEventTagsTool::class, [])
+        ->assertOk()
+        ->assertSee(array_values($names));
+});
+
+it('offers only the tags that can actually be attached', function () {
+    $user = User::factory()->create();
+    $stranger = User::factory()->create();
+
+    mcpEventTag(['de' => 'Vortrag']);
+    Tag::factory()->ofType('meetup_event')->named(['de' => 'Fremdvorschlag'])->pending($stranger)->create();
+    Tag::factory()->ofType('meetup_event')->named(['de' => 'Eigenvorschlag'])->pending($user)->create();
+    Tag::factory()->ofType('library_item')->named(['de' => 'Buchtipp'])->create();
+
+    EinundzwanzigServer::actingAs($user)
+        ->tool(ListEventTagsTool::class, [])
+        ->assertOk()
+        ->assertSee(['Vortrag', 'Eigenvorschlag'])
+        // A name offered here that the write tools would then refuse is worse than no
+        // list at all -- the agent would have no way to tell the two apart.
+        ->assertDontSee('Fremdvorschlag')
+        ->assertDontSee('Buchtipp');
 });

--- a/tests/Feature/Tags/EventTagPickerTest.php
+++ b/tests/Feature/Tags/EventTagPickerTest.php
@@ -188,17 +188,66 @@ it('stores a non-editors tag as an unapproved suggestion but selects it anyway',
     $component->assertSet('tagIds', [$tag->id]);
 });
 
-it('names a new tag in every locale so the other eight can find it', function () {
+it('names a new tag only in the language it was typed in', function () {
+    /*
+     * Replaces "names a new tag in every locale so the other eight can find it".
+     * That copy was not a translation, and it was what made the picker's
+     * "only available in :lang" line unreachable — see the case below and the
+     * createTag() docblock.
+     */
     $this->actingAs(editorUserForPicker());
+    app()->setLocale('cs');
 
-    Livewire::test('tags.picker', ['type' => 'meetup_event'])->call('createTag', 'Lagerfeuerrunde');
+    Livewire::test('tags.picker', ['type' => 'meetup_event'])->call('createTag', 'Rodiny s dětmi');
 
     $tag = Tag::query()->where('type', 'meetup_event')->get()
-        ->first(fn (Tag $t): bool => $t->getTranslation('name', 'de') === 'Lagerfeuerrunde');
+        ->first(fn (Tag $t): bool => $t->getTranslation('name', 'cs', false) === 'Rodiny s dětmi');
 
-    foreach (config('einundzwanzig.tag_locales') as $locale) {
-        expect($tag->getTranslation('name', $locale, false))->toBe('Lagerfeuerrunde');
+    expect($tag)->not->toBeNull()
+        ->and($tag->source_locale)->toBe('cs')
+        ->and($tag->getTranslations('name'))->toBe(['cs' => 'Rodiny s dětmi']);
+
+    foreach (['de', 'en', 'es', 'hu', 'lv', 'nl', 'pl', 'pt'] as $untouched) {
+        expect($tag->getTranslation('name', $untouched, false))->toBe('');
     }
+});
+
+it('marks a tag created in another language as a foreign-language label', function () {
+    /*
+     * The defect this whole change exists for: the warning at picker.blade.php could
+     * never fire for a tag the picker itself had created, because the typed name was
+     * written into all nine locales. Reverting createTag() to that write reddens the
+     * assertSee AND both expectations below.
+     */
+    $this->actingAs(editorUserForPicker());
+    app()->setLocale('cs');
+
+    Livewire::test('tags.picker', ['type' => 'meetup_event'])->call('createTag', 'Rodiny s dětmi');
+
+    $tag = Tag::query()->where('type', 'meetup_event')->get()
+        ->first(fn (Tag $t): bool => $t->getTranslation('name', 'cs', false) === 'Rodiny s dětmi');
+
+    app()->setLocale('nl');
+
+    // What the Dutch organiser actually reads in the option row. Asserted before the
+    // model expectations on purpose, so a red run proves THIS line can fail.
+    Livewire::test('tags.picker', ['type' => 'meetup_event'])
+        ->assertSee('Rodiny s dětmi')
+        ->assertSee('alleen beschikbaar in CS');
+
+    expect($tag->displayLocale('nl'))->toBe('cs')
+        ->and($tag->isDisplayNameSubstituted('nl'))->toBeTrue();
+});
+
+it('does not mark a seeded tag that carries all nine translations', function () {
+    // The other side of the same coin: the marker must stay off where the tag really
+    // does have a name in the reader's language, or it becomes noise on every row.
+    $this->actingAs(editorUserForPicker());
+    app()->setLocale('nl');
+
+    Livewire::test('tags.picker', ['type' => 'meetup_event'])
+        ->assertSee('Lezing')                        // "Vortrag" in Dutch, from the seeder
+        ->assertDontSee('alleen beschikbaar in');
 });
 
 it('selects the existing tag instead of creating a duplicate', function () {
@@ -226,6 +275,30 @@ it('catches a duplicate that exists only in another language', function () {
         ->assertSet('tagIds', [$talk->id]);
 
     expect(Tag::query()->where('type', 'meetup_event')->count())->toBe($before);
+});
+
+it('catches a duplicate of a tag that carries only one language', function () {
+    /*
+     * The duplicate guard walks all nine locales and a single-locale tag answers ''
+     * for eight of them. Since a tag created through the picker now has exactly one
+     * name, this is the shape the guard meets most often.
+     */
+    $this->actingAs(editorUserForPicker());
+    app()->setLocale('cs');
+
+    Livewire::test('tags.picker', ['type' => 'meetup_event'])->call('createTag', 'Rodiny s dětmi');
+
+    $created = Tag::query()->where('type', 'meetup_event')->get()
+        ->first(fn (Tag $t): bool => $t->getTranslation('name', 'cs', false) === 'Rodiny s dětmi');
+    $countBefore = Tag::query()->where('type', 'meetup_event')->count();
+
+    app()->setLocale('nl');
+
+    Livewire::test('tags.picker', ['type' => 'meetup_event'])
+        ->call('createTag', '  rodiny s DĚTMI ')   // different case and padding
+        ->assertSet('tagIds', [$created->id]);
+
+    expect(Tag::query()->where('type', 'meetup_event')->count())->toBe($countBefore);
 });
 
 it('ignores names that are too short or too long', function () {

--- a/tests/Feature/Tags/TagModerationTest.php
+++ b/tests/Feature/Tags/TagModerationTest.php
@@ -368,3 +368,251 @@ it('keeps a non-editor out of every ordering action', function () {
     expect($outsider->can('update', $tag))->toBeFalse()
         ->and($tag->fresh()->order_column)->toBe($orderBefore);
 });
+
+/*
+|--------------------------------------------------------------------------
+| Names, in all nine languages
+|--------------------------------------------------------------------------
+|
+| The screen could edit a tag's icon, its description, its featured flag and
+| its position — everything except the one field a picker actually matches on.
+| The owner's requirement ("Übersetzungen sollen ausfüllbar sein, für all
+| unsere Sprachen") was not reachable through any interface, and neither were
+| the three production rows the old picker left with one word in nine
+| languages.
+|
+*/
+
+it('loads every locale of the name into the editor', function () {
+    $this->actingAs(moderator());
+
+    $tag = Tag::factory()->named(['de' => 'Selbstverwahrung', 'en' => 'Self-custody'])
+        ->create(['type' => 'meetup_event']);
+
+    Livewire::test('tags.moderation')
+        ->call('edit', $tag->id)
+        ->assertSet('editNames.de', 'Selbstverwahrung')
+        ->assertSet('editNames.en', 'Self-custody')
+        ->assertSet('editNames.cs', '')
+        ->assertSet('editNames.pt', '');
+});
+
+it('fills in a translation the tag did not have', function () {
+    $this->actingAs(moderator());
+
+    $tag = Tag::factory()->named(['de' => 'Selbstverwahrung'])->create(['type' => 'meetup_event']);
+
+    Livewire::test('tags.moderation')
+        ->call('edit', $tag->id)
+        ->set('editNames.cs', 'Samospráva')
+        ->set('editNames.pl', 'Samodzielne przechowywanie')
+        ->call('save')
+        ->assertHasNoErrors();
+
+    $fresh = $tag->fresh();
+
+    expect($fresh->getTranslation('name', 'cs', false))->toBe('Samospráva')
+        ->and($fresh->getTranslation('name', 'pl', false))->toBe('Samodzielne przechowywanie')
+        ->and($fresh->getTranslation('name', 'de', false))->toBe('Selbstverwahrung')
+        // And the Czech reader is no longer told this is a German label.
+        ->and($fresh->isDisplayNameSubstituted('cs'))->toBeFalse();
+});
+
+it('names the languages that are still missing', function () {
+    $this->actingAs(moderator());
+
+    $tag = Tag::factory()->named(['de' => 'Selbstverwahrung', 'en' => 'Self-custody'])
+        ->create(['type' => 'meetup_event']);
+
+    $component = Livewire::test('tags.moderation')->call('edit', $tag->id);
+
+    expect($component->instance()->missingNameLocales)
+        ->toBe(['cs', 'es', 'hu', 'lv', 'nl', 'pl', 'pt']);
+
+    $component->assertSee('Fehlt in: CS, ES, HU, LV, NL, PL, PT');
+});
+
+it('drops a language again when its name is emptied', function () {
+    // The repair path for the three rows the old picker filled with one word in nine
+    // languages: delete the eight it is not written in.
+    $this->actingAs(moderator());
+
+    $tag = Tag::factory()
+        ->named(array_fill_keys(config('einundzwanzig.tag_locales'), 'Rodiny s dětmi'))
+        ->create(['type' => 'meetup_event']);
+
+    $component = Livewire::test('tags.moderation')->call('edit', $tag->id);
+
+    foreach (['de', 'en', 'es', 'hu', 'lv', 'nl', 'pl', 'pt'] as $wrong) {
+        $component->set('editNames.'.$wrong, '');
+    }
+
+    $component->call('save')->assertHasNoErrors();
+
+    $fresh = $tag->fresh();
+
+    expect($fresh->getTranslations('name'))->toBe(['cs' => 'Rodiny s dětmi'])
+        ->and($fresh->displayLocale('nl'))->toBe('cs')
+        ->and($fresh->isDisplayNameSubstituted('nl'))->toBeTrue()
+        // The language is gone from the stored column, not stored as "". Spatie's
+        // readers filter an empty value out either way (measured 2026-09-05), so only
+        // the raw attribute can tell the two apart — and only this keeps the column
+        // from collecting a dead entry per cleared language.
+        ->and(json_decode($fresh->getAttributes()['name'], true))->toBe(['cs' => 'Rodiny s dětmi']);
+});
+
+it('refuses to leave a tag without any name', function () {
+    // A nameless tag cannot be persisted at all (tags.slug is NOT NULL, and a slug
+    // comes from a name), and it would render as a blank row in every picker.
+    $this->actingAs(moderator());
+
+    $tag = Tag::factory()->named(['de' => 'Selbstverwahrung'])->create(['type' => 'meetup_event']);
+
+    $component = Livewire::test('tags.moderation')->call('edit', $tag->id);
+
+    foreach (config('einundzwanzig.tag_locales') as $locale) {
+        $component->set('editNames.'.$locale, '');
+    }
+
+    $component->call('save')->assertHasErrors('editNames');
+
+    expect($tag->fresh()->getTranslation('name', 'de', false))->toBe('Selbstverwahrung');
+});
+
+it('refuses a name that is too short or too long', function () {
+    $this->actingAs(moderator());
+
+    $tag = Tag::factory()->named(['de' => 'Selbstverwahrung'])->create(['type' => 'meetup_event']);
+
+    Livewire::test('tags.moderation')
+        ->call('edit', $tag->id)
+        ->set('editNames.cs', 'x')
+        ->call('save')
+        ->assertHasErrors('editNames.cs');
+
+    Livewire::test('tags.moderation')
+        ->call('edit', $tag->id)
+        ->set('editNames.cs', str_repeat('a', 61))
+        ->call('save')
+        ->assertHasErrors('editNames.cs');
+
+    expect($tag->fresh()->getTranslation('name', 'cs', false))->toBe('');
+});
+
+it('keeps the slug of a renamed language and of every other one', function () {
+    /*
+     * Tag::bootHasSlug() exists so a public URL is never rewritten by a later edit
+     * (commit fd48fa7: an API patch turned "nuernberg" into "nurnberg"). Editing names
+     * on this screen is exactly the kind of unrelated save that used to do it.
+     */
+    $this->actingAs(moderator());
+
+    $tag = Tag::factory()->named(['de' => 'Nürnberg Treff', 'en' => 'Nuremberg Meetup'])
+        ->create(['type' => 'meetup_event']);
+
+    // The tag slugger is Str::slug without a language option, so this is
+    // "nurnberg-treff" and not the "nuernberg-treff" that Meetup and City produce.
+    // What is being pinned here is that the value does not MOVE, whatever it is.
+    $slugsBefore = $tag->getTranslations('slug');
+    expect($slugsBefore['de'])->toBe('nurnberg-treff');
+
+    Livewire::test('tags.moderation')
+        ->call('edit', $tag->id)
+        ->set('editNames.de', 'Nürnberger Stammtisch')
+        ->set('editNames.cs', 'Norimberské setkání')
+        ->call('save')
+        ->assertHasNoErrors();
+
+    $fresh = $tag->fresh();
+
+    expect($fresh->getTranslation('slug', 'de'))->toBe($slugsBefore['de'])
+        ->and($fresh->getTranslation('slug', 'en'))->toBe($slugsBefore['en'])
+        // A language that had no name gets a slug now, which is the only new one.
+        ->and($fresh->getTranslation('slug', 'cs'))->toBe('norimberske-setkani')
+        ->and($fresh->getTranslation('name', 'de', false))->toBe('Nürnberger Stammtisch');
+});
+
+it('keeps the slug of a language whose name was removed', function () {
+    // Deliberate: the slug outlives the name it came from, so a different name in
+    // that language later cannot take over a URL that is already in the wild.
+    $this->actingAs(moderator());
+
+    $tag = Tag::factory()->named(['de' => 'Nürnberg Treff', 'en' => 'Nuremberg Meetup'])
+        ->create(['type' => 'meetup_event']);
+
+    $slugsBefore = $tag->getTranslations('slug');
+
+    Livewire::test('tags.moderation')
+        ->call('edit', $tag->id)
+        ->set('editNames.en', '')
+        ->call('save')
+        ->assertHasNoErrors();
+
+    $fresh = $tag->fresh();
+
+    expect($fresh->getTranslation('name', 'en', false))->toBe('')
+        ->and($fresh->getTranslations('slug'))->toBe($slugsBefore);
+});
+
+it('normalises whitespace in a name, as the picker does', function () {
+    $this->actingAs(moderator());
+
+    $tag = Tag::factory()->named(['de' => 'Selbstverwahrung'])->create(['type' => 'meetup_event']);
+
+    Livewire::test('tags.moderation')
+        ->call('edit', $tag->id)
+        ->set('editNames.en', "  Self   custody \n")
+        ->call('save')
+        ->assertHasNoErrors();
+
+    expect($tag->fresh()->getTranslation('name', 'en', false))->toBe('Self custody');
+});
+
+it('flags a tag whose nine names were copied by the old picker', function () {
+    /*
+     * The three production rows of 2026-09-05 (Poker, Pubkvíz, Rodiny s dětmi): one
+     * typed word in all nine languages, no source language recorded. No migration
+     * repairs them, because which of the nine is the original exists nowhere in the
+     * data — so the screen says so where the person who can read the word works.
+     */
+    $this->actingAs(moderator());
+
+    $copied = Tag::factory()
+        ->pending(User::factory()->create())
+        ->named(array_fill_keys(config('einundzwanzig.tag_locales'), 'Rodiny s dětmi'))
+        ->create(['type' => 'meetup_event']);
+
+    Livewire::test('tags.moderation')
+        ->call('edit', $copied->id)
+        ->assertSee('vermutlich vom alten Picker kopiert');
+});
+
+it('does not flag a seeded proper noun that is the same word everywhere', function () {
+    // Bitcoin, Nostr, Lightning: nine identical names on purpose. `created_by` is what
+    // separates them from the picker's copies.
+    $this->actingAs(moderator());
+
+    $seeded = Tag::factory()
+        ->named(array_fill_keys(config('einundzwanzig.tag_locales'), 'Bitcoin'))
+        ->create(['type' => 'meetup_event']);
+
+    // SetsCreatedBy stamps the acting user on anything created inside a request; a
+    // seeder runs on the console, where there is none. Reproduce that here.
+    $seeded->newQuery()->whereKey($seeded->id)->update(['created_by' => null]);
+
+    Livewire::test('tags.moderation')
+        ->call('edit', $seeded->id)
+        ->assertDontSee('vermutlich vom alten Picker kopiert');
+});
+
+it('keeps a non-editor out of the name editor', function () {
+    $outsider = User::factory()->create(['nostr' => null]);
+    $tag = Tag::factory()->named(['de' => 'Selbstverwahrung'])->create(['type' => 'meetup_event']);
+
+    $this->actingAs($outsider);
+
+    Livewire::test('tags.moderation')->assertStatus(403);
+
+    expect($outsider->can('update', $tag))->toBeFalse()
+        ->and($tag->fresh()->getTranslation('name', 'de', false))->toBe('Selbstverwahrung');
+});


### PR DESCRIPTION
Closes #117.

Four commits: the read half, a multilinguality defect found on the way, the write half, and one test the gate asked for.

## Reading tags (`5c454cd`)

The cause was not a missing field — `MeetupEventResource` has emitted `tags` since #39, but under `whenLoaded()`, and neither MCP tool loaded the relation. The key was **absent** rather than empty, so a caller could not tell "this event has no tags" from "this endpoint does not do tags".

## The defect found on the way (`c569661`)

`createTag()` in the tag picker wrote the typed name into **all nine locales**. `Tag::isDisplayNameSubstituted()` can therefore never be true, and the picker's own warning — built precisely to tell a reader that a label is in a foreign language — never fired for a single runtime-created tag.

Measured on production: 94 tags, and every one ever created through that path carried it. `Rodiny s dětmi` — Czech for "families with children" — was stored as the German, English, Spanish, Hungarian, Latvian, Dutch, Polish and Portuguese name too. (The 20 seeder rows whose nine names match are `Bitcoin`, `Nostr`, `Lightning`, `Whitepaper` — legitimately the same word everywhere.)

`tags.source_locale` records the locale that was active while typing. **No backfill in either direction**: for seeder rows the source is German by construction but nothing reads the column for them, and for runtime rows *which* of the nine languages the string is in exists nowhere in the database — that is the defect itself.

**No repair migration either.** Detecting those rows is safe; repairing them is not. Which of the nine copies survives decides what the picker tells every reader, and a wrong guess turns today's *missing* warning into a *false* one. The moderation screen now marks that signature and edits names in all nine locales instead, so a human who can read the word fixes it. The three production rows were repaired that way — one merged into the `Familien`/`Rodiny` tag that already existed, two given real translations.

## Writing tags (`65aa7b0`)

`create-meetup-event` and `update-meetup-event` accept `tags` by name; `list-event-tags` returns the vocabulary with all nine names.

**MCP never creates a tag** — #117 asks for that itself, and it is the one irreversible move: a caller inventing names at API speed is a duplicate generator no approval queue catches. Unknown name → the whole call aborts with the string named and nothing written. Two matches → an error listing every candidate, never a first hit.

Four semantics, each with its own test: omitted preserves, `[]` removes, a list replaces, and **`null` preserves** — that last one because `Laravel\Mcp\Request` applies no schema validation before `handle()`, so `null` really reaches the tool. It is the exact shape that destroyed a list in #70.

`tags` carries no validation rule on purpose: `validated()` only returns keys that have one, so the names cannot reach `MeetupEvent::create()`, where `HasTags` would push them through `findOrCreate()` with a **null type**. The gate reproduced that hazard rather than taking it on trust.

The REST API still cannot write tags, deliberately — a `tags` rule in the shared FormRequests would hand the public API a new write capability as a side effect. Measured: `PATCH {"location":"Rathaus","tags":["Vortrag"]}` writes the location, attaches 0 tags, creates nothing.

## Correction to `c569661`'s own commit message

It claims the editor was "measured at 1728, 768 and 375px … save button in the viewport at every width, and a browser test pins it". **The browser test covers two widths, not three, and never checks the save button** — and the gate measured the button below the fold at 768px and 375px. The column counts (3/2/1) and the absence of overflow do hold and are pinned. The rest of that sentence was overstated and is withdrawn here rather than left standing.

## Verification

Gate: three ACCEPT, with its own mutation probes re-run rather than trusted. 14 probes on the write half, all predicted reds matching. Full non-browser suite **2110 passed (7628 assertions)**.

`0696d6d` adds the one test the gate said was missing: it constructed the `displayName()` counter-example the implementation reported it could not build.

Filed rather than fixed: #118 — every MCP tool's wire name ends in `-tool` while the server's instructions promise the short name, across all 34 tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XfFQ18DFktM3ewnWo9Zt9X
