### PR TITLE
Let nostr:publish exit non-zero when it actually failed

### DIFF
--- a/app/Console/Commands/Nostr/PublishUnpublishedItems.php
+++ b/app/Console/Commands/Nostr/PublishUnpublishedItems.php
@@ -44,13 +44,32 @@ class PublishUnpublishedItems extends Command
     ];
 
     /**
-     * Only the schema gate below returns a non-zero exit code.
+     * Issue #84: every branch that prints an error now ends the run non-zero.
      *
-     * The other error branches (unsupported model, no text, a rejected publish) kept
-     * the exit code 0 they have always had; changing them would change what the
-     * scheduler sees for failures this issue never measured. Issue #72 is about the
-     * one branch that reports SUCCESS while hiding that it could not even ask the
-     * question.
+     * Until #84 only the schema gate from #72 did, so a publish that failed on every
+     * single run was invisible: routes/console.php schedules this hourly (MeetupEvent)
+     * and daily at 18:00 (Meetup), and ScheduleRunCommand::runEvent judges a run by its
+     * exit code alone — at 0 it raises nothing, dispatches no ScheduledTaskFailed and
+     * reports nothing, so the scheduler recorded a failing publisher as a success.
+     *
+     * TWO codes, not three, because a code only earns its place if a caller would act
+     * differently on it:
+     *
+     * - INVALID (2) — the invocation is wrong: `--model` names something this command
+     *   cannot query. No retry helps; a human has to fix the caller (routes/console.php
+     *   or the command line). This is what Symfony reserves 2 for, and it is the one
+     *   distinction worth making here: a configuration error, not a run failure.
+     * - FAILURE (1) — the invocation was right and the run did not publish: the schema
+     *   gate below, a record that yielded no text, or a publish that was refused. The
+     *   next scheduled run may well succeed, and #72's gate already uses this code.
+     *
+     * "No text generated" shares FAILURE with a refused publish instead of getting a
+     * third code, because the operator's next step is identical for both — read the
+     * error line, which names the model. A code nobody branches on is decoration.
+     *
+     * SUCCESS (0) still means "nothing to do": an empty queue is the normal state of an
+     * hourly run, and alarming on a healthy idle run would be worse than the defect
+     * this fixes.
      */
     public function handle(): int
     {
@@ -77,7 +96,7 @@ class PublishUnpublishedItems extends Command
         if (! $query) {
             $this->error("Unsupported model: {$modelName}");
 
-            return self::SUCCESS;
+            return self::INVALID;
         }
 
         /*
@@ -121,9 +140,13 @@ class PublishUnpublishedItems extends Command
                 $this->info("Published successfully for {$modelName}");
             } else {
                 $this->error("Failed to publish for {$modelName}: ".$result['errorOutput']);
+
+                return self::FAILURE;
             }
         } else {
             $this->error("No text generated for {$modelName}");
+
+            return self::FAILURE;
         }
 
         return self::SUCCESS;

--- a/tests/Feature/Console/NostrPublishExitCodeTest.php
+++ b/tests/Feature/Console/NostrPublishExitCodeTest.php
@@ -1,0 +1,123 @@
+<?php
+
+use App\Console\Commands\Nostr\PublishUnpublishedItems;
+use App\Models\City;
+use App\Models\Country;
+use App\Models\Meetup;
+use App\Models\MeetupEvent;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Process;
+
+/*
+ * Issue #84: `nostr:publish` reported every real failure with exit code 0.
+ *
+ * The command runs from routes/console.php hourly (MeetupEvent) and daily at 18:00
+ * (Meetup). Laravel's ScheduleRunCommand::runEvent is the only thing watching, and it
+ * watches exactly one number: a foreground event whose exit code is non-zero raises
+ * "Scheduled command [...] failed with exit code [N]", dispatches ScheduledTaskFailed
+ * and reports the exception. At exit 0 none of that happens — a publish that fails on
+ * every run is recorded as a success, and the only trace is a log line nobody reads.
+ *
+ * These tests pin one exit code per branch, in both directions: the failures must stay
+ * non-zero, and the two success paths must stay 0, because an idle queue is the normal
+ * state of an hourly run and alarming on it would be worse than the defect being fixed.
+ */
+
+function exitCodeTestMeetup(array $attributes = []): Meetup
+{
+    $city = City::factory()->create([
+        'country_id' => Country::factory()->create(['code' => 'de'])->id,
+    ]);
+
+    return Meetup::factory()->create(array_merge(['city_id' => $city->id], $attributes));
+}
+
+function exitCodeTestMeetupEvent(): MeetupEvent
+{
+    return MeetupEvent::factory()->create([
+        'meetup_id' => exitCodeTestMeetup()->id,
+        'start' => now()->addDay(),
+        // MeetupEventFactory fills nostr_status from NostrHelper::fakeNostrEventStatus(),
+        // which returns a status in 10 % of calls — that would take the record out of the
+        // command's `whereNull` gate and flake these tests one run in ten.
+        'nostr_status' => null,
+    ]);
+}
+
+it('exits INVALID when --model names a model the command cannot query', function () {
+    $this->artisan('nostr:publish', ['--model' => 'Sprint'])
+        ->expectsOutputToContain('Unsupported model: Sprint')
+        ->assertExitCode(2);
+});
+
+it('exits INVALID when --model is missing entirely', function () {
+    $this->artisan('nostr:publish')
+        ->expectsOutputToContain('Unsupported model')
+        ->assertExitCode(2);
+});
+
+/*
+ * The seam is deliberate. NostrTrait::getText returns null only through its
+ * `default` arm — a model that is none of Course, CourseEvent, Meetup, MeetupEvent —
+ * and the command's own match cannot select any other model, so today nothing can
+ * reach this branch. An empty translation cannot either: Translator::get returns
+ * `$line ?: $key`, so a blank line falls back to the key and is never falsy.
+ *
+ * The branch is therefore defence in depth, and the pin is what keeps it that way:
+ * whoever next adds a model arm to the command, or a text arm to the trait, cannot
+ * make "no text generated" exit 0 again without this test going red.
+ */
+it('exits FAILURE when no text could be generated for the record', function () {
+    exitCodeTestMeetupEvent();
+    Process::fake();
+
+    $this->app->bind(PublishUnpublishedItems::class, fn () => new class extends PublishUnpublishedItems
+    {
+        public function getText(Model $model, string $countryCode): ?string
+        {
+            return null;
+        }
+    });
+
+    $this->artisan('nostr:publish', ['--model' => 'MeetupEvent'])
+        ->expectsOutputToContain('No text generated for MeetupEvent')
+        ->assertExitCode(1);
+
+    Process::assertNothingRan();
+});
+
+it('exits FAILURE when the relay refuses the publish', function () {
+    exitCodeTestMeetupEvent();
+
+    Process::fake([
+        '*' => Process::result(output: '', errorOutput: 'relay refused the note', exitCode: 1),
+    ]);
+
+    $this->artisan('nostr:publish', ['--model' => 'MeetupEvent'])
+        ->expectsOutputToContain('Failed to publish for MeetupEvent: relay refused the note')
+        ->assertExitCode(1);
+});
+
+it('stays SUCCESS when the publish goes through', function () {
+    $meetupEvent = exitCodeTestMeetupEvent();
+
+    Process::fake([
+        '*' => Process::result(output: 'note1'.str_repeat('a', 58)),
+    ]);
+
+    $this->artisan('nostr:publish', ['--model' => 'MeetupEvent'])
+        ->expectsOutputToContain('Published successfully for MeetupEvent')
+        ->assertExitCode(0);
+
+    expect($meetupEvent->fresh()->nostr_status)->toBe('note1'.str_repeat('a', 58));
+});
+
+it('stays SUCCESS on an idle run with nothing to publish', function () {
+    $this->artisan('nostr:publish', ['--model' => 'MeetupEvent'])
+        ->expectsOutputToContain('No unpublished items for model: MeetupEvent')
+        ->assertExitCode(0);
+
+    $this->artisan('nostr:publish', ['--model' => 'Meetup'])
+        ->expectsOutputToContain('No unpublished items for model: Meetup')
+        ->assertExitCode(0);
+});


### PR DESCRIPTION
Three branches reported a real failure and returned 0: an unsupported
model, no text generated, and a refused publish. The command runs hourly
and again at 18:00, so a publish that failed every single time was
invisible to anything watching exit codes -- the scheduler recorded
success. An exit code that cannot express failure is an ornament, and
any alarm built on it is a decoy.

TWO codes, not three. An unsupported model returns INVALID (2): the
invocation itself is wrong, no retry helps, and a human has to fix
routes/console.php or the command line -- which is the one distinction
#84 asks for. No text generated and a refused publish share FAILURE (1),
because the operator's next step is identical for both: read the error
line, which names the model. A code no caller branches on is decoration.
The reasoning is in the handle() docblock, not only here.

What the scheduler now sees, read from ScheduleRunCommand::runEvent
rather than assumed: both entries are foreground, so a non-zero code
raises, dispatches ScheduledTaskFailed, and is reported -- Nightwatch is
installed and receives reported exceptions. schedule:run still exits 0;
it catches that. Nothing registers onFailure or emailOutputOnFailure, so
the report and the event are the whole signal. Code 2 is unreachable
from the scheduler, since both entries pass supported models.

Six pins, one per failure branch plus BOTH success paths. The success
pins are the point: alarming on a healthy empty queue would be a worse
defect than the one being fixed, and two mutation probes cover exactly
that -- a successful publish or an idle run returning FAILURE each
reddens a test. A third probe returns 2 as 1 and still fails, so the pin
is on the value rather than on "non-zero".

The no-text branch is currently unreachable in production and the test
says so: NostrTrait::getText() returns null only for a model the
command's own match cannot select, and an empty translation cannot get
there either -- Translator::get() ends in `$line ?: $key`, so a blank
line falls back to the key and is never falsy. The branch stays as
defence in depth, pinned through a bound subclass, so a future model arm
cannot silently exit 0.

routes/console.php is untouched: its comment describes
PublishCalendarEvents and is still true.

Closes #84



🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XfFQ18DFktM3ewnWo9Zt9X
