### PR TITLE
Let the deprecated link field move one entry, not the whole list

### DIFF
--- a/app/Http/Requests/Api/UpdateMeetupEventRequest.php
+++ b/app/Http/Requests/Api/UpdateMeetupEventRequest.php
@@ -85,9 +85,13 @@ class UpdateMeetupEventRequest extends FormRequest
             /**
              * Where to read more or sign up.
              *
-             * DEPRECATED (issue #70): use `links`. Still accepted and stored as a
-             * one-entry list, which REPLACES whatever list the event had. When both are
-             * sent, `links` wins and this value is dropped.
+             * DEPRECATED (issue #70): use `links`. Still accepted, and it addresses the
+             * FIRST entry of the list only (issue #108): a URL replaces that entry,
+             * `null` removes it, and every further entry keeps its place and its label.
+             * The answer's `link` is the first entry of the resulting list, which after
+             * a `null` is the entry that moved up. Replacing the whole list is what
+             * `links` is for; when both are sent, `links` wins and this value is
+             * dropped.
              *
              * @example https://example.com/meetup
              */

--- a/app/Http/Resources/MeetupEventResource.php
+++ b/app/Http/Resources/MeetupEventResource.php
@@ -96,8 +96,9 @@ class MeetupEventResource extends JsonResource
              * DEPRECATED (issue #70): the FIRST of `links` below, or null. An event can
              * carry up to five links since #70, and this field only ever shows one of
              * them. It is kept, unchanged, so existing clients do not break; read
-             * `links` instead. It is also still accepted on write, where it is taken as
-             * a one-entry list.
+             * `links` instead. It is also still accepted on write, where it addresses
+             * the first entry of the list only — see the `link` field of the create and
+             * update requests (issue #108).
              */
             'link' => $this->link,
             /**

--- a/app/Mcp/Tools/MeetupEvent/CreateMeetupEventTool.php
+++ b/app/Mcp/Tools/MeetupEvent/CreateMeetupEventTool.php
@@ -138,7 +138,11 @@ class CreateMeetupEventTool extends Tool
             'end' => $schema->string()->description('Optionales Ende DIESES Termins als Datum/Uhrzeit. Nicht zu verwechseln mit recurrence_end_date, das die Serie beendet.'),
             'location' => $schema->string()->description('Veranstaltungsort.'),
             'description' => $schema->string()->description('Beschreibung des Termins.'),
-            'link' => $schema->string()->description('Link zum Termin (URL).'),
+            'link' => $schema->string()->description('VERALTET, bitte "links" verwenden. Wird als erster Eintrag der Link-Liste gespeichert. Werden beide angegeben, gewinnt "links".'),
+            'links' => $schema->array()->items($schema->object([
+                'url' => $schema->string()->description('Die URL selbst.')->required(),
+                'label' => $schema->string()->description('Optionale Bezeichnung, z. B. "Meetup.com". Ohne Bezeichnung wird die blanke URL angezeigt.'),
+            ]))->max(MeetupEvent::MAX_LINKS)->description('Alle Orte, an denen der Termin angekündigt ist — Meetup.com, Luma, eigene Website, Telegram, Nostr. Höchstens '.MeetupEvent::MAX_LINKS.' Einträge in der gewünschten Reihenfolge; weglassen oder [] bedeutet keine Links. Ein sechster Eintrag wird abgelehnt, nichts wird still verworfen. Bei einer Serie erhalten alle Vorkommen dieselbe Liste.'),
             'tags' => $schema->array()->items($schema->string())->description('Themen-Tags dieses Termins, als NAMEN (z. B. ["Vortrag", "Einsteiger"]). Zulässig sind ausschließlich die Namen aus list-event-tags; erkannt wird jede der neun Sprachen, Groß-/Kleinschreibung egal. Ein unbekannter oder mehrdeutiger Name wird abgelehnt und es wird NIE ein Tag neu angelegt — dann bricht der ganze Aufruf ab, es entsteht kein Termin. Bei einer Serie erhalten alle Vorkommen dieselben Tags.'),
             'recurrence_type' => $schema->string()->description('Wiederholungstyp.'),
             'recurrence_day_of_week' => $schema->string()->description('Wochentag der Wiederholung.'),

--- a/app/Mcp/Tools/MeetupEvent/UpdateMeetupEventTool.php
+++ b/app/Mcp/Tools/MeetupEvent/UpdateMeetupEventTool.php
@@ -88,7 +88,11 @@ class UpdateMeetupEventTool extends Tool
             'end' => $schema->string()->description('Optionales Ende DIESES Termins. Nicht recurrence_end_date, das die Serie beendet.'),
             'location' => $schema->string()->description('Veranstaltungsort.'),
             'description' => $schema->string()->description('Beschreibung des Termins.'),
-            'link' => $schema->string()->description('Link zum Termin (URL).'),
+            'link' => $schema->string()->description('VERALTET, bitte "links" verwenden. Betrifft NUR den ERSTEN Eintrag der Link-Liste: eine URL ersetzt ihn, weglassen lässt alles unverändert. Alle weiteren Einträge bleiben samt Bezeichnung stehen. Wer die ganze Liste setzen will, nimmt "links".'),
+            'links' => $schema->array()->items($schema->object([
+                'url' => $schema->string()->description('Die URL selbst.')->required(),
+                'label' => $schema->string()->description('Optionale Bezeichnung, z. B. "Meetup.com". Ohne Bezeichnung wird die blanke URL angezeigt.'),
+            ]))->max(MeetupEvent::MAX_LINKS)->description('Ersetzt die Link-Liste des Termins VOLLSTÄNDIG, höchstens '.MeetupEvent::MAX_LINKS.' Einträge in der gewünschten Reihenfolge. Weglassen lässt die bestehenden Links unverändert; [] entfernt alle. Ein sechster Eintrag wird abgelehnt, nichts wird still verworfen.'),
             'tags' => $schema->array()->items($schema->string())->description('Ersetzt die Themen-Tags des Termins VOLLSTÄNDIG, als NAMEN (z. B. ["Vortrag", "Einsteiger"]). Weglassen lässt die bestehenden Tags unverändert; [] entfernt alle. Zulässig sind ausschließlich die Namen aus list-event-tags; erkannt wird jede der neun Sprachen, Groß-/Kleinschreibung egal. Ein unbekannter oder mehrdeutiger Name wird abgelehnt, der Termin bleibt dabei unverändert, und es wird NIE ein Tag neu angelegt.'),
             'recurrence_type' => $schema->string()->description('Wiederholungstyp.'),
             'recurrence_day_of_week' => $schema->string()->description('Wochentag der Wiederholung.'),

--- a/app/Models/MeetupEvent.php
+++ b/app/Models/MeetupEvent.php
@@ -156,6 +156,28 @@ class MeetupEvent extends Model
      * cast would re-encode the JSON, and "unchanged" has to mean the bytes in the column,
      * not a value that merely decodes the same. Restoring the raw string also makes the
      * attribute clean again, so the UPDATE statement does not carry the column at all.
+     *
+     * ## Writing `link` moves ONE entry, not the whole list (issue #108)
+     *
+     * The last branch used to build the list from the deprecated field alone, so
+     * `PATCH {"link": null}` left an event that had five labelled links with none —
+     * the same harm #70 closed one field over, and not hypothetical: the MCP update
+     * tool exposed `link` and nothing else, so an agent that did not re-send a URL
+     * wiped a list it had no way of knowing about.
+     *
+     * `link` is a view of ENTRY ONE, so writing it replaces entry one and clearing it
+     * removes entry one; entries two to five keep their order and their labels either
+     * way. The replacement carries no label, because a label describes the URL it was
+     * written for and not the one that took its place. On an empty list there is no
+     * entry one, so clearing is a no-op; on a one-entry list — every pre-#70 row and
+     * every event a legacy client ever created — entry one IS the list, so the field
+     * behaves exactly as it always did. Replacing the WHOLE list is what `links` is
+     * for, and the two must not be conflated.
+     *
+     * The mirror is re-derived afterwards rather than left at what the caller sent:
+     * `link` is documented as the first of `links`, and a null next to four surviving
+     * entries would tell a client that reads only the legacy field that this event has
+     * no link at all.
      */
     protected static function booted(): void
     {
@@ -174,9 +196,38 @@ class MeetupEvent extends Model
             }
 
             if ($meetupEvent->isDirty('link')) {
-                $meetupEvent->setAttribute('links', self::normaliseLinks([$meetupEvent->link]));
+                $entries = self::withFirstLink($meetupEvent->links, $meetupEvent->link);
+
+                $meetupEvent->setAttribute('links', $entries);
+                $meetupEvent->setAttribute('link', $entries[0]['url'] ?? null);
             }
         });
+    }
+
+    /**
+     * The list that results from writing the deprecated `link` on it (issue #108).
+     *
+     * Entry one is replaced by the given URL, or removed when there is none — a blank
+     * string counts as none, because a URL that is only whitespace is not a link. The
+     * splice does both in one step: with an empty replacement it deletes, with a
+     * one-entry replacement it substitutes, and on an empty list it appends the only
+     * entry there can be.
+     *
+     * A NULL `links` is the pre-#70 row {@see self::linkList()} describes. Its list is
+     * whatever the deprecated column held, which is entry one and nothing else — so
+     * treating it as empty here and writing the result back is the same answer, and it
+     * leaves the row in the one shape the column is supposed to have.
+     *
+     * @param  mixed  $links  The list as it stands, in any shape a writer may have left.
+     * @return list<array{url: string, label?: string}>
+     */
+    private static function withFirstLink(mixed $links, ?string $url): array
+    {
+        $entries = self::normaliseLinks($links);
+
+        array_splice($entries, 0, 1, self::normaliseLinks([$url]));
+
+        return $entries;
     }
 
     /**

--- a/tests/Feature/Api/MeetupEventDeprecatedLinkApiTest.php
+++ b/tests/Feature/Api/MeetupEventDeprecatedLinkApiTest.php
@@ -1,0 +1,192 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| Issue #108 — the deprecated `link` addresses the FIRST entry, nothing else
+|--------------------------------------------------------------------------
+|
+| Same harm class as #70, one field over: `PATCH {"link": null}` replaced the
+| whole stored list with an empty one, so an event with five labelled links
+| came back with none. #70 closed that door for `links`; this one closes it
+| for `link`.
+|
+| The rule these tests pin down: `link` is a view of entry ONE of the list.
+| Writing it replaces that entry, clearing it removes that entry, and entries
+| two to five are never touched either way. `links` keeps replacing the whole
+| list — the two fields say different things and must not be conflated.
+|
+| One test per input shape, exactly as #70 has for `links`, because the shapes
+| are three different answers and only a test per shape can tell them apart.
+|
+*/
+
+use App\Models\Meetup;
+use App\Models\MeetupEvent;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Laravel\Sanctum\Sanctum;
+
+function deprecatedLinkApiMeetup(): Meetup
+{
+    Sanctum::actingAs($user = User::factory()->create());
+
+    return Meetup::factory()->create(['created_by' => $user->id]);
+}
+
+/**
+ * @param  list<array{url: string, label?: string}>  $links
+ */
+function eventWithLinks(Meetup $meetup, array $links): MeetupEvent
+{
+    return MeetupEvent::factory()->for($meetup)->create(['links' => $links]);
+}
+
+/**
+ * The three labelled links of the issue report, plus the two that make "entries
+ * 2 to 5 keep their order and labels" a statement about more than one row.
+ *
+ * @return list<array{url: string, label?: string}>
+ */
+function fiveLabelledLinks(): array
+{
+    return [
+        ['url' => 'https://www.meetup.com/bitcoin-berlin/', 'label' => 'Meetup.com'],
+        ['url' => 'https://luma.com/berlin', 'label' => 'Luma'],
+        ['url' => 'https://t.me/berlin_btc', 'label' => 'Telegram'],
+        ['url' => 'https://x.com/btc_berlin', 'label' => 'X'],
+        ['url' => 'https://berlin.einundzwanzig.space'],
+    ];
+}
+
+/** @return list<array{url: string, label: string|null}> */
+function linksInColumn(MeetupEvent $event): array
+{
+    return json_decode(DB::table('meetup_events')->where('id', $event->id)->value('links'), true);
+}
+
+it('leaves the list alone when link is absent from the patch', function () {
+    $event = eventWithLinks(deprecatedLinkApiMeetup(), fiveLabelledLinks());
+    $before = DB::table('meetup_events')->where('id', $event->id)->value('links');
+
+    $this->patchJson("/api/meetup-events/{$event->id}", ['description' => 'Neuer Text'])
+        ->assertSuccessful()
+        ->assertJsonPath('data.links', $event->linkList())
+        ->assertJsonPath('data.link', 'https://www.meetup.com/bitcoin-berlin/');
+
+    expect(DB::table('meetup_events')->where('id', $event->id)->value('links'))->toBe($before);
+});
+
+it('removes only the first entry when link is sent as null', function () {
+    $event = eventWithLinks(deprecatedLinkApiMeetup(), fiveLabelledLinks());
+
+    $response = $this->patchJson("/api/meetup-events/{$event->id}", ['link' => null]);
+
+    // The four survivors, in their order, with their labels — the part the old
+    // behaviour destroyed without a trace.
+    $response->assertSuccessful()
+        ->assertJsonPath('data.links', [
+            ['url' => 'https://luma.com/berlin', 'label' => 'Luma'],
+            ['url' => 'https://t.me/berlin_btc', 'label' => 'Telegram'],
+            ['url' => 'https://x.com/btc_berlin', 'label' => 'X'],
+            ['url' => 'https://berlin.einundzwanzig.space', 'label' => null],
+        ])
+        // `link` is the first entry of the list, and the first entry is now Luma.
+        // Answering null here would leave a legacy reader believing an event with
+        // four links has none.
+        ->assertJsonPath('data.link', 'https://luma.com/berlin');
+
+    expect(linksInColumn($event))->toBe([
+        ['url' => 'https://luma.com/berlin', 'label' => 'Luma'],
+        ['url' => 'https://t.me/berlin_btc', 'label' => 'Telegram'],
+        ['url' => 'https://x.com/btc_berlin', 'label' => 'X'],
+        ['url' => 'https://berlin.einundzwanzig.space'],
+    ]);
+});
+
+it('replaces only the first entry when link is sent as a URL', function () {
+    $event = eventWithLinks(deprecatedLinkApiMeetup(), fiveLabelledLinks());
+
+    $this->patchJson("/api/meetup-events/{$event->id}", ['link' => 'https://example.com/new-first'])
+        ->assertSuccessful()
+        ->assertJsonPath('data.links', [
+            // The label went with the URL it described: an old label on a new link
+            // would say something about a link that is no longer there.
+            ['url' => 'https://example.com/new-first', 'label' => null],
+            ['url' => 'https://luma.com/berlin', 'label' => 'Luma'],
+            ['url' => 'https://t.me/berlin_btc', 'label' => 'Telegram'],
+            ['url' => 'https://x.com/btc_berlin', 'label' => 'X'],
+            ['url' => 'https://berlin.einundzwanzig.space', 'label' => null],
+        ])
+        ->assertJsonPath('data.link', 'https://example.com/new-first');
+
+    expect(linksInColumn($event))->toHaveCount(5);
+});
+
+it('still replaces the whole list when links is sent', function () {
+    $event = eventWithLinks(deprecatedLinkApiMeetup(), fiveLabelledLinks());
+
+    $this->patchJson("/api/meetup-events/{$event->id}", [
+        'links' => [['url' => 'https://example.com/only', 'label' => 'Only']],
+    ])
+        ->assertSuccessful()
+        ->assertJsonPath('data.links', [['url' => 'https://example.com/only', 'label' => 'Only']])
+        ->assertJsonPath('data.link', 'https://example.com/only');
+
+    expect(linksInColumn($event))->toBe([['url' => 'https://example.com/only', 'label' => 'Only']]);
+});
+
+/*
+ * The two edge cases a caller hits without meaning to (issue #108). Both are the
+ * same rule applied to a shorter list, which is why they are written down: an
+ * empty list has no entry one to remove, and a one-entry list is entirely entry
+ * one — so there the new rule and the pre-#70 behaviour coincide exactly, and a
+ * legacy client that only ever knew a single link keeps the semantics it had.
+ */
+it('does nothing when link is cleared on an event that has no links at all', function () {
+    $event = eventWithLinks(deprecatedLinkApiMeetup(), []);
+
+    $this->patchJson("/api/meetup-events/{$event->id}", ['link' => null])
+        ->assertSuccessful()
+        ->assertJsonPath('data.links', [])
+        ->assertJsonPath('data.link', null);
+
+    expect(linksInColumn($event))->toBe([]);
+});
+
+it('empties the list when link is cleared on an event that has exactly one', function () {
+    $event = eventWithLinks(deprecatedLinkApiMeetup(), [
+        ['url' => 'https://example.com/only', 'label' => 'Only'],
+    ]);
+
+    $this->patchJson("/api/meetup-events/{$event->id}", ['link' => null])
+        ->assertSuccessful()
+        ->assertJsonPath('data.links', [])
+        ->assertJsonPath('data.link', null);
+
+    expect(linksInColumn($event))->toBe([]);
+});
+
+it('sets the single link of an event that has none without inventing a second entry', function () {
+    $event = eventWithLinks(deprecatedLinkApiMeetup(), []);
+
+    $this->patchJson("/api/meetup-events/{$event->id}", ['link' => 'https://example.com/first'])
+        ->assertSuccessful()
+        ->assertJsonPath('data.links', [['url' => 'https://example.com/first', 'label' => null]])
+        ->assertJsonPath('data.link', 'https://example.com/first');
+});
+
+it('applies the same rule to a row the backfill never reached, where links is still NULL', function () {
+    $meetup = deprecatedLinkApiMeetup();
+    $event = MeetupEvent::factory()->for($meetup)->create(['link' => 'https://example.com/legacy']);
+
+    // A pre-#70 row: the column is genuinely NULL, and its only link is the
+    // deprecated field, which IS entry one.
+    DB::table('meetup_events')->where('id', $event->id)->update(['links' => null]);
+
+    $this->patchJson("/api/meetup-events/{$event->id}", ['link' => null])
+        ->assertSuccessful()
+        ->assertJsonPath('data.links', [])
+        ->assertJsonPath('data.link', null);
+
+    expect(linksInColumn($event))->toBe([]);
+});

--- a/tests/Feature/Api/MeetupEventLinksApiTest.php
+++ b/tests/Feature/Api/MeetupEventLinksApiTest.php
@@ -162,15 +162,24 @@ it('clears the list when links is sent as an empty array', function () {
     expect(json_decode(DB::table('meetup_events')->where('id', $event->id)->value('links'), true))->toBe([]);
 });
 
-it('keeps the deprecated single link working as an explicit replacement of the list', function () {
+it('keeps the deprecated single link working, on the first entry of the list', function () {
     $meetup = meetupEventLinksApiMeetup();
     $event = meetupEventWithFiveLinks($meetup);
 
     // `link` sent, `links` sent as null: the legacy field is the only thing the client
-    // said anything about, so it wins — one entry, and no leftovers of the old list.
+    // said anything about, so it is applied — to entry one. Until #108 it replaced the
+    // whole list here, and the four labelled entries below were the data loss that
+    // issue reported. The shapes of `link` itself have their own file,
+    // tests/Feature/Api/MeetupEventDeprecatedLinkApiTest.php.
     $this->patchJson("/api/meetup-events/{$event->id}", ['links' => null, 'link' => 'https://example.com/only'])
         ->assertSuccessful()
-        ->assertJsonPath('data.links', [['url' => 'https://example.com/only', 'label' => null]])
+        ->assertJsonPath('data.links', [
+            ['url' => 'https://example.com/only', 'label' => null],
+            ['url' => 'https://luma.com/berlin', 'label' => 'Luma'],
+            ['url' => 'https://t.me/berlin_btc', 'label' => 'Telegram'],
+            ['url' => 'https://x.com/btc_berlin', 'label' => 'X'],
+            ['url' => 'https://berlin.einundzwanzig.space', 'label' => null],
+        ])
         ->assertJsonPath('data.link', 'https://example.com/only');
 });
 

--- a/tests/Feature/Mcp/MeetupEventLinksMcpTest.php
+++ b/tests/Feature/Mcp/MeetupEventLinksMcpTest.php
@@ -1,0 +1,144 @@
+<?php
+
+/*
+|--------------------------------------------------------------------------
+| Issue #108 — the MCP tools know about `links`, not only about `link`
+|--------------------------------------------------------------------------
+|
+| The schema is the concrete exposure the issue names: an agent can only send
+| what the schema offers, so as long as `link` was the only link field there,
+| an agent-driven update was structurally unable to keep a multi-entry list —
+| it either re-sent one URL or cleared everything.
+|
+| Two halves, and both are needed. The schema tests state what an agent can
+| SEE; the behaviour tests state what happens when it writes, including the
+| clearing shape that produced the data loss.
+|
+*/
+
+use App\Mcp\Servers\EinundzwanzigServer;
+use App\Mcp\Tools\MeetupEvent\CreateMeetupEventTool;
+use App\Mcp\Tools\MeetupEvent\UpdateMeetupEventTool;
+use App\Models\Meetup;
+use App\Models\MeetupEvent;
+use App\Models\User;
+
+/** @return array<string, mixed> */
+function mcpToolProperties(string $tool): array
+{
+    return app($tool)->toArray()['inputSchema']['properties'];
+}
+
+/** @return list<array{url: string, label?: string}> */
+function threeLabelledLinks(): array
+{
+    return [
+        ['url' => 'https://www.meetup.com/bitcoin-berlin/', 'label' => 'Meetup.com'],
+        ['url' => 'https://luma.com/berlin', 'label' => 'Luma'],
+        ['url' => 'https://t.me/berlin_btc', 'label' => 'Telegram'],
+    ];
+}
+
+it('offers links on both meetup event tools, as a list of url and label', function (string $tool) {
+    $properties = mcpToolProperties($tool);
+
+    expect($properties)->toHaveKey('links')
+        ->and($properties['links']['type'])->toBe('array')
+        ->and($properties['links']['items']['properties'])->toHaveKeys(['url', 'label'])
+        ->and($properties['links']['items']['required'])->toBe(['url'])
+        ->and($properties['links']['maxItems'])->toBe(MeetupEvent::MAX_LINKS);
+})->with([CreateMeetupEventTool::class, UpdateMeetupEventTool::class]);
+
+it('keeps the deprecated link in the schema and says what it addresses', function (string $tool) {
+    $properties = mcpToolProperties($tool);
+
+    // Kept, not removed: an agent that has been sending `link` for a year keeps
+    // working. What changes is that its description now says how far it reaches.
+    expect($properties)->toHaveKey('link')
+        ->and($properties['link']['description'])->toContain('VERALTET')
+        ->and($properties['link']['description'])->toContain('links');
+})->with([CreateMeetupEventTool::class, UpdateMeetupEventTool::class]);
+
+it('says on the update tool that link touches the first entry only', function () {
+    expect(mcpToolProperties(UpdateMeetupEventTool::class)['link']['description'])
+        ->toContain('ERSTEN');
+});
+
+it('creates a meetup event with a whole list of links through the tool', function () {
+    $user = User::factory()->create();
+    $meetup = Meetup::factory()->create(['created_by' => $user->id]);
+
+    EinundzwanzigServer::actingAs($user)->tool(CreateMeetupEventTool::class, [
+        'meetup_id' => $meetup->id,
+        'start' => '2026-08-01 18:00:00',
+        'location' => 'Marktplatz',
+        'links' => threeLabelledLinks(),
+    ])->assertOk();
+
+    expect(MeetupEvent::query()->latest('id')->firstOrFail()->linkList())->toBe([
+        ['url' => 'https://www.meetup.com/bitcoin-berlin/', 'label' => 'Meetup.com'],
+        ['url' => 'https://luma.com/berlin', 'label' => 'Luma'],
+        ['url' => 'https://t.me/berlin_btc', 'label' => 'Telegram'],
+    ]);
+});
+
+it('replaces the whole list through the update tool', function () {
+    $user = User::factory()->create();
+    $event = MeetupEvent::factory()->create(['created_by' => $user->id, 'links' => threeLabelledLinks()]);
+
+    EinundzwanzigServer::actingAs($user)->tool(UpdateMeetupEventTool::class, [
+        'id' => $event->id,
+        'links' => [['url' => 'https://example.com/only', 'label' => 'Only']],
+    ])->assertOk();
+
+    expect($event->fresh()->linkList())->toBe([['url' => 'https://example.com/only', 'label' => 'Only']]);
+});
+
+it('does not wipe the list when an agent updates other fields and sends no link at all', function () {
+    $user = User::factory()->create();
+    $event = MeetupEvent::factory()->create(['created_by' => $user->id, 'links' => threeLabelledLinks()]);
+
+    EinundzwanzigServer::actingAs($user)->tool(UpdateMeetupEventTool::class, [
+        'id' => $event->id,
+        'location' => 'Rathaus',
+    ])->assertOk();
+
+    expect($event->fresh()->linkList())->toHaveCount(3)
+        ->and($event->fresh()->location)->toBe('Rathaus');
+});
+
+/*
+ * The measured defect of the issue, through the door it walked in: an agent that
+ * clears the one link field it knows about. Three labelled links, one call — and
+ * before #108 all three were gone.
+ */
+it('removes only the first entry when an agent clears the deprecated link', function () {
+    $user = User::factory()->create();
+    $event = MeetupEvent::factory()->create(['created_by' => $user->id, 'links' => threeLabelledLinks()]);
+
+    EinundzwanzigServer::actingAs($user)->tool(UpdateMeetupEventTool::class, [
+        'id' => $event->id,
+        'link' => null,
+    ])->assertOk();
+
+    expect($event->fresh()->linkList())->toBe([
+        ['url' => 'https://luma.com/berlin', 'label' => 'Luma'],
+        ['url' => 'https://t.me/berlin_btc', 'label' => 'Telegram'],
+    ]);
+});
+
+it('replaces only the first entry when an agent sends a single link', function () {
+    $user = User::factory()->create();
+    $event = MeetupEvent::factory()->create(['created_by' => $user->id, 'links' => threeLabelledLinks()]);
+
+    EinundzwanzigServer::actingAs($user)->tool(UpdateMeetupEventTool::class, [
+        'id' => $event->id,
+        'link' => 'https://example.com/agent',
+    ])->assertOk();
+
+    expect($event->fresh()->linkList())->toBe([
+        ['url' => 'https://example.com/agent', 'label' => null],
+        ['url' => 'https://luma.com/berlin', 'label' => 'Luma'],
+        ['url' => 'https://t.me/berlin_btc', 'label' => 'Telegram'],
+    ]);
+});

--- a/tests/Feature/Meetups/MeetupEventLinksTest.php
+++ b/tests/Feature/Meetups/MeetupEventLinksTest.php
@@ -239,7 +239,12 @@ it('still clears the list on update when it is given as an empty array', functio
         ->and($event->fresh()->link)->toBeNull();
 });
 
-it('replaces the list with the legacy field when only that one is given', function () {
+/*
+ * Until #108 this expected ONE entry: the legacy field replaced the whole list, which
+ * is exactly how an event with five links came back with one. `link` addresses entry
+ * one, so the second entry is none of its business and stays.
+ */
+it('replaces only the first entry when the legacy field is the only one given', function () {
     $meetup = Meetup::factory()->create(['created_by' => actingAsUser()->id]);
     $event = MeetupEvent::factory()->for($meetup)->create([
         'links' => [
@@ -250,7 +255,10 @@ it('replaces the list with the legacy field when only that one is given', functi
 
     $event->update(['links' => null, 'link' => 'https://example.com/legacy']);
 
-    expect($event->fresh()->linkList())->toBe([['url' => 'https://example.com/legacy', 'label' => null]]);
+    expect($event->fresh()->linkList())->toBe([
+        ['url' => 'https://example.com/legacy', 'label' => null],
+        ['url' => 'https://t.me/berlin_btc', 'label' => null],
+    ]);
 });
 
 /*


### PR DESCRIPTION
PATCH {"link": null} left an event that had five labelled links with
none. That is the same harm #70 closed one field over, and it was not
hypothetical: the MCP update tool exposed `link` and no `links` at all,
so an agent that simply did not re-send a URL wiped a list it had no
way of knowing existed.

`link` is a VIEW OF ENTRY ONE. Writing it replaces entry one, clearing
it removes entry one, and entries two to five keep their order and
their labels either way. Replacing the whole list is what `links` is
for, and the two must not be conflated. The replacement carries no
label, because a label describes the URL it was written for and not the
one that took its place.

Both alternatives were rejected on purpose. Making `link` read-only
breaks a published contract; refusing `link: null` turns a data loss
into an error for callers who legitimately want the field gone.

The two edge cases, decided and pinned rather than left to be
discovered. On an EMPTY list there is no entry one, so clearing is a
no-op. On a ONE-ENTRY list -- every pre-#70 row and every event a
legacy client ever created -- entry one IS the list, so the field
behaves exactly as it always did and no old caller sees a change. A row
whose `links` column is still NULL is the same case: its only link is
entry one.

The mirror is re-derived rather than left at what the caller sent, so
after `link: null` the field answers the entry that moved up. A null
beside four surviving entries would tell a client that reads only the
legacy field that the event has no link at all -- and the resource
documents `link` as the first of `links`.

#70's own semantics are untouched and measured, not assumed: `links`
absent preserves, `links: null` preserves (the getRawOriginal guard in
the branch above), `links: []` clears. 27 of the 29 existing tests are
unchanged and green.

Two existing tests encoded the OLD promise ("legacy field replaces the
whole list") and went red. They were rewritten in place to the new
rule with a #108 comment. Nothing was deleted.

Written red first: against the unchanged model the new tests fail with
the whole list gone and with the list collapsed to one entry -- the two
reported defects, reproduced before the fix.

Two mutation probes. Restoring the old assignment reddens exactly the
four behaviour tests on BOTH doors while the three #70 forms stay green,
which is what shows the neighbouring promise is not being measured by
accident. Removing the mirror re-derivation reddens exactly one
assertion, so that line is load-bearing rather than decoration.

Both MCP tools gain `links` with the same semantics the REST side has;
`link` stays in their schema marked deprecated, the update tool's
description saying it addresses the first entry only. No handle() change
was needed -- both tools validate through the form requests, which knew
`links` already.

Found, not fixed: there is no fifth writer of the `link` column. The
Livewire editor always sends `links` as an array, so it never reaches
the changed branch.

Closes #108



🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XfFQ18DFktM3ewnWo9Zt9X
