### PR TITLE
Give MeetupEventResource the same zone-marked timestamps

### DIFF
--- a/app/Http/Resources/MeetupEventResource.php
+++ b/app/Http/Resources/MeetupEventResource.php
@@ -21,10 +21,55 @@ class MeetupEventResource extends JsonResource
             'meetup_id' => $this->meetup_id,
             /** Headline for this one date; null means the meetup's own name applies. */
             'title' => $this->title,
-            /** Start of the event, UTC. */
+            /**
+             * DEPRECATED (issue #85): start of the event, UTC, in Carbon's default JSON
+             * form — `2026-09-16T17:00:00.000000Z`, microseconds and a `Z` suffix. That
+             * is a THIRD spelling of one instant beside the `2026-09-16 17:00` and
+             * `2026-09-16T17:00:00+00:00` the list endpoints emit; read `start_iso`
+             * below instead, which is the form the rest of the API uses.
+             *
+             * Kept unchanged, byte for byte, until the consumers of these endpoints and
+             * of the MCP tools have moved over — dropping it is a breaking change and
+             * belongs to a coordinated client release, not to a later edit here. Both
+             * fields describe the same instant, so a client can migrate one at a time.
+             */
             'start' => $this->start,
-            /** End of THIS occurrence, UTC. Null for open-ended meetups; `recurrence_end_date` ends the series. */
+            /**
+             * DEPRECATED (issue #85), exactly like `start` above and on the same terms:
+             * end of THIS occurrence, UTC, as `2026-09-16T20:30:00.000000Z`. Null for
+             * open-ended meetups; `recurrence_end_date` ends the series. Read `end_iso`.
+             */
             'end' => $this->end,
+            /**
+             * The zone-marked replacement for `start` (issue #85):
+             * `2026-09-16T17:00:00+00:00` — ISO 8601 with a numeric OFFSET, not the `Z`
+             * shorthand and without microseconds. Identical format and identical
+             * `<field>_iso` naming to `start_iso` on `GET /api/meetup-events` and
+             * `next_event_start_iso` on `GET /api/mobile/meetups` (issue #71), so a
+             * client reading a list and then a single event parses ONE form.
+             *
+             * This is the CONVERT case, not the reinterpret one. `start` is a `datetime`
+             * cast, so the value arrives as an App\Support\Carbon that already knows its
+             * zone, and `->setTimezone('UTC')` moves that known instant to UTC.
+             * `Carbon::parse($value, 'UTC')` — what MobileMeetupListController needs,
+             * because its correlated subquery hands it a bare `Y-m-d H:i:s` string with
+             * no zone at all — would be the wrong operation here: this value is never a
+             * zoneless string. App\Support\Carbon extends CarbonImmutable, so the
+             * conversion returns a new instance and cannot move the deprecated field.
+             *
+             * A no-op in value today (config('app.timezone') is UTC, and SetTimezone
+             * runs on the web middleware group only — never on an API or MCP request).
+             * Spelling the conversion out makes `+00:00` a promise of this resource
+             * instead of a side effect of that configuration.
+             */
+            'start_iso' => $this->start->setTimezone('UTC')->toIso8601String(),
+            /**
+             * The zone-marked replacement for `end` (issue #85):
+             * `2026-09-16T20:30:00+00:00`, converted exactly like `start_iso`. Always
+             * present, and null for an open-ended event — never absent, so a client can
+             * tell "no end time" from "this endpoint does not serve one".
+             */
+            'end_iso' => $this->end?->setTimezone('UTC')->toIso8601String(),
             /**
              * The address in plain words, as the organiser wrote it. Always the readable
              * answer — including "watch the Signal group" — while the `osm_*` fields below

--- a/tests/Feature/Api/MeetupEventResourceTimestampsApiTest.php
+++ b/tests/Feature/Api/MeetupEventResourceTimestampsApiTest.php
@@ -1,0 +1,122 @@
+<?php
+
+use App\Models\City;
+use App\Models\Country;
+use App\Models\Meetup;
+use App\Models\MeetupEvent;
+use App\Models\User;
+use Laravel\Sanctum\Sanctum;
+
+/*
+ * Issue #85: MeetupEventResource passed `start` / `end` through as raw Carbon objects,
+ * so Laravel's default serialisation decided the format — `2026-09-16T17:00:00.000000Z`.
+ * That is a THIRD spelling of one instant next to the `Y-m-d H:i` and the
+ * `+00:00` form the list endpoints emit since #71.
+ *
+ * The fix is ADDITIVE, exactly as in #71: `start_iso` / `end_iso` are new and carry the
+ * `+00:00` form; the Carbon-serialised fields stay byte for byte until the consumers of
+ * the authenticated endpoints and of the MCP tools have moved over. Half of this file
+ * therefore asserts that the old fields did NOT move.
+ *
+ * Every assertion is on the literal emitted string, and the deprecated literals below
+ * were measured against `master` before the change rather than copied from the issue.
+ * `assertJsonStructure()` or `toHaveKey()` would stay green through exactly the silent
+ * format change this issue is about.
+ */
+
+beforeEach(function () {
+    $this->owner = User::factory()->create();
+    Sanctum::actingAs($this->owner);
+
+    $country = Country::factory()->create(['code' => 'de']);
+    $city = City::factory()->create(['country_id' => $country->id]);
+    // The creator becomes leader of the meetup through the model's booted hook, which
+    // is what makes the event show up in `mine` / `mineShow`.
+    $this->meetup = Meetup::factory()->create([
+        'city_id' => $city->id,
+        'created_by' => $this->owner->id,
+    ]);
+});
+
+function meetupEventForResource(array $attributes = []): MeetupEvent
+{
+    return MeetupEvent::factory()->create([
+        'meetup_id' => test()->meetup->id,
+        'created_by' => test()->owner->id,
+        'start' => '2026-09-16 17:00:00',
+        'end' => '2026-09-16 20:30:00',
+        ...$attributes,
+    ]);
+}
+
+it('leaves the Carbon-serialised start/end of the authenticated endpoints untouched', function () {
+    $event = meetupEventForResource();
+
+    $data = $this->getJson("/api/my-meetup-events/{$event->id}")->assertOk()->json('data');
+
+    expect($data['start'])->toBe('2026-09-16T17:00:00.000000Z')
+        ->and($data['end'])->toBe('2026-09-16T20:30:00.000000Z');
+});
+
+it('leaves the Carbon-serialised start/end of the mine list untouched as well', function () {
+    $event = meetupEventForResource();
+
+    $row = collect($this->getJson('/api/my-meetup-events')->assertOk()->json('data'))
+        ->firstWhere('id', $event->id);
+
+    expect($row['start'])->toBe('2026-09-16T17:00:00.000000Z')
+        ->and($row['end'])->toBe('2026-09-16T20:30:00.000000Z');
+});
+
+it('adds zone-marked ISO 8601 twins to MeetupEventResource', function () {
+    $event = meetupEventForResource();
+
+    $data = $this->getJson("/api/my-meetup-events/{$event->id}")->assertOk()->json('data');
+
+    expect($data['start_iso'])->toBe('2026-09-16T17:00:00+00:00')
+        ->and($data['end_iso'])->toBe('2026-09-16T20:30:00+00:00');
+});
+
+it('keeps end_iso present and null for an open-ended event, exactly like end', function () {
+    $event = meetupEventForResource(['end' => null]);
+
+    $data = $this->getJson("/api/my-meetup-events/{$event->id}")->assertOk()->json('data');
+
+    expect($data)->toHaveKey('end_iso')
+        ->and($data['end'])->toBeNull()
+        ->and($data['end_iso'])->toBeNull()
+        ->and($data['start_iso'])->toBe('2026-09-16T17:00:00+00:00');
+});
+
+it('emits the same start_iso for one event through the resource and through the list endpoint', function () {
+    /*
+     * The point of the whole issue: one instant, one new spelling — not a fourth. The
+     * two values are asserted AGAINST EACH OTHER, not each against its own literal,
+     * because a per-endpoint literal test passes while the two silently diverge. The
+     * literal is pinned once afterwards so a pair of nulls cannot satisfy the equality.
+     */
+    $event = meetupEventForResource();
+
+    $resource = $this->getJson("/api/my-meetup-events/{$event->id}")->assertOk()->json('data');
+    $listRow = collect($this->getJson('/api/meetup-events')->assertOk()->json())
+        ->firstWhere('id', $event->id);
+
+    expect($resource['start_iso'])->toBe($listRow['start_iso'])
+        ->and($resource['end_iso'])->toBe($listRow['end_iso'])
+        ->and($listRow['start_iso'])->toBe('2026-09-16T17:00:00+00:00');
+});
+
+it('states one instant in exactly two spellings per endpoint, and the new one is shared', function () {
+    // The deprecated spellings still differ per endpoint — that is the migration debt
+    // #71 and #85 both left in place on purpose. What may NOT differ is the `_iso` form.
+    $event = meetupEventForResource();
+
+    $resource = $this->getJson("/api/my-meetup-events/{$event->id}")->assertOk()->json('data');
+    $listRow = collect($this->getJson('/api/meetup-events')->assertOk()->json())
+        ->firstWhere('id', $event->id);
+
+    expect([$resource['start'], $listRow['start']])
+        ->toBe(['2026-09-16T17:00:00.000000Z', '2026-09-16 17:00'])
+        ->and(array_unique([$resource['start_iso'], $listRow['start_iso']]))
+        ->toBe(['2026-09-16T17:00:00+00:00']);
+});

--- a/tests/Feature/Mcp/MeetupEventMcpToolTest.php
+++ b/tests/Feature/Mcp/MeetupEventMcpToolTest.php
@@ -5,6 +5,8 @@ use App\Mcp\Tools\MeetupEvent\CreateMeetupEventTool;
 use App\Mcp\Tools\MeetupEvent\ListMyMeetupEventsTool;
 use App\Mcp\Tools\MeetupEvent\ShowMyMeetupEventTool;
 use App\Mcp\Tools\MeetupEvent\UpdateMeetupEventTool;
+use App\Models\City;
+use App\Models\Country;
 use App\Models\Meetup;
 use App\Models\MeetupEvent;
 use App\Models\User;
@@ -19,7 +21,16 @@ it('lets an authenticated user create a meetup event and stamps created_by', fun
         'location' => 'Marktplatz',
     ]);
 
-    $response->assertOk()->assertSee('Marktplatz');
+    /*
+     * The timestamp shape is part of what this tool puts in front of an agent, so it is
+     * asserted here rather than left to rot (issue #85): the zone-marked `start_iso`
+     * arrived, and the Carbon-serialised `start` beside it did NOT move — dropping it
+     * would break every consumer that already reads it.
+     */
+    $response->assertOk()
+        ->assertSee('Marktplatz')
+        ->assertSee('2026-08-01T18:00:00+00:00')
+        ->assertSee('2026-08-01T18:00:00.000000Z');
 
     $this->assertDatabaseHas('meetup_events', [
         'location' => 'Marktplatz',
@@ -69,4 +80,34 @@ it('forbids viewing someone elses meetup event in mine show', function () {
     EinundzwanzigServer::actingAs(User::factory()->create())
         ->tool(ShowMyMeetupEventTool::class, ['id' => $meetupEvent->id])
         ->assertHasErrors();
+});
+
+it('hands an agent the same start_iso over MCP as GET /api/meetup-events does over HTTP', function () {
+    /*
+     * The MCP tools serialise through MeetupEventResource, so an agent that lists events
+     * over HTTP and then reads one over MCP must see ONE spelling of the instant
+     * (issue #85). The tool's value is asserted against the ENDPOINT'S value, not
+     * against a second literal — a per-consumer literal stays green while the two
+     * diverge. The literal below only keeps a pair of empty strings from satisfying it,
+     * since assertSee('') would match anything.
+     */
+    $user = User::factory()->create();
+    $country = Country::factory()->create(['code' => 'de']);
+    $city = City::factory()->create(['country_id' => $country->id]);
+    $meetup = Meetup::factory()->create(['city_id' => $city->id, 'created_by' => $user->id]);
+    $event = MeetupEvent::factory()->create([
+        'meetup_id' => $meetup->id,
+        'created_by' => $user->id,
+        'start' => '2026-08-01 18:00:00',
+    ]);
+
+    $listRow = collect($this->getJson('/api/meetup-events')->assertOk()->json())
+        ->firstWhere('id', $event->id);
+
+    expect($listRow['start_iso'])->toBe('2026-08-01T18:00:00+00:00');
+
+    EinundzwanzigServer::actingAs($user)
+        ->tool(ShowMyMeetupEventTool::class, ['id' => $event->id])
+        ->assertOk()
+        ->assertSee($listRow['start_iso']);
 });


### PR DESCRIPTION
The API stated one instant in three spellings: Y-m-d H:i with no zone
on the legacy list fields, +00:00 on the fields #71 added, and
.000000Z from MeetupEventResource passing raw Carbon objects through.
The third reaches POST, PATCH, my-meetup-events, mineShow -- and every
agent-driven read, because the MCP tools go through this resource.

start_iso and end_iso are added additively in the +00:00 form. The old
fields keep their spelling and are deprecated in place, the migration
path #71 established.

CONVERT, not reinterpret, and measured rather than assumed:
MeetupEvent casts start and end to datetime, so the value arrives as a
Carbon that already knows its zone -- get_class() returns
App\Support\Carbon, and the pre-change resource emitted
2026-09-16T17:00:00.000000Z, which is exactly the third spelling. The
mobile endpoint's correlated subquery yields a zoneless string and
therefore needs the zone inside parse(); here that would be the wrong
operation. App\Support\Carbon extends CarbonImmutable, so
setTimezone() cannot move the `start` printed beside it -- checked with
an identity comparison, not assumed.

The cross-consumer test compares the two values AGAINST EACH OTHER, not
each against its own literal, because a per-endpoint literal test passes
while the two diverge. The literal appears once beside it so a pair of
nulls cannot satisfy the equality. Probe A confirms it: changing only
the resource to the Z form reddens that assertion and the MCP one with
it, while the byte-identity tests stay green.

DoD 5 turned up something worth naming: the MCP tests asserted no
timestamp shape at all -- only assertSee('Marktplatz'). They now pin
both forms, and a new test requires an agent to receive the same
start_iso over MCP as HTTP delivers.

The API still has three spellings, not four: the new one is the SAME
string across all three consumers, verified against each other rather
than declared.

Found, not fixed: recurrence_end_date, created_at and updated_at in this
same resource still go out as raw Carbon in the .000000Z form. #85 names
start and end, and the owner's decision was about those two. Same
defect, three more fields, its own follow-up.

Closes #85



🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XfFQ18DFktM3ewnWo9Zt9X
