### PR TITLE
Republish a Nostr record when its payload actually changed

### DIFF
--- a/app/Console/Commands/Nostr/PublishCalendarEvents.php
+++ b/app/Console/Commands/Nostr/PublishCalendarEvents.php
@@ -6,6 +6,7 @@ use App\Models\Meetup;
 use App\Models\MeetupEvent;
 use App\Support\NostrCalendarEventFactory;
 use App\Support\NostrEventTransmitter;
+use App\Support\NostrPayloadFingerprint;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Schema;
 use swentel\nostr\Key\Key;
@@ -133,6 +134,17 @@ class PublishCalendarEvents extends Command
         $model->nostr_coordinate = NostrCalendarEventFactory::coordinate($event->getKind(), $pubkeyHex, $dTag);
         $model->save();
 
+        /*
+         * Record WHAT went out, next to the `nostr_coordinate` that records where it
+         * went (issue #92). The coordinate alone cannot answer whether the relays still
+         * hold what this portal would publish today, which is the question
+         * `nostr:republish-calendar --changed` exists to answer. Written after the
+         * transmission succeeded and never before it: a fingerprint stored for an event
+         * no relay accepted would declare a record up to date that was never published
+         * with that payload at all.
+         */
+        NostrPayloadFingerprint::remember($model, $event);
+
         $this->info("Published calendar event for {$modelName} #{$model->id}");
 
         if ($model instanceof MeetupEvent) {
@@ -166,6 +178,13 @@ class PublishCalendarEvents extends Command
      * meetup and by `nostr:republish-calendar`, so the damage of a warning is bounded
      * to a stale calendar, while the damage of a false failure is an operator chasing
      * a publish that succeeded.
+     *
+     * SINCE ISSUE #92 THAT RETRY IS AUTOMATIC. The fingerprint below is only written
+     * when the send succeeded, so a warned-about calendar keeps the fingerprint of the
+     * payload it last really carried — which no longer matches the one the factory
+     * builds now that this event exists. `nostr:republish-calendar --changed` therefore
+     * picks it up on its next scheduled run, without waiting for the meetup's next
+     * event or for an operator.
      */
     private function refreshCalendarFor(MeetupEvent $meetupEvent, string $hexKey): void
     {
@@ -191,6 +210,8 @@ class PublishCalendarEvents extends Command
 
             return;
         }
+
+        NostrPayloadFingerprint::remember($meetup, $calendar);
 
         $this->info("Refreshed calendar for Meetup #{$meetup->id}");
     }

--- a/app/Console/Commands/Nostr/RepublishCalendarEvents.php
+++ b/app/Console/Commands/Nostr/RepublishCalendarEvents.php
@@ -6,6 +6,7 @@ use App\Models\Meetup;
 use App\Models\MeetupEvent;
 use App\Support\NostrCalendarEventFactory;
 use App\Support\NostrEventTransmitter;
+use App\Support\NostrPayloadFingerprint;
 use Illuminate\Console\Command;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Collection;
@@ -29,18 +30,29 @@ use swentel\nostr\Sign\Sign;
  *
  * ## Answers to the three questions issue #92 left open
  *
- * WHICH RECORDS — every record that carries a coordinate, not only the ones whose
- * payload demonstrably changed. Deciding "changed" would mean storing the published
- * event and diffing it, i.e. a schema change and a second source of truth, to save a
- * re-send that is idempotent anyway. `--meetup` and `--limit` are how an operator
- * narrows it instead. Past events are included: their kind 31923 is still on the relays
- * and still reachable from the calendar, so it still carries the wrong zone.
+ * WHICH RECORDS — either, and the flag says which. Without `--changed` this is the
+ * operator's blunt instrument: every record that carries a coordinate, whether or not
+ * its payload moved, narrowed with `--meetup` and `--limit`. Past events are included —
+ * their kind 31923 is still on the relays and still reachable from the calendar, so it
+ * still carries whatever it was published with. With `--changed` only the records whose
+ * payload the current code no longer builds the same way are re-sent, compared through
+ * {@see NostrPayloadFingerprint} against `nostr_payload_hash`.
  *
- * WHO DECIDES — an operator, deliberately. This command is NOT scheduled, and
- * `routes/console.php` is deliberately left alone. A bulk re-send is a burst against
- * every relay in the list, and it re-sends payloads nobody complained about. The
- * automatic half of the problem is solved where it belongs and incrementally: publishing
- * an event refreshes its calendar (see {@see PublishCalendarEvents}).
+ * An earlier version of this docblock argued that deciding "changed" was not worth "a
+ * schema change and a second source of truth, to save a re-send that is idempotent
+ * anyway". That reasoning holds for a command a human runs and stops being true the
+ * moment the trigger is automatic, which is what the issue actually asked for: without
+ * the comparison the automatic form is a blanket re-send of ~400 signed events to every
+ * relay on a timer, and an error in the payload would be re-broadcast on that timer for
+ * ever. The fingerprint is what makes the automatic path self-terminating — it is
+ * written on success, so every record is re-sent once per real change and then stops.
+ *
+ * WHO DECIDES — both, in their own mode, and they do not collide. `--changed` is
+ * scheduled (see `routes/console.php`) and is the automatic half. The default mode is
+ * still an operator decision and is still not scheduled: a re-send of payloads nobody
+ * complained about is a burst against every relay in the list and belongs to a human.
+ * A forced run in EITHER mode records the fingerprint of what it sent, so a manual
+ * repair is not immediately re-done by the scheduled one.
  *
  * WHAT THROTTLES IT — a pause between records, `--sleep`, default 2 seconds. The
  * numbers it is set against, read from the public API on 2026-09-04: 307 meetups and
@@ -62,10 +74,12 @@ use swentel\nostr\Sign\Sign;
  * opt-in the same slip would cost hundreds of writes to public relays that cannot be
  * taken back. Add `-v` to dump the full unsigned event JSON per record.
  *
- * IDEMPOTENT. Running it twice re-sends the same payload under the same `d` tag; the
- * relay replaces the event in place, and no column here is written, so there is no
- * local state to corrupt. The only visible difference between two runs is
- * `created_at`, `id` and `sig`.
+ * IDEMPOTENT, in both senses. On the wire, running it twice re-sends the same payload
+ * under the same `d` tag and the relay replaces the event in place; the only difference
+ * between two runs is `created_at`, `id` and `sig`. Locally, a successful send writes
+ * exactly one column, `nostr_payload_hash`, and writes the same value for the same
+ * payload — so `--changed` sends on the first run and nothing at all on the second.
+ * `nostr_coordinate` is never written here; the address does not move.
  *
  * KEY MISMATCH IS A SKIP, NOT A SILENT REWRITE. The coordinate is recomputed from the
  * configured key and compared with the stored one. If they differ, the configured key
@@ -78,6 +92,7 @@ class RepublishCalendarEvents extends Command
     protected $signature = 'nostr:republish-calendar
         {--model= : Meetup or MeetupEvent — omit to do both}
         {--meetup= : Restrict to one meetup, by id or slug}
+        {--changed : Only records whose payload the current code no longer builds the same way}
         {--limit=0 : Stop after this many records; 0 means no limit}
         {--sleep=2 : Seconds to wait between records; see the class docblock}
         {--force : Actually transmit. Without it this command is a dry run}';
@@ -121,6 +136,25 @@ class RepublishCalendarEvents extends Command
 
                 return self::FAILURE;
             }
+
+            /*
+             * The same gate for the fingerprint column, but against the OPPOSITE
+             * failure. A missing `nostr_coordinate` makes this command do nothing; a
+             * missing `nostr_payload_hash` makes `--changed` do everything, because
+             * every record then reads back a null fingerprint, counts as stale and is
+             * re-sent — on every scheduled run, for ever. That is the burst this whole
+             * mechanism exists to prevent, so an unmigrated database must stop the
+             * command rather than be absorbed by it.
+             */
+            if ($this->option('changed') && ! Schema::hasColumn($table, NostrPayloadFingerprint::COLUMN)) {
+                $this->error(sprintf(
+                    'Missing column: %s.%s — run php artisan migrate. Without it --changed considers every published record stale and would re-send the whole catalogue on every run.',
+                    $table,
+                    NostrPayloadFingerprint::COLUMN,
+                ));
+
+                return self::FAILURE;
+            }
         }
 
         $meetupFilter = $this->option('meetup');
@@ -144,6 +178,32 @@ class RepublishCalendarEvents extends Command
         $pubkeyHex = $key->getPublicKey($hexKey);
 
         $records = $this->records($modelName, $meetup);
+        $skipped = 0;
+
+        /*
+         * THE FILTER RUNS BEFORE `--limit`, not after, and that ordering is the
+         * difference between a mechanism that drains and one that stalls. A limit
+         * applied first would hand the batch ten records that may all be up to date,
+         * send nothing, and pick the same ten on the next run — for ever. Filtering
+         * first makes the limit a cap on WORK DONE rather than on rows looked at, so
+         * every scheduled run makes progress while there is progress to make.
+         *
+         * Key mismatches are dropped here too, for the same reason: a record published
+         * under a rotated key can never be re-sent, and leaving it in the candidate set
+         * would let a handful of them occupy the batch on every run and starve the
+         * records that can actually be repaired.
+         */
+        if ($this->option('changed')) {
+            $candidates = $records->count();
+            [$records, $skipped] = $this->onlyStale($records, $pubkeyHex);
+
+            $this->line(sprintf(
+                'Checked %d published record(s): %d carry a payload this code no longer builds.',
+                $candidates,
+                $records->count(),
+            ));
+        }
+
         $limit = max(0, (int) $this->option('limit'));
 
         if ($limit > 0) {
@@ -152,6 +212,10 @@ class RepublishCalendarEvents extends Command
 
         if ($records->isEmpty()) {
             $this->info('Nothing to republish.');
+
+            if ($skipped > 0) {
+                $this->warn("Skipped {$skipped} record(s) published under another key.");
+            }
 
             return self::SUCCESS;
         }
@@ -168,25 +232,16 @@ class RepublishCalendarEvents extends Command
 
         $sent = 0;
         $failed = 0;
-        $skipped = 0;
         $first = true;
 
         foreach ($records as $record) {
             $event = $this->eventFor($record, $pubkeyHex);
-            $coordinate = NostrCalendarEventFactory::coordinate(
-                $event->getKind(),
-                $pubkeyHex,
-                $this->dTagFor($record),
-            );
+            $coordinate = $this->coordinateFor($record, $event, $pubkeyHex);
 
-            if ($coordinate !== $record->nostr_coordinate) {
-                $this->warn(sprintf(
-                    'Skipped %s #%d: stored as %s but the configured key would publish it as %s.',
-                    class_basename($record),
-                    $record->id,
-                    (string) $record->nostr_coordinate,
-                    $coordinate,
-                ));
+            // In `--changed` mode these were already dropped during the scan, so this
+            // check never fires twice for the same record. It stays because the default
+            // mode does not scan at all.
+            if (! $this->publishedUnderConfiguredKey($record, $coordinate)) {
                 $skipped++;
 
                 continue;
@@ -214,6 +269,20 @@ class RepublishCalendarEvents extends Command
             $signer->signEvent($event, $hexKey);
 
             if ($this->transmitter->transmit($event, config('services.nostr.relays', []))) {
+                /*
+                 * The fingerprint of the event that was ACTUALLY signed and sent, not
+                 * of the one built during the `--changed` scan a moment earlier. The
+                 * two are the same payload in every realistic case, but the invariant
+                 * that matters is "this column names what the relays hold", and only
+                 * the event that left the process can make that true.
+                 *
+                 * Recorded in both modes on purpose. A forced default-mode repair that
+                 * left the column alone would leave every record it just fixed looking
+                 * stale, and the scheduled `--changed` run would re-send the entire
+                 * catalogue again within the hour — the manual and the automatic path
+                 * would keep undoing each other's reason to exist.
+                 */
+                NostrPayloadFingerprint::remember($record, $event);
                 $sent++;
 
                 continue;
@@ -279,6 +348,73 @@ class RepublishCalendarEvents extends Command
                 ->get();
 
         return $events->values()->concat($meetups->values());
+    }
+
+    /**
+     * The records whose payload the relays no longer hold, and how many were dropped
+     * because they were published under a different key.
+     *
+     * ONE EVENT IS BUILT PER CANDIDATE HERE, and the winners are built a second time in
+     * the send loop. That is deliberate rather than sloppy: `created_at` is stamped at
+     * build time, so an event carried over from this scan would go out with a timestamp
+     * up to `--sleep × batch size` seconds older than its own transmission. Harmless for
+     * NIP-01 — it is still far newer than the event it replaces — but the second build
+     * is a hash and a handful of already-loaded relations, and it keeps the timestamp
+     * honest. The relations are eager-loaded by {@see self::records()}, so the scan does
+     * not go back to the database per record; the kind 31924 arm is the exception, since
+     * a calendar's `a` tags are a query by construction.
+     *
+     * @param  Collection<int, Meetup|MeetupEvent>  $records
+     * @return array{Collection<int, Meetup|MeetupEvent>, int}
+     */
+    private function onlyStale(Collection $records, string $pubkeyHex): array
+    {
+        $skipped = 0;
+
+        $stale = $records->filter(function (Model $record) use ($pubkeyHex, &$skipped): bool {
+            $event = $this->eventFor($record, $pubkeyHex);
+
+            if (! $this->publishedUnderConfiguredKey($record, $this->coordinateFor($record, $event, $pubkeyHex))) {
+                $skipped++;
+
+                return false;
+            }
+
+            return NostrPayloadFingerprint::isStale($record, $event);
+        })->values();
+
+        return [$stale, $skipped];
+    }
+
+    /**
+     * Whether the configured key is the key this record was published under, warning
+     * once if it is not.
+     *
+     * Re-sending under a different key would create a SECOND event at a new address
+     * while the old one stays on the relays unchanged, so the answer is a skip and a
+     * report. A key rotation is an operational decision, not something a repair command
+     * gets to make on the operator's behalf.
+     */
+    private function publishedUnderConfiguredKey(Model $record, string $coordinate): bool
+    {
+        if ($coordinate === $record->nostr_coordinate) {
+            return true;
+        }
+
+        $this->warn(sprintf(
+            'Skipped %s #%d: stored as %s but the configured key would publish it as %s.',
+            class_basename($record),
+            $record->id,
+            (string) $record->nostr_coordinate,
+            $coordinate,
+        ));
+
+        return false;
+    }
+
+    private function coordinateFor(Model $record, Event $event, string $pubkeyHex): string
+    {
+        return NostrCalendarEventFactory::coordinate($event->getKind(), $pubkeyHex, $this->dTagFor($record));
     }
 
     private function eventFor(Model $record, string $pubkeyHex): Event

--- a/app/Support/NostrPayloadFingerprint.php
+++ b/app/Support/NostrPayloadFingerprint.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace App\Support;
+
+use App\Models\Meetup;
+use App\Models\MeetupEvent;
+use swentel\nostr\Event\Event;
+
+/**
+ * The fingerprint of a published NIP-52 payload, and the record of the last one sent.
+ *
+ * This is the trigger issue #92 asked for. `nostr_coordinate` says WHERE a record sits
+ * on the relays; it cannot say whether what sits there is still what the portal would
+ * publish today. Without that second answer, a change to the published payload — the
+ * geography `t` tags of #69, the `start_tzid` repair of #104 — reaches the back
+ * catalogue only when a human remembers to run `nostr:republish-calendar`.
+ *
+ * ## What the fingerprint covers, and why exactly this
+ *
+ * KIND, TAGS AND CONTENT, in that order, hashed with SHA-256. Those three are the whole
+ * of what a reader of the event sees, and they are precisely the fields a change to the
+ * portal's code or data can move. The order and the shape mirror NIP-01's own
+ * serialisation for the event id — `[0, pubkey, created_at, kind, tags, content]` — with
+ * the two clock- and key-bound fields removed, so the value is recognisable as "the
+ * NIP-01 id of everything that is not the clock or the key".
+ *
+ * `created_at` IS EXCLUDED, and this is the single most load-bearing decision in the
+ * class. {@see NostrCalendarEventFactory} stamps it from the application clock at build
+ * time, so it differs on every build of the same record. Including it would make every
+ * record's fingerprint differ from the stored one on every run — the automatic path
+ * would re-send the entire catalogue to every relay, every run, forever, and unlike a
+ * one-off bulk repair it would not stop. `NostrPayloadFingerprintTest` pins that
+ * exclusion directly rather than trusting this paragraph.
+ *
+ * `id` and `sig` ARE EXCLUDED for the same reason once removed: `id` is the hash of the
+ * six NIP-01 fields including `created_at`, and `sig` is over `id`, so both inherit the
+ * clock. They are also only present after signing, while this fingerprint is taken of
+ * the unsigned event the factory built.
+ *
+ * `pubkey` IS EXCLUDED because a key change is not a payload change, it is an ADDRESS
+ * change: the coordinate `<kind>:<pubkey>:<d>` moves, and both commands already refuse
+ * to re-send a record whose stored coordinate names a different key. Hashing the pubkey
+ * in as well would duplicate that check in the one place where it reads as a payload
+ * repair rather than as the key rotation it is.
+ *
+ * TAG ORDER IS PART OF THE FINGERPRINT, deliberately. NIP-01 serialises tags as an
+ * ordered array, so two events with the same tags in a different order are two different
+ * events on the wire, with different ids. The factory builds every list deterministically
+ * (`a` tags ordered by `start` then `id`, topics most-specific first), so an order change
+ * is a real change and should trigger a re-send.
+ *
+ * ## What is stored, and what NULL means
+ *
+ * The fingerprint of the last event SUCCESSFULLY TRANSMITTED for the record, in
+ * `nostr_payload_hash`. NULL means unknown — never published, or published before the
+ * column existed. A record with a coordinate and a NULL fingerprint is therefore stale
+ * by {@see self::isStale()}, which is what carries the #69/#104 back catalogue into the
+ * repair instead of silently declaring it up to date. Nothing is backfilled; see the
+ * migration `2026_09_05_191105_add_nostr_payload_hash_...` for that decision in full.
+ */
+final class NostrPayloadFingerprint
+{
+    /**
+     * The column both models carry it in. Named once so a rename cannot half-happen.
+     */
+    public const COLUMN = 'nostr_payload_hash';
+
+    /**
+     * The fingerprint of an event's payload.
+     *
+     * JSON_UNESCAPED_SLASHES and JSON_UNESCAPED_UNICODE match `Event::toJson()`, so the
+     * bytes hashed here are the bytes that go on the wire for these three fields. They
+     * do not change the VALUE of the comparison — any consistent encoding would do —
+     * but a fingerprint that is computed over a different byte string than the one an
+     * operator sees in `-v` output is a needless second reality.
+     */
+    public static function of(Event $event): string
+    {
+        return hash('sha256', json_encode(
+            [$event->getKind(), $event->getTags(), $event->getContent()],
+            JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE,
+        ));
+    }
+
+    /**
+     * Whether the relays hold something other than what this event would put there.
+     *
+     * A non-string stored value (NULL, and nothing else can occur) counts as stale. That
+     * is the "unknown means presumed stale" rule stated in the class docblock: the safe
+     * direction is one idempotent re-send, because the unsafe direction is the defect
+     * #92 reports, dressed up as a mechanism that looks like it works.
+     */
+    public static function isStale(Meetup|MeetupEvent $record, Event $event): bool
+    {
+        $stored = $record->getAttribute(self::COLUMN);
+
+        return ! is_string($stored) || ! hash_equals($stored, self::of($event));
+    }
+
+    /**
+     * Record that this event is what the relays now hold for this record.
+     *
+     * ONLY EVER CALLED AFTER A SUCCESSFUL TRANSMISSION, and of the event that was
+     * actually signed and sent — not of one built earlier for the staleness scan. If a
+     * send fails, the fingerprint stays where it was and the record is picked up again
+     * on the next run, which is what makes a failed relay a delay rather than a silent
+     * loss.
+     *
+     * WRITTEN AS A BARE UPDATE, past Eloquent, on purpose. Three things must not happen:
+     *
+     *  - `updated_at` must not move. It is an input other code reads as "when did this
+     *    record last change", and a transmission is not a change to the record. It is
+     *    also the field a naive version of this whole feature would have keyed on, so
+     *    moving it here would corrupt the very signal that made it the wrong choice.
+     *  - No model events. `Meetup` and `MeetupEvent` both carry
+     *    {@see App\Observers\ApiChangeObserver}, so an ordinary `save()` would write an
+     *    `api_changes` row, broadcast it and dispatch webhook deliveries — a public
+     *    "this meetup changed" for every calendar refresh, with no field a consumer can
+     *    see. `saveQuietly()` would fix that half and still move the timestamp.
+     *  - No other column. A `save()` would persist whatever else happens to be dirty on
+     *    the model; this statement carries exactly one column.
+     *
+     * The in-memory model is brought in line afterwards and marked clean, so a caller
+     * that keeps using the object sees the stored value and does not carry a phantom
+     * dirty attribute into its next `save()`.
+     */
+    public static function remember(Meetup|MeetupEvent $record, Event $event): string
+    {
+        $fingerprint = self::of($event);
+
+        $record->getConnection()
+            ->table($record->getTable())
+            ->where($record->getKeyName(), $record->getKey())
+            ->update([self::COLUMN => $fingerprint]);
+
+        $record->setAttribute(self::COLUMN, $fingerprint);
+        $record->syncOriginalAttribute(self::COLUMN);
+
+        return $fingerprint;
+    }
+}

--- a/database/migrations/2026_09_05_191105_add_nostr_payload_hash_to_meetups_and_meetup_events_tables.php
+++ b/database/migrations/2026_09_05_191105_add_nostr_payload_hash_to_meetups_and_meetup_events_tables.php
@@ -1,0 +1,86 @@
+<?php
+
+use App\Support\NostrPayloadFingerprint;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+/**
+ * Issue #92: the fingerprint of the payload each record was last published with.
+ *
+ * `nostr_coordinate` answers WHERE a record sits on the relays; it cannot answer
+ * WHETHER what sits there is still what the portal would publish today. That second
+ * question is the whole of #92: `nostr:publish-calendar` is gated on
+ * `nostr_coordinate IS NULL`, so a record it has published keeps the payload it went
+ * out with for good, and every later change to the published payload — the geography
+ * `t` tags of #69, the `start_tzid` repair of #104 — reaches only the records
+ * published after it. This column is the answer to the second question, and therefore
+ * the trigger the issue asked for.
+ *
+ * ## What goes in it
+ *
+ * The SHA-256 of the canonical form of the last event this portal successfully
+ * transmitted for the record — kind, tags and content, and deliberately nothing else.
+ * See {@see NostrPayloadFingerprint} for why `created_at`, `id`, `sig` and
+ * `pubkey` are excluded; excluding `created_at` in particular is what keeps a record
+ * from looking changed on every single run.
+ *
+ * A hash and not the payload itself: nothing ever needs to read the old payload back,
+ * only to compare it, and storing a signed event per record would put a second copy of
+ * the published catalogue in the database with no reader.
+ *
+ * ## NULL, and why nothing is backfilled
+ *
+ * NULL means UNKNOWN, in exactly two situations: the record was never published, or it
+ * was published before this column existed. The two are told apart by
+ * `nostr_coordinate`, not by this column.
+ *
+ * A record with a coordinate and a NULL hash is therefore treated as STALE by
+ * `nostr:republish-calendar --changed`, and re-sent once. That is a deliberate
+ * decision, not an omission: the alternative — computing today's payload for every
+ * already-published record and writing it in as if it had been sent — would assert
+ * something the portal does not know, and it would assert it in the one direction that
+ * silently reproduces the defect this issue reports, because it would mark exactly the
+ * back catalogue of #69 and #104 as up to date. The cost of the honest direction is one
+ * idempotent re-send per already-published record, paced by the scheduler and
+ * self-terminating: the hash is written on success, so each record is re-sent once and
+ * never again.
+ *
+ * ## Not fillable, not indexed
+ *
+ * Not added to `Meetup::$fillable` (`MeetupEvent` is unguarded) on purpose — this column
+ * is written by exactly one code path, {@see NostrPayloadFingerprint::remember()},
+ * and never by a request. No index: the staleness comparison cannot run in SQL (the
+ * current payload has to be built in PHP first), so an index would be paid for and never
+ * used. The rows are pre-filtered by `nostr_coordinate IS NOT NULL`, which is the
+ * selective predicate.
+ */
+return new class extends Migration
+{
+    /**
+     * @var list<string>
+     */
+    private array $tables = ['meetups', 'meetup_events'];
+
+    public function up(): void
+    {
+        foreach ($this->tables as $table) {
+            Schema::table($table, function (Blueprint $blueprint) {
+                // 64 chars: SHA-256 in lowercase hex. Fixed width rather than `text`,
+                // because unlike a coordinate this value has one shape forever.
+                $blueprint->string('nostr_payload_hash', 64)
+                    ->nullable()
+                    ->after('nostr_coordinate');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        foreach ($this->tables as $table) {
+            Schema::table($table, function (Blueprint $blueprint) {
+                $blueprint->dropColumn('nostr_payload_hash');
+            });
+        }
+    }
+};

--- a/routes/console.php
+++ b/routes/console.php
@@ -5,6 +5,7 @@ use App\Console\Commands\Database\PruneApiChanges;
 use App\Console\Commands\Database\UpdateMeetupActivity;
 use App\Console\Commands\Nostr\PublishCalendarEvents;
 use App\Console\Commands\Nostr\PublishUnpublishedItems;
+use App\Console\Commands\Nostr\RepublishCalendarEvents;
 
 Schedule::command(CleanupLoginKeys::class)->everyFifteenMinutes();
 
@@ -95,10 +96,12 @@ Schedule::command(PublishUnpublishedItems::class, [
 | Idle cost is one indexed query per run: with nothing to publish the command
 | prints "No unpublished items" and exits 0 without opening a socket.
 |
-| `nostr:republish-calendar` is deliberately NOT scheduled. It re-sends the
-| whole back catalogue, which is a burst against every relay in the list and a
-| decision for an operator, not for cron; its own docblock carries the
-| reasoning and its default is a dry run.
+| `nostr:republish-calendar` WITHOUT `--changed` is deliberately NOT scheduled.
+| It re-sends the whole back catalogue, which is a burst against every relay in
+| the list and a decision for an operator, not for cron; its own docblock
+| carries the reasoning and its default is a dry run. The `--changed` half of
+| it IS scheduled, below, and the difference between the two is the whole of
+| issue #92 — see there.
 |
 | NO `withoutOverlapping()` / `onOneServer()` — MATCHING THE HOUSE PATTERN
 |
@@ -139,6 +142,85 @@ Schedule::command(PublishCalendarEvents::class, [
 Schedule::command(PublishCalendarEvents::class, [
     '--model' => 'Meetup',
 ])->everyFiveMinutes();
+
+/*
+|--------------------------------------------------------------------------
+| NIP-52 payload repair (issue #92)
+|--------------------------------------------------------------------------
+|
+| The trigger #92 was missing. The two entries above are one-way doors: they
+| gate on `nostr_coordinate IS NULL`, so a record they have published keeps the
+| payload it went out with for good, and every later change to what the portal
+| publishes — the geography `t` tags of #69, the `start_tzid` repair of #104 —
+| reached only the records published after it. This entry closes that door from
+| the other side.
+|
+| WHY `--changed` AND NOT A NIGHTLY BLANKET REPUBLISH. A timer that re-sends
+| everything ships ~400 signed events to every relay for nothing, and a bad
+| payload would be re-broadcast on that timer for ever instead of once.
+| `--changed` compares a fingerprint of the payload the current code builds
+| against `nostr_payload_hash`, the fingerprint of what was last successfully
+| sent (App\Support\NostrPayloadFingerprint). The fingerprint is written on
+| success, so the mechanism is self-terminating: one re-send per real change,
+| then silence. It is NOT keyed on `updated_at` — the #104 case changed the
+| payload of every published event with no database write at all, and an
+| `updated_at` check would have missed exactly the records the issue is about.
+|
+| WORST CASE ON THE WIRE, per relay:
+|
+|   peak       1 event / 2 s = 0.5 events/s, for 18 s (10 records, `--sleep=2`
+|              pauses between them, 9 pauses)
+|   sustained  10 events/h = 0.0028 events/s
+|   idle       0 events. With nothing stale the run opens no socket.
+|
+| That peak is the same as a manual `nostr:republish-calendar --force`; what
+| the batch cap buys is the sustained figure, which is ~1/40 of the manual
+| command's 0.5 events/s held for 13 minutes.
+|
+| WHY hourly WITH `--limit=10` AND NOT everyFiveMinutes WITH ONE RECORD.
+|
+| Unlike the publisher above, this command cannot pick its work with an indexed
+| WHERE: "has the payload changed" is only answerable by BUILDING the payload,
+| so every run costs one event build per already-published record whether or
+| not anything is stale. Measured 2026-09-05 on a synthetic catalogue of the
+| size production would reach if every meetup opted in — 307 meetups plus 76
+| upcoming events, the public-API figures of 2026-09-04:
+|
+|   383 published records, nothing stale
+|   -> 72 ms and 322 queries per idle scan (three runs: 75/71/72 ms, 322 each)
+|
+| 307 of those queries are one per meetup, because a calendar's `a` tags are a
+| query by construction (NostrCalendarEventFactory::publishedEventCoordinates).
+| SO THE SCAN IS NOT A BOTTLENECK AT EITHER CADENCE, and pretending otherwise
+| would be dressing a preference up as a constraint: 24 runs a day is 7.7k
+| queries, 288 runs a day is 93k. What decides it is that the twelvefold cost
+| buys nothing — the records already sit on the relays with a readable, merely
+| older payload, so nobody is waiting the way the reporter of #49 was waiting
+| for a first publish.
+|
+| The batch cap is what buys the drain rate back, and that is the figure that
+| actually matters: a code change that moves every payload at once clears the
+| 383-record catalogue in 39 runs — under two days — against 383 runs, 16 days,
+| at one record per run. A single stale record, the steady-state case when an
+| organiser edits a description, goes out within the hour. An operator who
+| wants a repair faster than that runs the command by hand, which is exactly
+| what the unflagged form is for.
+|
+| WHY `--force` IS ON THE SCHEDULER AND NOT THE DEFAULT. The command's default
+| is a dry run because forgetting a flag must cost a printed plan rather than
+| hundreds of unrecallable writes to public relays. That protects a human at a
+| shell; a scheduler entry is written once and read by everyone, so the flag is
+| the sentence that says out loud that this line transmits.
+|
+| `nostr_publishing_enabled` is honoured here as everywhere: a re-send is a new
+| signed event, i.e. a publishing act, so a meetup that has opted out is not in
+| the candidate set at all.
+*/
+Schedule::command(RepublishCalendarEvents::class, [
+    '--changed',
+    '--force',
+    '--limit' => 10,
+])->hourly();
 
 Schedule::command(UpdateMeetupActivity::class)->dailyAt('03:30');
 

--- a/tests/Feature/Console/NostrCalendarScheduleTest.php
+++ b/tests/Feature/Console/NostrCalendarScheduleTest.php
@@ -96,3 +96,72 @@ it('does not report a command that is not scheduled', function () {
     // real absence rather than a broken lookup.
     expect(scheduledMatching('nostr:publish '))->not->toBeEmpty();
 });
+
+/*
+|--------------------------------------------------------------------------
+| nostr:republish-calendar --changed must be registered too (issue #92)
+|--------------------------------------------------------------------------
+|
+| Same guard, same reason, one issue later. The two publisher entries above
+| gate on `nostr_coordinate IS NULL`, so a record they published keeps its
+| payload for good; #92 is that nothing ever re-sends it. The command that
+| does exists and is tested, and — exactly as in #49 — being complete and
+| correct is not the same as running.
+*/
+it('schedules the payload repair for already-published records', function () {
+    $entries = scheduledMatching('nostr:republish-calendar');
+
+    expect($entries)->toHaveCount(1, 'nostr:republish-calendar is not scheduled at all');
+});
+
+/*
+ * THE FLAGS ARE THE DECISION, not decoration on it.
+ *
+ * `--changed` is what separates this entry from the thing the repo owner
+ * rejected: a nightly blanket republish ships ~400 signed events to every
+ * relay for nothing, and a bad payload is then re-broadcast on a timer instead
+ * of once. Dropping the flag leaves a line that still runs, still exits 0 and
+ * quietly becomes that blanket republish — so the flag is asserted, not just
+ * the command name.
+ *
+ * `--force` is what makes it transmit at all; without it the command is a dry
+ * run by default and the schedule entry would print a plan into a log nobody
+ * reads, while the back catalogue stayed exactly as broken as #92 found it.
+ *
+ * `--limit` is the batch cap the pacing arithmetic in routes/console.php is
+ * computed against: 10 records, `--sleep=2` between them, i.e. a peak of 0.5
+ * events/s per relay for 18 s and a sustained 10 events/h.
+ */
+it('repairs only changed payloads, transmits, and caps the batch', function () {
+    $command = (string) scheduledMatching('nostr:republish-calendar')[0]->command;
+
+    // NOT `toContain($needle, $message)`: Pest's toContain is VARIADIC, so a second
+    // argument is read as a second needle and the assertion then demands the whole
+    // sentence appear in the command string. Measured here — it failed on the first
+    // run, which is the only reason this note exists rather than a silent green.
+    expect(str_contains($command, '--changed'))
+        ->toBeTrue('the repair entry lost --changed and is now a blanket republish')
+        ->and(str_contains($command, '--force'))
+        ->toBeTrue('the repair entry is a dry run and repairs nothing')
+        ->and(str_contains($command, '--limit=10'))
+        ->toBeTrue('the repair entry lost its batch cap');
+});
+
+/*
+ * Hourly, and the interval is a trade rather than a taste.
+ *
+ * Unlike the publisher above, this command cannot pick its work with an
+ * indexed WHERE — "has the payload changed" is only answerable by BUILDING the
+ * payload, so every run costs one event build per already-published record
+ * whether or not anything is stale. Measured 2026-09-05 on 383 published
+ * records, the size production reaches if every meetup opts in: 72 ms and 322
+ * queries per idle scan. That is cheap at either cadence, which is the honest
+ * reading — every five minutes would simply pay it twelve times over for a
+ * repair nobody is waiting on. The batch cap is what carries the drain rate:
+ * a code change that moves every payload clears 383 records in 39 runs, under
+ * two days, instead of 383 runs.
+ */
+it('repairs hourly, the cadence its scan cost and batch size were chosen for', function () {
+    expect(scheduledMatching('nostr:republish-calendar')[0]->expression)
+        ->toBe('0 * * * *', 'the payload repair is no longer hourly');
+});

--- a/tests/Feature/Console/RepublishChangedPayloadTest.php
+++ b/tests/Feature/Console/RepublishChangedPayloadTest.php
@@ -1,0 +1,572 @@
+<?php
+
+use App\Models\City;
+use App\Models\Country;
+use App\Models\Meetup;
+use App\Models\MeetupEvent;
+use App\Support\NostrEventTransmitter;
+use App\Support\NostrPayloadFingerprint;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use swentel\nostr\Event\Event;
+use swentel\nostr\Key\Key;
+use Tests\Fixtures\RecordingNostrTransmitter;
+
+/**
+ * `nostr:republish-calendar --changed` — the automatic trigger of issue #92.
+ *
+ * The mechanism is a fingerprint of the published payload
+ * ({@see NostrPayloadFingerprint}) stored per record, compared against the
+ * payload the current code builds. It has two failure modes and they are opposites, so
+ * a test suite that only proves "a changed payload is re-sent" is half a guard:
+ *
+ *  - WRONG IN ONE DIRECTION IT NEVER RE-SENDS. The fix silently does not reach the back
+ *    catalogue — which is precisely the defect #92 reports, now with a mechanism that
+ *    looks like it works. Pinned by the "is re-sent" tests below, and above all by the
+ *    two that change the payload WITHOUT touching the record's row.
+ *  - WRONG IN THE OTHER IT RE-SENDS EVERYTHING ON EVERY RUN. A burst to every relay,
+ *    repeatedly, and unlike a one-off bulk repair it does not stop. Pinned by the
+ *    "sends nothing" tests, the idempotence test, and the schema guard.
+ *
+ * NO RELAY IS CONTACTED. Every test binds {@see RecordingNostrTransmitter} into the
+ * container, which records events instead of opening a websocket.
+ */
+const CHANGED_PAYLOAD_TEST_KEY = '9c1a7f3e5b2d84061fae93c7d05b2e814a6f37c9b0d51e2a8437fc6b9d0e5a12';
+
+function changedTransmitter(): RecordingNostrTransmitter
+{
+    $transmitter = new RecordingNostrTransmitter;
+    app()->instance(NostrEventTransmitter::class, $transmitter);
+
+    return $transmitter;
+}
+
+function changedPubkey(): string
+{
+    return (new Key)->getPublicKey(CHANGED_PAYLOAD_TEST_KEY);
+}
+
+/**
+ * A meetup in the reporter's Indianapolis, so a repaired event is visibly repaired
+ * rather than merely re-sent: the city sits in America/Indiana/Indianapolis, the zone
+ * issue #104 was about.
+ */
+function changedMeetup(array $attributes = []): Meetup
+{
+    $country = Country::factory()->create(['code' => 'us']);
+    $city = City::factory()->create([
+        'country_id' => $country->id,
+        'latitude' => 39.7684,
+        'longitude' => -86.1581,
+    ]);
+
+    return Meetup::factory()->create(array_merge([
+        'city_id' => $city->id,
+        'nostr_publishing_enabled' => true,
+    ], $attributes));
+}
+
+/**
+ * A meetup and its events, all taken through the REAL publisher, so their coordinates
+ * and their stored fingerprints are the ones production would have.
+ *
+ * @return array{Meetup, Collection<int, MeetupEvent>}
+ */
+function changedPublished(int $events = 1, array $meetupAttributes = []): array
+{
+    $meetup = changedMeetup($meetupAttributes);
+
+    $created = Collection::times($events, fn (int $n): MeetupEvent => MeetupEvent::factory()->create([
+        'meetup_id' => $meetup->id,
+        'start' => now()->addWeeks($n),
+        'title' => null,
+    ]));
+
+    test()->artisan('nostr:publish-calendar', ['--model' => 'Meetup'])->assertExitCode(0);
+
+    // One record per run, by design — see PublishCalendarEvents.
+    foreach ($created as $ignored) {
+        test()->artisan('nostr:publish-calendar', ['--model' => 'MeetupEvent'])->assertExitCode(0);
+    }
+
+    return [$meetup->refresh(), $created->each->refresh()];
+}
+
+/**
+ * The events transmitted after the given baseline — i.e. the ones the repair sent.
+ *
+ * @return list<Event>
+ */
+function changedSince(RecordingNostrTransmitter $transmitter, int $baseline): array
+{
+    return array_values(array_slice($transmitter->events, $baseline));
+}
+
+/**
+ * The raw database row, past Eloquent — every column, exactly as stored.
+ *
+ * @return array<string, mixed>
+ */
+function changedRow(string $table, int $id): array
+{
+    return (array) DB::table($table)->where('id', $id)->first();
+}
+
+beforeEach(function () {
+    config([
+        'services.nostr.publisher_key' => CHANGED_PAYLOAD_TEST_KEY,
+        'services.nostr.relays' => ['wss://fake.relay.test'],
+    ]);
+});
+
+/*
+|--------------------------------------------------------------------------
+| Failure mode 1: it never re-sends
+|--------------------------------------------------------------------------
+*/
+
+it('re-sends a record whose published payload changed', function () {
+    $transmitter = changedTransmitter();
+    [$meetup] = changedPublished();
+    $baseline = count($transmitter->events);
+
+    $this->travel(90)->seconds();
+    $meetup->update(['intro' => 'A completely new introduction for the calendar.']);
+
+    $this->artisan('nostr:republish-calendar', ['--changed' => true, '--sleep' => 0, '--force' => true])
+        ->assertExitCode(0);
+
+    $republished = changedSince($transmitter, $baseline);
+
+    // The intro is the calendar's content and nothing else's, so exactly ONE of the two
+    // published records is stale. A mechanism that re-sent both would pass a test that
+    // only asserted "something went out".
+    expect($republished)->toHaveCount(1)
+        ->and($republished[0]->getKind())->toBe(31924)
+        ->and(RecordingNostrTransmitter::tagValue($republished[0], 'd'))->toBe("meetup-{$meetup->id}")
+        ->and($republished[0]->getContent())->toBe($meetup->fresh()->intro);
+});
+
+/**
+ * THE #104 CASE, and the one a naive `updated_at` check would miss. The zone of a
+ * published event is derived from the meetup city's coordinates, so it can change with
+ * no write to `meetup_events` at all — which is the same shape as the code change that
+ * produced #104, where `start_tzid` moved for every published event and not one database
+ * row was touched.
+ *
+ * The record's ENTIRE row is asserted byte-identical across the change, so no per-record
+ * database state could have triggered the re-send: only the built payload could.
+ */
+it('re-sends a record whose payload changed with its own row untouched', function () {
+    $transmitter = changedTransmitter();
+    [$meetup, $events] = changedPublished();
+    $meetupEvent = $events->first();
+    $baseline = count($transmitter->events);
+
+    $rowBefore = changedRow('meetup_events', $meetupEvent->id);
+
+    $this->travel(90)->seconds();
+
+    // The city moves to New York. Nothing in `meetup_events` is written.
+    $meetup->city->update(['latitude' => 40.7128, 'longitude' => -74.0060]);
+
+    expect(changedRow('meetup_events', $meetupEvent->id))->toBe($rowBefore);
+
+    $this->artisan('nostr:republish-calendar', [
+        '--changed' => true, '--model' => 'MeetupEvent', '--sleep' => 0, '--force' => true,
+    ])->assertExitCode(0);
+
+    $republished = changedSince($transmitter, $baseline);
+
+    expect($republished)->toHaveCount(1)
+        ->and(RecordingNostrTransmitter::tagValue($republished[0], 'start_tzid'))->toBe('America/New_York')
+        ->and(RecordingNostrTransmitter::tagValue($republished[0], 'd'))->toBe("meetup-event-{$meetupEvent->id}");
+
+    // And the re-send itself wrote nothing but the fingerprint: same row, one column on.
+    $rowAfter = changedRow('meetup_events', $meetupEvent->id);
+    expect(array_keys(array_diff_assoc($rowAfter, $rowBefore)))->toBe(['nostr_payload_hash']);
+});
+
+/**
+ * The back catalogue of issues #69 and #104: a record with a coordinate and no stored
+ * fingerprint, i.e. one published before the column existed. NULL means UNKNOWN, and
+ * unknown is treated as stale — the alternative would mark exactly those records as up
+ * to date and reproduce the defect the issue reports.
+ *
+ * Nothing is backfilled, so the repair costs one idempotent re-send per record and then
+ * stops: the second run below sends nothing.
+ */
+it('re-sends a record published before the fingerprint column existed, exactly once', function () {
+    $transmitter = changedTransmitter();
+    [$meetup, $events] = changedPublished();
+    $meetupEvent = $events->first();
+
+    // The starting state of the production catalogue: address known, payload unknown.
+    // Written past Eloquent so `updated_at` stays where it was.
+    DB::table('meetups')->where('id', $meetup->id)->update(['nostr_payload_hash' => null]);
+    DB::table('meetup_events')->where('id', $meetupEvent->id)->update(['nostr_payload_hash' => null]);
+
+    $baseline = count($transmitter->events);
+    $rowBefore = changedRow('meetup_events', $meetupEvent->id);
+
+    $this->travel(90)->seconds();
+    $this->artisan('nostr:republish-calendar', ['--changed' => true, '--sleep' => 0, '--force' => true])
+        ->expectsOutputToContain('Checked 2 published record(s): 2 carry a payload this code no longer builds.')
+        ->assertExitCode(0);
+
+    $firstRun = changedSince($transmitter, $baseline);
+
+    expect($firstRun)->toHaveCount(2)
+        ->and($firstRun[0]->getKind())->toBe(31923)
+        ->and($firstRun[1]->getKind())->toBe(31924)
+        // The payload the repair carries is today's, wrong-zone defect included: the
+        // whole point of reaching the back catalogue at all.
+        ->and(RecordingNostrTransmitter::tagValue($firstRun[0], 'start_tzid'))->toBe('America/Indiana/Indianapolis')
+        ->and(RecordingNostrTransmitter::tagValues($firstRun[1], 'a'))
+        ->toBe(['31923:'.changedPubkey().":meetup-event-{$meetupEvent->id}"])
+        // Nothing but the fingerprint was written, so this is not a row-level trigger
+        // that happens to fire once.
+        ->and(array_keys(array_diff_assoc(changedRow('meetup_events', $meetupEvent->id), $rowBefore)))
+        ->toBe(['nostr_payload_hash']);
+
+    $second = count($transmitter->events);
+    $this->travel(90)->seconds();
+    $this->artisan('nostr:republish-calendar', ['--changed' => true, '--sleep' => 0, '--force' => true])
+        ->assertExitCode(0);
+
+    expect(changedSince($transmitter, $second))->toBe([]);
+});
+
+/**
+ * A calendar refresh that the relay rejected leaves the fingerprint of the payload it
+ * really last carried, so the scheduled `--changed` run repairs it — where before this
+ * change the warning was the end of the story until the meetup's next event or an
+ * operator.
+ */
+it('repairs a calendar whose inline refresh was rejected', function () {
+    $transmitter = changedTransmitter();
+    $meetup = changedMeetup();
+    $meetupEvent = MeetupEvent::factory()->create([
+        'meetup_id' => $meetup->id,
+        'start' => now()->addWeek(),
+        'title' => null,
+    ]);
+
+    $this->artisan('nostr:publish-calendar', ['--model' => 'Meetup'])->assertExitCode(0);
+
+    $transmitter->rejectedKinds = [31924];
+    $this->artisan('nostr:publish-calendar', ['--model' => 'MeetupEvent'])
+        ->expectsOutputToContain('could not refresh the calendar')
+        ->assertExitCode(0);
+    $transmitter->rejectedKinds = [];
+
+    $baseline = count($transmitter->events);
+
+    $this->travel(90)->seconds();
+    $this->artisan('nostr:republish-calendar', ['--changed' => true, '--sleep' => 0, '--force' => true])
+        ->assertExitCode(0);
+
+    $republished = changedSince($transmitter, $baseline);
+
+    expect($republished)->toHaveCount(1)
+        ->and($republished[0]->getKind())->toBe(31924)
+        ->and(RecordingNostrTransmitter::tagValues($republished[0], 'a'))
+        ->toBe(['31923:'.changedPubkey().":meetup-event-{$meetupEvent->id}"]);
+});
+
+/**
+ * A relay that refuses the re-send must leave the fingerprint alone, or the record would
+ * be marked repaired without anything having reached a relay — a silent loss dressed as
+ * a success.
+ */
+it('keeps a record stale when the re-send failed', function () {
+    $transmitter = changedTransmitter();
+    [$meetup] = changedPublished();
+    $meetup->update(['intro' => 'Changed while the relays are down.']);
+
+    $transmitter->accepts = false;
+    $this->travel(90)->seconds();
+    $this->artisan('nostr:republish-calendar', ['--changed' => true, '--sleep' => 0, '--force' => true])
+        ->assertExitCode(1);
+
+    $transmitter->accepts = true;
+    $baseline = count($transmitter->events);
+
+    $this->travel(90)->seconds();
+    $this->artisan('nostr:republish-calendar', ['--changed' => true, '--sleep' => 0, '--force' => true])
+        ->assertExitCode(0);
+
+    expect(changedSince($transmitter, $baseline))->toHaveCount(1)
+        ->and(changedSince($transmitter, $baseline)[0]->getKind())->toBe(31924);
+});
+
+/*
+|--------------------------------------------------------------------------
+| Failure mode 2: it re-sends everything, on every run
+|--------------------------------------------------------------------------
+*/
+
+it('sends nothing when no published payload changed', function () {
+    $transmitter = changedTransmitter();
+    [$meetup, $events] = changedPublished();
+    $baseline = count($transmitter->events);
+
+    $this->travel(90)->seconds();
+    $this->artisan('nostr:republish-calendar', ['--changed' => true, '--sleep' => 0, '--force' => true])
+        ->expectsOutputToContain('Checked 2 published record(s): 0 carry a payload this code no longer builds.')
+        ->expectsOutputToContain('Nothing to republish.')
+        ->assertExitCode(0);
+
+    expect(changedSince($transmitter, $baseline))->toBe([])
+        // The publisher recorded what it sent, which is what makes the line above true.
+        ->and($meetup->fresh()->nostr_payload_hash)->toMatch('/^[0-9a-f]{64}$/')
+        ->and($events->first()->fresh()->nostr_payload_hash)->toMatch('/^[0-9a-f]{64}$/');
+});
+
+/**
+ * IDEMPOTENCE, the property that keeps a real change from becoming a standing burst.
+ * The first run repairs, the second finds nothing — measured over three consecutive runs
+ * because "twice" cannot tell a self-terminating mechanism from one that alternates.
+ */
+it('re-sends a changed record once and nothing on the runs after it', function () {
+    $transmitter = changedTransmitter();
+    [$meetup] = changedPublished(2);
+
+    $this->travel(90)->seconds();
+    $meetup->update(['name' => 'Renamed Bitcoin Meetup Indianapolis']);
+
+    $baseline = count($transmitter->events);
+    $this->artisan('nostr:republish-calendar', ['--changed' => true, '--sleep' => 0, '--force' => true])
+        ->assertExitCode(0);
+
+    // The name is the calendar's title AND the title of both events, which carry no
+    // title of their own — so all three published records are stale.
+    expect(changedSince($transmitter, $baseline))->toHaveCount(3);
+
+    foreach ([2, 3] as $run) {
+        $before = count($transmitter->events);
+        $this->travel(90)->seconds();
+        $this->artisan('nostr:republish-calendar', ['--changed' => true, '--sleep' => 0, '--force' => true])
+            ->assertExitCode(0);
+
+        expect(changedSince($transmitter, $before))->toBe([], "run {$run} re-sent something");
+    }
+});
+
+/**
+ * The trigger is the payload, never `updated_at`. This is the direction in which a naive
+ * `updated_at` check does not merely miss a repair but manufactures traffic: any write
+ * that leaves the published payload alone — an organiser toggling RSVP, a background job
+ * touching a row — would re-broadcast the record to every relay.
+ */
+it('does not re-send a record that was written to without changing its payload', function () {
+    $transmitter = changedTransmitter();
+    [$meetup, $events] = changedPublished();
+    $meetupEvent = $events->first();
+    $baseline = count($transmitter->events);
+
+    $this->travel(90)->seconds();
+
+    // `rsvp_enabled` and `attendees` appear in no published tag. Both rows are really
+    // written: `updated_at` moves on both.
+    $publishedAtMeetup = $meetup->fresh()->updated_at;
+    $publishedAtEvent = $meetupEvent->fresh()->updated_at;
+
+    $meetup->update(['rsvp_enabled' => ! $meetup->rsvp_enabled]);
+    $meetupEvent->update(['attendees' => ['npub1someone']]);
+
+    expect($meetup->fresh()->updated_at->greaterThan($publishedAtMeetup))->toBeTrue()
+        ->and($meetupEvent->fresh()->updated_at->greaterThan($publishedAtEvent))->toBeTrue();
+
+    $this->artisan('nostr:republish-calendar', ['--changed' => true, '--sleep' => 0, '--force' => true])
+        ->expectsOutputToContain('Checked 2 published record(s): 0 carry a payload this code no longer builds.')
+        ->assertExitCode(0);
+
+    expect(changedSince($transmitter, $baseline))->toBe([]);
+});
+
+it('is a dry run by default in changed mode too', function () {
+    $transmitter = changedTransmitter();
+    [$meetup] = changedPublished();
+    $meetup->update(['intro' => 'Changed, but nobody said --force.']);
+    $baseline = count($transmitter->events);
+
+    $this->travel(90)->seconds();
+    $this->artisan('nostr:republish-calendar', ['--changed' => true, '--sleep' => 0])
+        ->expectsOutputToContain('DRY RUN')
+        ->assertExitCode(0);
+
+    expect(changedSince($transmitter, $baseline))->toBe([])
+        // And a dry run must not record a fingerprint either, or the next real run
+        // would consider the record repaired without a single event having left.
+        ->and($meetup->fresh()->nostr_payload_hash)->not->toBeNull();
+
+    $this->artisan('nostr:republish-calendar', ['--changed' => true, '--sleep' => 0, '--force' => true])
+        ->assertExitCode(0);
+
+    expect(changedSince($transmitter, $baseline))->toHaveCount(1);
+});
+
+/**
+ * A re-send is a new signed event, so it is a publishing act; an organiser who switched
+ * publishing off has withdrawn consent to those. The stale payload is not an exception
+ * to that.
+ */
+it('leaves a stale record alone when its meetup opted out of publishing', function () {
+    $transmitter = changedTransmitter();
+    [$meetup] = changedPublished();
+    $meetup->update(['intro' => 'Changed after opting out.', 'nostr_publishing_enabled' => false]);
+    $baseline = count($transmitter->events);
+
+    $this->travel(90)->seconds();
+    $this->artisan('nostr:republish-calendar', ['--changed' => true, '--sleep' => 0, '--force' => true])
+        ->expectsOutputToContain('Checked 0 published record(s)')
+        ->assertExitCode(0);
+
+    expect(changedSince($transmitter, $baseline))->toBe([]);
+});
+
+/**
+ * An unmigrated database must stop this command rather than be absorbed by it. Without
+ * the column every record reads back a null fingerprint, counts as stale, and the
+ * hourly entry re-sends the whole catalogue on every run for ever — the exact burst the
+ * mechanism exists to prevent, arriving through a missing migration.
+ */
+it('refuses to run in changed mode without the fingerprint column', function () {
+    changedTransmitter();
+    changedPublished();
+
+    Schema::table('meetups', fn ($table) => $table->dropColumn('nostr_payload_hash'));
+
+    $this->artisan('nostr:republish-calendar', ['--changed' => true, '--sleep' => 0, '--force' => true])
+        ->expectsOutputToContain('would re-send the whole catalogue on every run')
+        ->assertExitCode(1);
+
+    // The default mode does not read the column and keeps working, so the guard is
+    // scoped to the mode that needs it.
+    $this->artisan('nostr:republish-calendar', ['--sleep' => 0])
+        ->expectsOutputToContain('DRY RUN')
+        ->assertExitCode(0);
+});
+
+/*
+|--------------------------------------------------------------------------
+| Batching: the filter runs before the limit
+|--------------------------------------------------------------------------
+*/
+
+/**
+ * The scheduled entry runs with `--limit=10`, so the limit has to cap WORK DONE and not
+ * ROWS LOOKED AT. Applied the other way round, a batch could be filled with records that
+ * are already up to date, send nothing, and pick the same rows again on every run — a
+ * mechanism that never finishes and never says so.
+ */
+it('fills the batch with stale records only, and drains across runs', function () {
+    $transmitter = changedTransmitter();
+    [$meetup, $events] = changedPublished(2);
+
+    $this->travel(90)->seconds();
+    $meetup->update(['name' => 'Renamed Bitcoin Meetup Indianapolis']);
+
+    $dTagsSent = [];
+
+    foreach ([1, 2, 3] as $run) {
+        $before = count($transmitter->events);
+        $this->travel(90)->seconds();
+        $this->artisan('nostr:republish-calendar', ['--changed' => true, '--limit' => 1, '--sleep' => 0, '--force' => true])
+            ->assertExitCode(0);
+
+        $sent = changedSince($transmitter, $before);
+        expect($sent)->toHaveCount(1, "run {$run} did not send exactly one record");
+        $dTagsSent[] = RecordingNostrTransmitter::tagValue($sent[0], 'd');
+    }
+
+    // Events before calendars, earliest start first — and every record exactly once.
+    expect($dTagsSent)->toBe([
+        "meetup-event-{$events[0]->id}",
+        "meetup-event-{$events[1]->id}",
+        "meetup-{$meetup->id}",
+    ]);
+
+    $after = count($transmitter->events);
+    $this->travel(90)->seconds();
+    $this->artisan('nostr:republish-calendar', ['--changed' => true, '--limit' => 1, '--sleep' => 0, '--force' => true])
+        ->assertExitCode(0);
+
+    expect(changedSince($transmitter, $after))->toBe([]);
+});
+
+/**
+ * A record published under a rotated key can never be re-sent — its address belongs to
+ * another key. Leaving it in the candidate set would let a handful of them occupy the
+ * batch on every run and starve the records that CAN be repaired, so it is dropped
+ * during the scan and reported, not carried into the limit.
+ */
+it('does not let an unrepairable key mismatch occupy the batch', function () {
+    $transmitter = changedTransmitter();
+    [$meetup, $events] = changedPublished(2);
+
+    DB::table('meetup_events')->where('id', $events[0]->id)->update([
+        'nostr_coordinate' => '31923:'.str_repeat('b2', 32).":meetup-event-{$events[0]->id}",
+    ]);
+
+    $this->travel(90)->seconds();
+    $meetup->update(['name' => 'Renamed Bitcoin Meetup Indianapolis']);
+    $baseline = count($transmitter->events);
+
+    $this->artisan('nostr:republish-calendar', ['--changed' => true, '--limit' => 1, '--sleep' => 0, '--force' => true])
+        ->expectsOutputToContain('but the configured key would publish it as')
+        ->assertExitCode(0);
+
+    $sent = changedSince($transmitter, $baseline);
+
+    // The batch of one went to the SECOND event, not to the unrepairable first one.
+    expect($sent)->toHaveCount(1)
+        ->and(RecordingNostrTransmitter::tagValue($sent[0], 'd'))->toBe("meetup-event-{$events[1]->id}");
+});
+
+/*
+|--------------------------------------------------------------------------
+| The manual command keeps its behaviour
+|--------------------------------------------------------------------------
+*/
+
+/**
+ * `--changed` is opt-in. Without it the command is what it was: a blunt operator repair
+ * that re-sends everything published, whether or not the payload moved.
+ */
+it('still re-sends unchanged records when --changed is not given', function () {
+    $transmitter = changedTransmitter();
+    changedPublished();
+    $baseline = count($transmitter->events);
+
+    $this->travel(90)->seconds();
+    $this->artisan('nostr:republish-calendar', ['--sleep' => 0, '--force' => true])
+        ->doesntExpectOutputToContain('carry a payload this code no longer builds')
+        ->assertExitCode(0);
+
+    expect(changedSince($transmitter, $baseline))->toHaveCount(2);
+});
+
+/**
+ * A forced manual repair records what it sent, so the hourly `--changed` entry does not
+ * immediately re-send the whole catalogue behind the operator's back.
+ */
+it('records the fingerprint on a forced default-mode run', function () {
+    $transmitter = changedTransmitter();
+    [$meetup] = changedPublished();
+    DB::table('meetups')->where('id', $meetup->id)->update(['nostr_payload_hash' => null]);
+    DB::table('meetup_events')->where('meetup_id', $meetup->id)->update(['nostr_payload_hash' => null]);
+
+    $this->travel(90)->seconds();
+    $this->artisan('nostr:republish-calendar', ['--sleep' => 0, '--force' => true])->assertExitCode(0);
+
+    $baseline = count($transmitter->events);
+
+    $this->travel(90)->seconds();
+    $this->artisan('nostr:republish-calendar', ['--changed' => true, '--sleep' => 0, '--force' => true])
+        ->assertExitCode(0);
+
+    expect(changedSince($transmitter, $baseline))->toBe([]);
+});

--- a/tests/Feature/Support/NostrPayloadFingerprintTest.php
+++ b/tests/Feature/Support/NostrPayloadFingerprintTest.php
@@ -1,0 +1,163 @@
+<?php
+
+use App\Models\ApiChange;
+use App\Models\Meetup;
+use App\Support\NostrPayloadFingerprint;
+use swentel\nostr\Event\Event;
+
+/**
+ * The fingerprint is the whole of the automatic trigger in issue #92, so it is pinned
+ * here field by field rather than only through the command that uses it.
+ *
+ * Both directions of getting it wrong are a defect, and they are opposite defects:
+ * cover too little and a changed payload never reaches the back catalogue, which is the
+ * bug #92 reports, now behind a mechanism that looks like it works; cover too much — a
+ * single clock-bound field is enough — and every record differs on every run and the
+ * scheduler broadcasts the entire catalogue to every relay for ever.
+ */
+function fingerprintEvent(int $kind = 31923, string $content = 'the payload', array $tags = [['d', 'meetup-event-1'], ['title', 'Bitcoin Meetup']]): Event
+{
+    $event = new Event;
+    $event->setKind($kind);
+    $event->setContent($content);
+    $event->setTags($tags);
+    $event->setCreatedAt(1_800_000_000);
+
+    return $event;
+}
+
+it('gives the same fingerprint to the same payload', function () {
+    expect(NostrPayloadFingerprint::of(fingerprintEvent()))
+        ->toBe(NostrPayloadFingerprint::of(fingerprintEvent()))
+        ->and(NostrPayloadFingerprint::of(fingerprintEvent()))->toMatch('/^[0-9a-f]{64}$/');
+});
+
+/**
+ * THE FAILURE MODE THAT DOES NOT STOP. `NostrCalendarEventFactory` stamps `created_at`
+ * from the application clock on every build, so a fingerprint that covered it would
+ * differ from the stored one on every single run — and the scheduled `--changed` entry
+ * would re-send every published record to every relay, hourly, for ever.
+ */
+it('ignores created_at, which changes on every build of the same record', function () {
+    $earlier = fingerprintEvent();
+    $earlier->setCreatedAt(1_800_000_000);
+
+    $later = fingerprintEvent();
+    $later->setCreatedAt(1_900_000_000);
+
+    expect(NostrPayloadFingerprint::of($later))->toBe(NostrPayloadFingerprint::of($earlier));
+});
+
+/**
+ * `id` and `sig` are derived from `created_at` (NIP-01: the id is the hash of
+ * `[0, pubkey, created_at, kind, tags, content]`, the signature is over the id), so
+ * they carry the clock in disguise. `pubkey` is excluded because a key change moves the
+ * ADDRESS, not the payload, and both commands refuse to re-send under a foreign key.
+ */
+it('ignores the signature envelope: id, sig and pubkey', function () {
+    $bare = fingerprintEvent();
+
+    $signed = fingerprintEvent();
+    $signed->setId(str_repeat('a1', 32));
+    $signed->setSignature(str_repeat('f0', 64));
+    $signed->setPublicKey(str_repeat('b2', 32));
+
+    expect(NostrPayloadFingerprint::of($signed))->toBe(NostrPayloadFingerprint::of($bare));
+});
+
+/**
+ * THE FAILURE MODE THAT IS SILENT. Each of these is a real change this portal has
+ * shipped: the `t` tags of #69 added tags, the `start_tzid` repair of #104 changed a tag
+ * value, and a meetup's `intro` is the event content.
+ */
+it('changes when any part of the published payload changes', function (string $label, Event $changed) {
+    expect(NostrPayloadFingerprint::of($changed))
+        ->not->toBe(NostrPayloadFingerprint::of(fingerprintEvent()), $label);
+})->with([
+    'content' => ['content', fn () => fingerprintEvent(content: 'a different payload')],
+    'kind' => ['kind', fn () => fingerprintEvent(kind: 31924)],
+    'a tag value' => ['a tag value', fn () => fingerprintEvent(tags: [['d', 'meetup-event-1'], ['title', 'Renamed Meetup']])],
+    'an added tag' => ['an added tag', fn () => fingerprintEvent(tags: [['d', 'meetup-event-1'], ['title', 'Bitcoin Meetup'], ['t', 'indianapolis']])],
+    'a removed tag' => ['a removed tag', fn () => fingerprintEvent(tags: [['d', 'meetup-event-1']])],
+    'tag order' => ['tag order', fn () => fingerprintEvent(tags: [['title', 'Bitcoin Meetup'], ['d', 'meetup-event-1']])],
+]);
+
+/**
+ * Order is part of the fingerprint because it is part of the event: NIP-01 serialises
+ * tags as an ordered array, so two events carrying the same tags in a different order
+ * have different ids and are different events on the wire.
+ */
+it('treats a reordered tag list as a different payload', function () {
+    $original = fingerprintEvent(tags: [['d', 'x'], ['t', 'bitcoin'], ['t', 'meetup']]);
+    $reordered = fingerprintEvent(tags: [['d', 'x'], ['t', 'meetup'], ['t', 'bitcoin']]);
+
+    expect(NostrPayloadFingerprint::of($reordered))->not->toBe(NostrPayloadFingerprint::of($original));
+});
+
+it('reports a record with no stored fingerprint as stale', function () {
+    $meetup = Meetup::factory()->create();
+
+    expect($meetup->nostr_payload_hash)->toBeNull()
+        ->and(NostrPayloadFingerprint::isStale($meetup, fingerprintEvent()))->toBeTrue();
+});
+
+it('reports a record as fresh only while the stored fingerprint matches', function () {
+    $meetup = Meetup::factory()->create();
+    $event = fingerprintEvent();
+
+    NostrPayloadFingerprint::remember($meetup, $event);
+
+    expect(NostrPayloadFingerprint::isStale($meetup, $event))->toBeFalse()
+        ->and(NostrPayloadFingerprint::isStale($meetup->fresh(), $event))->toBeFalse()
+        ->and(NostrPayloadFingerprint::isStale($meetup, fingerprintEvent(content: 'moved')))->toBeTrue();
+});
+
+/**
+ * A transmission is not a change to the record. `updated_at` is what other code reads to
+ * answer "when did this last change", and it is also the signal a naive version of this
+ * feature would have keyed on — so moving it here would corrupt the very field whose
+ * unsuitability is the reason the fingerprint exists.
+ */
+it('records the fingerprint without moving updated_at', function () {
+    $meetup = Meetup::factory()->create(['updated_at' => now()->subMonth()]);
+    $before = $meetup->fresh()->updated_at;
+
+    $this->travel(1)->hour();
+    NostrPayloadFingerprint::remember($meetup, fingerprintEvent());
+
+    expect($meetup->fresh()->updated_at->equalTo($before))->toBeTrue()
+        ->and($meetup->fresh()->nostr_payload_hash)->toBe(NostrPayloadFingerprint::of(fingerprintEvent()));
+});
+
+/**
+ * Both models carry `ApiChangeObserver`, so an ordinary save here would publish "this
+ * meetup changed" to the change log, the broadcast channel and every webhook subscriber
+ * — every time a calendar is refreshed, with no field a consumer could point at.
+ */
+it('records the fingerprint without writing to the public change log', function () {
+    config()->set('einundzwanzig.change_log.enabled', true);
+    $meetup = Meetup::factory()->create();
+    $before = ApiChange::query()->count();
+
+    NostrPayloadFingerprint::remember($meetup, fingerprintEvent());
+
+    expect(ApiChange::query()->count())->toBe($before);
+
+    // Positive control: the log really is on, so the count above is a real absence
+    // rather than a feature switched off.
+    $meetup->update(['name' => 'Renamed for the control']);
+    expect(ApiChange::query()->count())->toBeGreaterThan($before);
+});
+
+/**
+ * A `save()` would flush whatever else happens to be dirty on the model. This statement
+ * carries one column, so an in-memory edit nobody asked to persist stays unpersisted.
+ */
+it('writes only its own column', function () {
+    $meetup = Meetup::factory()->create(['name' => 'Stored Name']);
+    $meetup->name = 'Never Saved';
+
+    NostrPayloadFingerprint::remember($meetup, fingerprintEvent());
+
+    expect($meetup->fresh()->name)->toBe('Stored Name');
+});


### PR DESCRIPTION
#69 and #104 both fixed the builder and left the relays holding the old
payload. Each needed a human to remember that a code change had made
published records wrong, and to run nostr:republish-calendar by hand.
That is the part that does not scale: the next builder fix will be
noticed by nobody.

Selection is a FINGERPRINT COMPARISON, not a timestamp. What a record
would be built as today is hashed and compared with what was hashed
when it was last sent:

    hash('sha256', json_encode([kind, tags, content]))

NIP-01's own serialisation order, with every clock- and key-bound field
removed. created_at is excluded because newEvent() stamps it from the
application clock on every build -- include it and every record differs
on every run, for ever. id hashes created_at and sig signs id, so both
carry the clock in disguise. pubkey is excluded because a key change
moves the ADDRESS, not the payload, and both commands already refuse to
re-send under a foreign key. Tag ORDER is inside the hash: NIP-01
serialises tags as an ordered array, so a reorder is a different event
with a different id.

A timestamp cannot express this. The trigger is a code change, and code
changes do not touch updated_at -- measured across processes, with the
row's fingerprint byte-identical before and after a one-line edit to
NostrCalendarEventFactory, and the re-send firing anyway on zero
database writes. Reverting the edit fires it a second time, which is
correct: the trigger is STATE, not event.

The hash is written PAST Eloquent -- a bare one-column UPDATE, no
updated_at, no model events. Both models carry ApiChangeObserver, so an
ordinary save() would emit a public "this meetup changed" to the change
log, the broadcast channel and every webhook subscriber on every
calendar refresh, naming no field a consumer could act on.

NULL means unknown: never published, or published before the column
existed. nostr_coordinate tells those apart, and a record with a
coordinate and no fingerprint is presumed stale and re-sent once.
NOTHING IS BACKFILLED, deliberately: computing today's payload and
writing it in as if it had been sent would assert something the portal
does not know, in the one direction that marks the #69/#104 back
catalogue as already correct. The honest direction costs one idempotent
re-send per record and terminates by itself.

--limit is applied AFTER the staleness filter. The other way round, a
batch of ten could fill with up-to-date records, send nothing, and pick
the same ten for ever. Key mismatches drop out in the same scan for the
same reason.

Scheduled hourly as --changed --force --limit=10, verified as the
literal string through schedule:list. Per relay that is 0.5 events/s
for 18 s at peak -- the same peak a manual --force already produces --
0.0028 events/s sustained, and zero when nothing is stale, because the
run returns before opening a socket. 383 stale records clear in 39 runs
rather than 383.

The scan cost was measured rather than asserted, and it changed the
argument: an idle scan over 383 published records is 72 ms and 322
queries, one per meetup because a calendar's `a` tags are a query by
construction. That is not a bottleneck at either cadence, so the
comment says so instead of dressing a preference as a constraint. What
decides hourly is that twelve times the cost buys nothing -- the
records are on the relays already, merely older.

Idempotence is measured over THREE runs, not two: twice cannot tell a
self-terminating mechanism from an alternating one. Run 1 sends 3, runs
2 and 3 send nothing.

Both failure modes are pinned, because they are opposite and each looks
like success from the other side. Never re-sending is caught by five
tests, including one that asserts exactly ONE of two published records
goes out -- a blanket re-send does not pass it. Re-sending everything
every run is caught by four, including a row written to without
changing its payload, whose updated_at is asserted to have moved while
nothing is sent.

24 mutation probes, all killed. Notably: covering created_at reddens 11
tests, covering pubkey reddens 21, and replacing the bare UPDATE with
save() reddens the change-log and updated_at guards.

No test touches a relay -- every one binds a recording transmitter.
The manual command keeps its contract: without --changed the selection
is unchanged and the dry run is still the default.

Found, not fixed: DownloadMeetupCalendarCancellationTest:121 asserts a
factory write and a later update() land in the same wall-clock second
with no clock pinned, and failed once in five runs. Nothing to do with
Nostr; needs a travelTo() around the pair.

Not done, deliberately: nostr:whoami does not report a stale count. A
useful operator affordance, and not what #92 asked for.

Closes #92



🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XfFQ18DFktM3ewnWo9Zt9X
