### PR TITLE
Move the hand-written guidance out of the Boost block

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,13 +83,6 @@ This project has domain-specific skills available in `**/skills/**`. You MUST ac
 
 - Every change must be programmatically tested. Write a new test or update an existing test, then run the affected tests to make sure they pass.
 - Run the minimum number of tests needed to ensure code quality and speed. Use `php artisan test --compact` with a specific filename or filter.
-- **Never run the full suite unfiltered in an automated context.** `php artisan test --compact` includes the `Browser` testsuite, which starts a Playwright server; where none can start it hangs with no output until something kills it. Measured 2026-09-01: 25+ minutes of silence, twice, on a change that touched only `lang/en.json`. Scope it instead:
-
-  ```
-  timeout 900 php artisan test --compact --exclude-testsuite=Browser
-  ```
-
-  Browser assertions stay available on purpose — run them deliberately through `vendor/bin/pest --testsuite=Browser`, never as a side effect of a full run.
 
 === laravel/core rules ===
 
@@ -199,3 +192,30 @@ vendor/bin/pest --agent='visit("/")->on()->mobile()->screenshot(fullPage: false,
 For full usage — backend examples, browser testing, screenshots, responsive checks, combining frontend and backend assertions, RefreshDatabase guidance, and pitfalls — load the **`pest-plugin-agent` skill**.
 
 </laravel-boost-guidelines>
+
+# Project guidelines — deliberately OUTSIDE the Boost block
+
+**Do not move anything below this line back into `<laravel-boost-guidelines>`, and do
+not add hand-written guidance inside that block.** The position is load-bearing, not
+cosmetic: `php artisan boost:install` does not append to this file, it regenerates the
+whole `<laravel-boost-guidelines>` … `</laravel-boost-guidelines>` block from the Blade
+templates under `vendor/laravel/boost/.ai/`. Everything inside the block is therefore
+Boost's to overwrite — hand-written text there is deleted at the next install, and the
+command reports success while doing it. Everything below the closing tag is untouched.
+
+Measured 2026-09-05 for issue #83: the composed Boost output for this project
+(`GuidelineComposer::compose()`) matched the block byte for byte except for the Test
+Enforcement passage below, which was the only hand-written text left inside it.
+
+`tests/Feature/BoostGuidelinesOutsideBlockTest.php` guards both failure modes — the
+passage disappearing, and the passage reappearing inside the block.
+
+## Test Enforcement
+
+- **Never run the full suite unfiltered in an automated context.** `php artisan test --compact` includes the `Browser` testsuite, which starts a Playwright server; where none can start it hangs with no output until something kills it. Measured 2026-09-01: 25+ minutes of silence, twice, on a change that touched only `lang/en.json`. Scope it instead:
+
+  ```
+  timeout 900 php artisan test --compact --exclude-testsuite=Browser
+  ```
+
+  Browser assertions stay available on purpose — run them deliberately through `vendor/bin/pest --testsuite=Browser`, never as a side effect of a full run.

--- a/tests/Feature/BoostGuidelinesOutsideBlockTest.php
+++ b/tests/Feature/BoostGuidelinesOutsideBlockTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| Guard against #83 regressing: hand-written guidance in CLAUDE.md must sit
+| BELOW </laravel-boost-guidelines>, never inside the block.
+|
+| `boost:install` does not append to CLAUDE.md, it regenerates the whole
+| <laravel-boost-guidelines> block from the Blade templates under
+| vendor/laravel/boost/.ai/. Anything hand-written inside that block is
+| dropped at the next install, and the command reports success while doing
+| it — the loss is silent. Text below the closing tag survives.
+|
+| The passage guarded here is the Browser-testsuite warning, added by hand
+| in 01766c7 and ca131fc. It carries a measurement (25+ minutes of silence,
+| twice) which is the only reason anyone believes the hazard; rediscovering
+| it costs the next agent the same time.
+|
+| Presence alone is not enough. A regeneration that reinstated a
+| Boost-owned copy inside the block would keep a presence-only check green
+| while the passage is once again one `boost:install` away from deletion.
+| Both halves are therefore asserted: present below the tag, absent above.
+|--------------------------------------------------------------------------
+*/
+
+/**
+ * The two load-bearing sentences of the warning. The measurement is quoted
+ * verbatim on purpose — a reworded measurement is a weaker one.
+ *
+ * @var array<int, string>
+ */
+const BROWSER_SUITE_WARNING_NEEDLES = [
+    'Never run the full suite unfiltered in an automated context.',
+    'Measured 2026-09-01: 25+ minutes of silence, twice, on a change that touched only `lang/en.json`.',
+];
+
+/**
+ * @return array{inside: string, outside: string}
+ */
+function splitClaudeMdAtBoostBlock(): array
+{
+    $claudeMd = file_get_contents(base_path('CLAUDE.md'));
+    $closingTag = '</laravel-boost-guidelines>';
+
+    $position = strpos($claudeMd, $closingTag);
+
+    expect($position)->not->toBeFalse(
+        'CLAUDE.md no longer contains a '.$closingTag.' tag. This guard cannot tell '
+        .'Boost-owned text from hand-written text without it.'
+    );
+
+    return [
+        'inside' => substr($claudeMd, 0, $position),
+        'outside' => substr($claudeMd, $position + strlen($closingTag)),
+    ];
+}
+
+it('keeps the Browser-testsuite warning in CLAUDE.md, below the Boost block', function () {
+    $parts = splitClaudeMdAtBoostBlock();
+
+    // Deliberately str_contains() rather than expect()->not->toContain(): Pest's
+    // toContain() is variadic, so a failure message passed as a second argument
+    // becomes a second needle and a negated assertion passes whenever only one of
+    // the two is present. Same reason as BoostProjectRulesDisabledTest.
+    foreach (BROWSER_SUITE_WARNING_NEEDLES as $needle) {
+        expect(str_contains($parts['outside'], $needle))->toBeTrue(
+            'CLAUDE.md must keep this text below </laravel-boost-guidelines>, where '
+            ."boost:install cannot overwrite it: \"{$needle}\""
+        );
+    }
+});
+
+it('keeps the Browser-testsuite warning out of the Boost block', function () {
+    $parts = splitClaudeMdAtBoostBlock();
+
+    foreach (BROWSER_SUITE_WARNING_NEEDLES as $needle) {
+        expect(str_contains($parts['inside'], $needle))->toBeFalse(
+            'This text sits inside <laravel-boost-guidelines> and the next boost:install '
+            ."will delete it without saying so. Move it below the closing tag: \"{$needle}\""
+        );
+    }
+});


### PR DESCRIPTION
boost:install regenerates the whole <laravel-boost-guidelines> block
from vendor/laravel/boost/.ai/, and reports success while doing it. That
block was lines 1 to 201 -- the entire file -- so everything in
CLAUDE.md was regenerable, including guidance nobody at Laravel wrote.

Which passages were hand-written was established by regeneration, not by
reading: the same GuidelineConfig boost:install builds was constructed
from boost.json and GuidelineComposer::compose() called through tinker,
producing the exact string an install would write without writing it.
Diffed against the current block, it is byte-identical except for seven
lines -- the Browser-testsuite warning added in ca131fc and 01766c7.
Exactly one passage, not a judgement call.

Two candidates were checked and rejected: ## Foundational Context comes
verbatim from foundation.blade.php (87a9234 records it as a boost:update
product), and the .ai/rules paragraph #60 removed is Boost-owned and
absent from both file and composition.

The passage moves below the closing tag, verbatim -- it quotes a
measurement, and a reworded measurement is a weaker one. The new heading
states the mechanism, so the position reads as load-bearing rather than
stylistic.

BoostGuidelinesOutsideBlockTest splits the file at the closing tag and
requires the text present BELOW it and absent ABOVE. Both, because
presence alone stays green after a regeneration that reinstates a
Boost-owned copy -- probed exactly that way, and it fires. Removing the
passage reddens one test, moving it back inside reddens two.

str_contains() rather than expect()->not->toContain(), for the reason
#60 recorded: toContain() is variadic, so a failure message passed as a
second argument becomes a second needle and the negated assertion stays
green.

boost:install was NOT run. It was not needed to prove any of this, and
running it would have rewritten the file under test.

Found, not fixed: AGENTS.md carries its own copy of the block with the
same warning inside it, and still contains the .ai/rules mandate #60
removed -- filed as #120. Boost also has a supported slot for custom
guidelines, .ai/guidelines/, whose content it composes INTO the block
and preserves; recorded in #120 so it is not rediscovered as a surprise.

Closes #83



🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XfFQ18DFktM3ewnWo9Zt9X
